### PR TITLE
fix: just force use llvm 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,7 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
-          echo 'export PATH="/usr/local/opt/llvm@17/bin:$PATH"' >> ~/.bash_profile
+          echo "PATH=/usr/local/opt/llvm@17/bin:$PATH" >> $GITHUB_ENV
         # 17
 
       - name: Bootstrap MaaDeps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
 
       - name: Install compiler
         run: |
-          brew install llvm
+          brew install llvm@17
         # 17
 
       - name: Bootstrap MaaDeps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,7 +226,6 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
-          echo "PATH=/usr/local/opt/llvm@17/bin:$PATH" >> $GITHUB_ENV
         # 17
 
       - name: Bootstrap MaaDeps
@@ -238,8 +237,8 @@ jobs:
       - name: Build MAA for x86_64
         if: ${{ matrix.arch == 'x86_64' }}
         env:
-          CC: "/usr/local/opt/llvm/bin/clang"
-          CXX: "/usr/local/opt/llvm/bin/clang++"
+          CC: "/usr/local/opt/llvm@17/bin/clang"
+          CXX: "/usr/local/opt/llvm@17/bin/clang++"
         run: |
           cmake --preset 'NinjaMulti' \
             -DMAADEPS_TRIPLET='maa-${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-osx' \
@@ -250,8 +249,8 @@ jobs:
       - name: Build MAA for aarch64
         if: ${{ matrix.arch == 'aarch64' }}
         env:
-          CC: "/opt/homebrew/opt/llvm/bin/clang"
-          CXX: "/opt/homebrew/opt/llvm/bin/clang++"
+          CC: "/opt/homebrew/opt/llvm@17/bin/clang"
+          CXX: "/opt/homebrew/opt/llvm@17/bin/clang++"
         run: |
           cmake --preset 'NinjaMulti' \
             -DMAADEPS_TRIPLET='maa-${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-osx' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,6 +226,7 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
+          echo 'export PATH="/usr/local/opt/llvm@17/bin:$PATH"' >> ~/.bash_profile
         # 17
 
       - name: Bootstrap MaaDeps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,6 +259,7 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
+          echo 'export PATH="/usr/local/opt/llvm@17/bin:$PATH"' >> ~/.bash_profile
         # 17
 
       - name: Bootstrap MaaDeps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,7 +259,6 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
-          echo "PATH=/usr/local/opt/llvm@17/bin:$PATH" >> $GITHUB_ENV
         # 17
 
       - name: Bootstrap MaaDeps
@@ -271,8 +270,8 @@ jobs:
       - name: Build MAA for x86_64
         if: ${{ matrix.arch == 'x86_64' }}
         env:
-          CC: "/usr/local/opt/llvm/bin/clang"
-          CXX: "/usr/local/opt/llvm/bin/clang++"
+          CC: "/usr/local/opt/llvm@17/bin/clang"
+          CXX: "/usr/local/opt/llvm@17/bin/clang++"
         run: |
           cmake --preset 'NinjaMulti' \
             -DMAADEPS_TRIPLET='maa-${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-osx' \
@@ -284,8 +283,8 @@ jobs:
       - name: Build MAA for aarch64
         if: ${{ matrix.arch == 'aarch64' }}
         env:
-          CC: "/opt/homebrew/opt/llvm/bin/clang"
-          CXX: "/opt/homebrew/opt/llvm/bin/clang++"
+          CC: "/opt/homebrew/opt/llvm@17/bin/clang"
+          CXX: "/opt/homebrew/opt/llvm@17/bin/clang++"
         run: |
           cmake --preset 'NinjaMulti' \
             -DMAADEPS_TRIPLET='maa-${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-osx' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
 
       - name: Install compiler
         run: |
-          brew install llvm
+          brew install llvm@17
         # 17
 
       - name: Bootstrap MaaDeps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -259,7 +259,7 @@ jobs:
       - name: Install compiler
         run: |
           brew install llvm@17
-          echo 'export PATH="/usr/local/opt/llvm@17/bin:$PATH"' >> ~/.bash_profile
+          echo "PATH=/usr/local/opt/llvm@17/bin:$PATH" >> $GITHUB_ENV
         # 17
 
       - name: Bootstrap MaaDeps


### PR DESCRIPTION
目前mac 13 x86_64会出现codecvt报deprecated然后Werror，但是mac 14 aarch64不会
本来尝试了直接把实现改成boost locale，但是mac上会出现下面这个问题
[https://github.com/llvm/llvm-project/issues/84392](https://github.com/llvm/llvm-project/issues/84392)
直接回退llvm到17可能能解决
