### PR TITLE
perf:添加MacOS中自动搜索蓝叠模拟器的功能

### DIFF
--- a/source/MaaToolkit/AdbDevice/AdbDeviceMacOSFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceMacOSFinder.cpp
@@ -28,6 +28,11 @@ AdbDeviceMacOSFinder::AdbDeviceMacOSFinder()
           { .keyword = "genymotion",
             .adb_candidate_paths = { "player.app/Contents/MacOS/tools/adb"_path },
             .adb_common_serials = { "127.0.0.1:6555" } } },
+
+        { "BlueStacks",
+          { .keyword = "BlueStacks",
+            .adb_candidate_paths = { "BlueStacks.app/Contents/MacOS/hd-adb"_path },
+            .adb_common_serials = { "127.0.0.1:5555" } } },
     };
 
     set_emulator_const_data(std::move(emulators));


### PR DESCRIPTION
实际的adb路径是
```
/Applications/BlueStacks.app/Contents/MacOS/hd-adb
```
bluestacks路径是
```
/Applications/BlueStacks.app/Contents/MacOS/bluestacks
```
所以在自动搜索中的路径是绝对路径还是相对于`blurstacks`的相对路径