### PR TITLE
docs: 更改最佳实践中MRA指向链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _✨ 基于图像识别的自动化黑盒测试框架 ✨_
 - [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) 森空岛 小助手 ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
   基于全新架构的 森空岛 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
-- [MRA](https://github.com/NaNExist/ResonanceAssistant) 列车长 小助手  
+- [MRA](https://github.com/MaaXYZ/MaaResonance) 雷索纳斯 列车长 小助手
   基于全新架构的 列车长 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
 ## 生态共建

--- a/README_en.md
+++ b/README_en.md
@@ -62,7 +62,7 @@ It offers low-code simplicity while maintaining high extensibility. The framewor
 - [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) Skland Assistant ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
   Based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
-- [MRA](https://github.com/NaNExist/ResonanceAssistant) Resonance Assistant  
+- [MRA](https://github.com/MaaXYZ/MaaResonance) Maa Resonance
   A Conductor Assistant based on MAA's new architecture. Image technology + simulation control, no more clicking! Powered by MaaFramework.
 
 ## Eco-Building


### PR DESCRIPTION
由于一些分歧，原链接指向项目现已archived。
故将其修改为基于MaaFramework Tauri Template开发的新项目。