### PR TITLE
feat: IWYU

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -442,3 +442,5 @@ FodyWeavers.xsd
 # Chore
 .DS_Store
 .nuke/temp/*
+
+!include/MaaToolkit/Win32

--- a/include/MaaFramework/Instance/MaaController.h
+++ b/include/MaaFramework/Instance/MaaController.h
@@ -8,6 +8,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Instance/MaaCustomController.h
+++ b/include/MaaFramework/Instance/MaaCustomController.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Instance/MaaInstance.h
+++ b/include/MaaFramework/Instance/MaaInstance.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Instance/MaaResource.h
+++ b/include/MaaFramework/Instance/MaaResource.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/MaaAPI.h
+++ b/include/MaaFramework/MaaAPI.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MaaDef.h"
+#include "MaaDef.h" // IWYU pragma: export
 
 #include "Instance/MaaController.h"
 #include "Instance/MaaCustomController.h"

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -7,9 +7,11 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
-#include "MaaPort.h"
+#include "MaaPort.h" // IWYU pragma: export
 #include <stdint.h>
 
 struct MaaStringBuffer;
@@ -30,7 +32,7 @@ typedef struct MaaInstanceAPI* MaaInstanceHandle;
 
 typedef uint8_t MaaBool;
 typedef uint64_t MaaSize;
-#define MaaNullSize ((MaaSize) - 1)
+#define MaaNullSize ((MaaSize)-1)
 
 typedef const char* MaaStringView;
 

--- a/include/MaaFramework/Task/MaaCustomAction.h
+++ b/include/MaaFramework/Task/MaaCustomAction.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Task/MaaCustomRecognizer.h
+++ b/include/MaaFramework/Task/MaaCustomRecognizer.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Task/MaaSyncContext.h
+++ b/include/MaaFramework/Task/MaaSyncContext.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Utility/MaaBuffer.h
+++ b/include/MaaFramework/Utility/MaaBuffer.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaFramework/Utility/MaaUtility.h
+++ b/include/MaaFramework/Utility/MaaUtility.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaFramework/MaaAPI.h>
+
 #pragma once
 
 #include "../MaaDef.h"

--- a/include/MaaToolkit/Config/MaaToolkitConfig.h
+++ b/include/MaaToolkit/Config/MaaToolkitConfig.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaToolkit/MaaToolkitAPI.h>
+
 #pragma once
 
 #include "../MaaToolkitDef.h"

--- a/include/MaaToolkit/Device/MaaToolkitDevice.h
+++ b/include/MaaToolkit/Device/MaaToolkitDevice.h
@@ -7,6 +7,8 @@
  *
  */
 
+// IWYU pragma: private, include <MaaToolkit/MaaToolkitAPI.h>
+
 #pragma once
 
 #include "../MaaToolkitDef.h"

--- a/include/MaaToolkit/ExecAgent/MaaToolkitExecAgent.h
+++ b/include/MaaToolkit/ExecAgent/MaaToolkitExecAgent.h
@@ -1,3 +1,5 @@
+// IWYU pragma: private, include <MaaToolkit/MaaToolkitAPI.h>
+
 #pragma once
 
 #include "../MaaToolkitDef.h"

--- a/include/MaaToolkit/MaaToolkitAPI.h
+++ b/include/MaaToolkit/MaaToolkitAPI.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "MaaToolkitDef.h"
+#include "MaaToolkitDef.h" // IWYU pragma: export
 
 #include "Config/MaaToolkitConfig.h"
 #include "Device/MaaToolkitDevice.h"

--- a/include/MaaToolkit/MaaToolkitDef.h
+++ b/include/MaaToolkit/MaaToolkitDef.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#include "MaaFramework/MaaDef.h"
+#include "MaaFramework/MaaDef.h" // IWYU pragma: export

--- a/include/MaaToolkit/Win32/MaaToolkitWin32Window.h
+++ b/include/MaaToolkit/Win32/MaaToolkitWin32Window.h
@@ -1,3 +1,5 @@
+// IWYU pragma: private, include <MaaToolkit/MaaToolkitAPI.h>
+
 #pragma once
 
 #include "../MaaToolkitDef.h"
@@ -27,10 +29,10 @@ extern "C"
      *
      * This function searches the function by regex search. See also MaaToolkitFindWindow().
      *
-     * @param class_name The class name regex of the window. If passed an empty string, class name will
-     * not be filtered.
-     * @param window_name The window name regex of the window. If passed an empty string, window name will
-     * not be filtered.
+     * @param class_name The class name regex of the window. If passed an empty string, class name
+     * will not be filtered.
+     * @param window_name The window name regex of the window. If passed an empty string, window
+     * name will not be filtered.
      * @return MaaSize The number of windows found that match the criteria. To get the corresponding
      * window handle, use MaaToolkitGetWindow().
      */
@@ -75,7 +77,8 @@ extern "C"
      * @param buffer The output buffer.
      * @return MaaBool.
      */
-    MAA_TOOLKIT_API MaaBool MaaToolkitGetWindowClassName(MaaWin32Hwnd hwnd, MaaStringBufferHandle buffer);
+    MAA_TOOLKIT_API MaaBool
+        MaaToolkitGetWindowClassName(MaaWin32Hwnd hwnd, MaaStringBufferHandle buffer);
 
     /**
      * @brief Get the window window name by hwnd.


### PR DESCRIPTION
https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-private

主要作用让在支持IWYU(比如clangd)的玩意别提示包含里面的东西

比如, 用了`MaaCreateStringBuffer`然后补全, 现在会自动包含`MaaFramework/MaaAPI.h`, 之前则是会包含`MaaFramework/Utility/MaaBuffer.h`

---

顺便修了个git ignore的问题