### PR TITLE
docs: add instructions for the "focus" field

### DIFF
--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -203,7 +203,15 @@ Android 设置界面存在菜单 `显示`/`存储`/`无障碍`，其中 `存储`
 
 - `focus`: *any*  
     关注节点，会额外产生部分回调消息。可选，默认 null，不产生回调消息。  
-    详见 [节点通知](#节点通知)。
+
+    - *string*
+
+        节点动作开始时该内容会被输出到回调信息（输出的内容可以在[通用 UI](/README.md#通用-ui)中看到）。
+
+        （可选）该消息支持以指定颜色输出 *[color:`color_str`]`My custom message.`[/color]* ，支持的 `color_str` 请参见 [CSS Color Module Level 3](https://www.w3.org/TR/css-color-3/#:~:text=4.3.%20Extended%20color%20keywords) 。
+
+    - *object*
+        详见 [节点通知](#节点通知)。
 
 ### Pipeline v2
 


### PR DESCRIPTION
原本苦于不知道怎么在特定的节点打印日志，后来在读M9A的pipline时看到原来还有这样的用法。
就自作主张来补充文档了（