### PR TITLE
chore(Python): 完善 Win32Controller 类型注释; 调整 AlgorithmEnum 继承方式

### DIFF
--- a/source/binding/Python/maa/controller.py
+++ b/source/binding/Python/maa/controller.py
@@ -349,7 +349,7 @@ class Win32Controller(Controller):
 
     def __init__(
         self,
-        hWnd: Optional[ctypes.c_void_p],
+        hWnd: Union[ctypes.c_void_p, int, None],
         screencap_method: int = MaaWin32ScreencapMethodEnum.DXGI_DesktopDup,
         input_method: int = MaaWin32InputMethodEnum.Seize,
         notification_handler: Optional[NotificationHandler] = None,

--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -1,10 +1,11 @@
 import ctypes
 import platform
 from dataclasses import dataclass
-from enum import IntEnum, Enum
+from enum import IntEnum
 from typing import List, Tuple, Union, Dict, Optional
 
 import numpy
+from strenum import StrEnum  # For Python 3.9/3.10
 
 MaaBool = ctypes.c_uint8
 MaaSize = ctypes.c_size_t
@@ -446,7 +447,7 @@ RectType = Union[
 ]
 
 
-class AlgorithmEnum(str, Enum):
+class AlgorithmEnum(StrEnum):
     DirectHit = "DirectHit"
     TemplateMatch = "TemplateMatch"
     FeatureMatch = "FeatureMatch"

--- a/source/binding/Python/requirements.txt
+++ b/source/binding/Python/requirements.txt
@@ -1,1 +1,2 @@
 numpy
+strenum


### PR DESCRIPTION
```python
from enuromm import Enum

from strenum import StrEnum


class Enum1(str,Enum): # Current
    OCR = "OCR"

class Enum2(StrEnum): # PR
    OCR = "OCR"

if __name__ == "__main__":
    print(Enum1.OCR) # Enum1.OCR
    print(Enum1.OCR.value) # OCR
    print(Enum2.OCR) # OCR
```

StrEnum 于 Python3.11 加入标准库，在历史版本中需要 `pip install strenum` (最低支持 Python3.6)

尽管部分教程会使用下面的方法，但我在 Python3.9.10 下测试并没有得到预期结果。
```python
...
class Enum1(str,Enum):
    pass
```