### PR TITLE
chore: update pipeline.schema.json

### DIFF
--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -594,7 +594,7 @@ Orange 的 next 中，
         "action": "Command",
         "exec": "Python",
         "args": [
-            "{RESOURCE_DIR}/my_script/test.py"
+            "{RESOURCE_DIR}/my_script/test.py",
             "Haha",
             "{IMAGE}",
             "{NODE}",

--- a/tools/pipeline.schema.json
+++ b/tools/pipeline.schema.json
@@ -40,6 +40,7 @@
                         "StartApp",
                         "StopApp",
                         "StopTask",
+                        "Command",
                         "Custom"
                     ],
                     "default": "DoNothing"
@@ -286,6 +287,23 @@
                     "default": ""
                 },
                 "package": {},
+                "exec": {
+                    "description": "执行的程序路径。必选。",
+                    "type": "string"
+                },
+                "args": {
+                    "description": "执行的参数。可选。支持部分运行期参数替换：{ENTRY}, {NODE}, {IMAGE}, {BOX}, {RESOURCE_DIR}, {LIBRARY_DIR}。",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "detach": {
+                    "description": "分离子进程，即不等待子进程执行完成，直接继续之后后面的节点。可选，默认 false。",
+                    "type": "boolean",
+                    "default": false
+                },
                 "custom_action": {
                     "description": "动作名，同 MaaResourceRegisterCustomAction 接口传入的动作名。必选。",
                     "type": "string",
@@ -725,6 +743,14 @@
                             "properties": {
                                 "action": {
                                     "const": "StopTask"
+                                }
+                            }
+                        },
+                        {
+                            "$comment": "Command",
+                            "properties": {
+                                "action": {
+                                    "const": "Command"
                                 }
                             }
                         },


### PR DESCRIPTION
对照 [3.1-任务流水线协议.md#Command](https://github.com/MaaXYZ/MaaFramework/blob/main/docs/zh_cn/3.1-%E4%BB%BB%E5%8A%A1%E6%B5%81%E6%B0%B4%E7%BA%BF%E5%8D%8F%E8%AE%AE.md#command) 的 action 属性加入 `Command` 选项、并添加 `exec`、`args`、`detach` 属性使得能够通过给出的 example：

```json
{
    "NodeA": {
        "action": "Command",
        "exec": "Python",
        "args": [
            "{RESOURCE_DIR}/my_script/test.py"
            "Haha",
            "{IMAGE}",
            "{NODE}",
            "{BOX}"
        ]
    },
    "NodeB": {
        "action": "Command",
        "exec": "{RESOURCE_DIR}/my_exec/my_exec.exe"
    }
}
```

然后发现给出的举例少了个逗号，也修一下