### PR TITLE
docs: 为最佳实践添加正确的徽章来标明所使用的语言

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ _✨ 基于图像识别的自动化黑盒测试框架 ✨_
 
 ## 最佳实践
 
-- [M9A](https://github.com/MaaXYZ/M9A) 1999 小助手 ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [M9A](https://github.com/MaaXYZ/M9A) 1999 小助手 ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)    
   基于全新架构的 亿韭韭韭 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
 - [MAAIP](https://github.com/Arcelibs/MAAIP) 基於 MAA 框架技術的 idolypride 自動化程序  
@@ -53,28 +54,35 @@ _✨ 基于图像识别的自动化黑盒测试框架 ✨_
 - [MAABH3](https://github.com/MaaXYZ/MAABH3) 《崩坏3》小助手 | A one-click tool for the daily tasks of Honkai Impact. ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
   基于全新架构的 蹦蹦蹦 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
-- [MAALimbusCompany](https://github.com/hxdnshx/MAALimbusCompany) 边狱公司 小助手 ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [MAALimbusCompany](https://github.com/hxdnshx/MAALimbusCompany) 边狱公司 小助手 ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)  
   基于全新架构的 边狱公司 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
 - [MBA](https://github.com/MaaXYZ/MBA) BA 小助手 ![csharp](https://img.shields.io/badge/C%23-239120?logo=csharp&logoColor=white)  
   基于 MAA 全新架构的 BA 小助手。图像技术 + 模拟控制，解放双手，不再点点点！由 MaaFramework 强力驱动！
 
-- [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) 森空岛 小助手 ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
+- [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) 森空岛 小助手 ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)      
   基于全新架构的 森空岛 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
-- [MRA](https://github.com/MaaXYZ/MaaResonance) 雷索纳斯 列车长 小助手  
+- [MRA](https://github.com/MaaXYZ/MaaResonance) 雷索纳斯 列车长 小助手  ![NodeJS](https://camo.githubusercontent.com/ebf7c2fa711fe1e35a62d51214a518b0ff67a89cdf1404dc04c961446fd861b3/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d4e6f64656a732d63306562643f7374796c653d666c61742d737175617265266c6f676f3d4e6f64652e6a73
+)    
   基于全新架构的 列车长 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
-- [MaaHatsuboshiTA](https://github.com/Carpenter-MK1/MaaHatsuboshiTA) 学院偶像大师 初星助教  
+- [MaaHatsuboshiTA](https://github.com/Carpenter-MK1/MaaHatsuboshiTA) 学院偶像大师 初星助教  ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)    
   基于全新架构的制作人代肝工具，养肝护眼 + 节省时间，~~出轨美铃！~~ 由 MaaFramework 强力驱动！
 
-- [MCCA](https://github.com/MaaXYZ/MCCA) 交错战线 小助手 ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [MCCA](https://github.com/MaaXYZ/MCCA) 交错战线 小助手 ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)  
   基于全新架构的 交错战线 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
   
-- [MSBA](https://github.com/overflow65537/MAA_SnowBreak) 分析员 小助手  
+- [MSBA](https://github.com/overflow65537/MAA_SnowBreak) 分析员 小助手  ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)     
   基于全新架构的 尘白禁区 小助手。图像技术 + 模拟控制，解放双手！由 MaaFramework 强力驱动！
 
-- [MaaAeonFantasy](https://github.com/Andl-Liu/MaaAeonFantasy)  星神少女 预言之子 小助手  
+- [MaaAeonFantasy](https://github.com/Andl-Liu/MaaAeonFantasy)  星神少女 预言之子 小助手  ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)     
   基于全新架构的 星神少女 小助手。图像技术 + 模拟控制，让手去做它该做的事！由 MaaFramework 强力驱动！
 
 - [maa-whmx](https://github.com/MAWHA/maa-whmx) 物华弥新 小助手 ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white) ![qt](https://img.shields.io/badge/Qt6-41CD52?logo=Qt&logoColor=white)  

--- a/README_en.md
+++ b/README_en.md
@@ -44,7 +44,8 @@ It offers low-code simplicity while maintaining high extensibility. The framewor
 
 ## Best Practices
 
-- [M9A](https://github.com/MaaXYZ/M9A) 1999 Assistant ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [M9A](https://github.com/MaaXYZ/M9A) 1999 Assistant ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)      
   The 1999 Assistant, based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
 - [MAAIP](https://github.com/Arcelibs/MAAIP) idolypride Automation Program Based on MAA Framework Technology  
@@ -53,28 +54,35 @@ It offers low-code simplicity while maintaining high extensibility. The framewor
 - [MAABH3](https://github.com/MaaXYZ/MAABH3) Honkai Impact 3 Assistant ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
   A one-click tool for the daily tasks of Honkai Impact, based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
-- [MAALimbusCompany](https://github.com/hxdnshx/MAALimbusCompany) Limbus Company Assistant ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [MAALimbusCompany](https://github.com/hxdnshx/MAALimbusCompany) Limbus Company Assistant ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)      
   Based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
 - [MBA](https://github.com/MaaXYZ/MBA) BA Assistant ![csharp](https://img.shields.io/badge/C%23-239120?logo=csharp&logoColor=white)  
   A BA Assistant based on MAA's new architecture. Image technology + simulation control, no more clicking! Powered by MaaFramework.
 
-- [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) Skland Assistant ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white)  
+- [MAS](https://github.com/MaaXYZ/MaaAssistantSkland) Skland Assistant ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)      
   Based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
-- [MRA](https://github.com/MaaXYZ/MaaResonance) Maa Resonance  
+- [MRA](https://github.com/MaaXYZ/MaaResonance) Maa Resonance  ![NodeJS](https://camo.githubusercontent.com/ebf7c2fa711fe1e35a62d51214a518b0ff67a89cdf1404dc04c961446fd861b3/68747470733a2f2f696d672e736869656c64732e696f2f62616467652f2d4e6f64656a732d63306562643f7374796c653d666c61742d737175617265266c6f676f3d4e6f64652e6a73
+)    
   A Conductor Assistant based on MAA's new architecture. Image technology + simulation control, no more clicking! Powered by MaaFramework.
 
-- [MaaHatsuboshiTA](https://github.com/Carpenter-MK1/MaaHatsuboshiTA) Hatsuboshi Teaching Assistant   
+- [MaaHatsuboshiTA](https://github.com/Carpenter-MK1/MaaHatsuboshiTA) Hatsuboshi Teaching Assistant   ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)    
   A Tool For Producers PLaying Gakuen-Idolmaster. Powered by MaaFramework.
 
-- [MCCA](https://github.com/MaaXYZ/MCCA) CrossCore Assistant ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white)  
+- [MCCA](https://github.com/MaaXYZ/MCCA) CrossCore Assistant ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)      
   The CrossCore Assistant, based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
-- [MSBA](https://github.com/overflow65537/MAA_SnowBreak) Snow break Assistant !  
+- [MSBA](https://github.com/overflow65537/MAA_SnowBreak) Snow break Assistant !  ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)    
   The Snow break Assistant, based on a brand new architecture. Image technology + simulation control, freeing your hands! Powered by MaaFramework.
 
-- [MaaAeonFantasy](https://github.com/Andl-Liu/MaaAeonFantasy) Aeon Fantasy Assistant !  
+- [MaaAeonFantasy](https://github.com/Andl-Liu/MaaAeonFantasy) Aeon Fantasy Assistant !  ![Pipeline](https://img.shields.io/badge/Pipeline-%23454545?logo=codecademy&logoColor=%23FFFFFF&color=%23454545
+)    
   The Aeon Fantasy Assistant, based on a brand new architecture. Image technology + simulation control, let your hands do what they should do! Powered by MaaFramework.
 
 - [maa-whmx](https://github.com/MAWHA/maa-whmx) Wuhua Mixin Assistant ![cpp](https://img.shields.io/badge/C%2B%2B-00599C?logo=c%2B%2B&logoColor=white) ![qt](https://img.shields.io/badge/Qt6-41CD52?logo=Qt&logoColor=white)   


### PR DESCRIPTION
旧的python徽章并不准确,所以全部替换
MAS森空岛原本用的是C++,最近的版本改为picli
MRA雷索纳斯应该标记为NodeJS(不太确定,使用pnpm进行构建)
