### PR TITLE
ci: 为 binding test 指定 Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,11 @@ jobs:
               with:
                   sdk-version: 22621
 
+            - name: Setup Python
+              uses: actions/setup-python@v5.2.0
+              with:
+                python-version: '3.9'
+
             - name: Bootstrap MaaDeps
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -175,6 +180,11 @@ jobs:
               uses: Chocobo1/setup-ccache-action@v1
               with:
                   remove_stale_cache: false
+
+            - name: Setup Python
+              uses: actions/setup-python@v5.2.0
+              with:
+                python-version: '3.9'
 
             - name: Bootstrap MaaDeps
               env:
@@ -288,6 +298,11 @@ jobs:
               uses: Chocobo1/setup-ccache-action@v1
               with:
                   remove_stale_cache: false
+
+            - name: Setup Python
+              uses: actions/setup-python@v5.2.0
+              with:
+                python-version: '3.9'
 
             - name: Bootstrap MaaDeps
               env:


### PR DESCRIPTION
MacOS 14 没有 Python 3.9 的 cahce ，但安装过程只花了 20s ，应该可以忽略不计？其他平台都有 Python 3.9 的 cache，不需要另行安装，可以直接使用。
https://github.com/weinibuliu/MaaFramework/actions/runs/12211925463