### PR TITLE
feat: StartAgent

### DIFF
--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -888,3 +888,37 @@ Synchronously wait for server thread to end
 ### MaaAgentServerDetach
 
 Detach server thread
+
+## MaaToolkitProjectInterface.h
+
+### MaaToolkitProjectInterfaceLoad
+
+- `interface_path`: Path to interface.json file
+
+Load interface.json file and read agent configuration from it
+
+### MaaToolkitProjectInterfaceLoaded
+
+Check if interface.json is loaded
+
+### MaaToolkitProjectInterfaceBindResource
+
+- `resource`: Resource
+
+Bind resource for Agent
+
+### MaaToolkitProjectInterfaceStartAgent
+
+Start Agent process using loaded agent configuration
+
+### MaaToolkitProjectInterfaceStopAgent
+
+Stop Agent process
+
+### MaaToolkitProjectInterfaceAgentRunning
+
+Check if Agent process is running
+
+### MaaToolkitProjectInterfaceAgentConnected
+
+Check if Agent is connected

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -888,3 +888,37 @@
 ### MaaAgentServerDetach
 
 分离服务线程
+
+## MaaToolkitProjectInterface.h
+
+### MaaToolkitProjectInterfaceLoad
+
+- `interface_path`: interface.json 文件路径
+
+加载 interface.json 文件并读取其中的 agent 配置
+
+### MaaToolkitProjectInterfaceLoaded
+
+判断是否已加载 interface.json
+
+### MaaToolkitProjectInterfaceBindResource
+
+- `resource`: 资源
+
+为 Agent 绑定资源
+
+### MaaToolkitProjectInterfaceStartAgent
+
+使用已加载的 agent 配置启动 Agent 进程
+
+### MaaToolkitProjectInterfaceStopAgent
+
+停止 Agent 进程
+
+### MaaToolkitProjectInterfaceAgentRunning
+
+判断 Agent 进程是否正在运行
+
+### MaaToolkitProjectInterfaceAgentConnected
+
+判断 Agent 是否已连接

--- a/include/MaaToolkit/MaaToolkitAPI.h
+++ b/include/MaaToolkit/MaaToolkitAPI.h
@@ -5,3 +5,4 @@
 #include "AdbDevice/MaaToolkitAdbDevice.h"
 #include "Config/MaaToolkitConfig.h"
 #include "DesktopWindow/MaaToolkitDesktopWindow.h"
+#include "ProjectInterface/MaaToolkitProjectInterface.h"

--- a/include/MaaToolkit/ProjectInterface/MaaToolkitProjectInterface.h
+++ b/include/MaaToolkit/ProjectInterface/MaaToolkitProjectInterface.h
@@ -1,0 +1,70 @@
+/**
+ * @file MaaToolkitProjectInterface.h
+ * @brief Project Interface API for MaaToolkit
+ *
+ * @copyright Copyright (c) 2024
+ */
+
+// IWYU pragma: private, include <MaaToolkit/MaaToolkitAPI.h>
+
+#pragma once
+
+#include "../MaaToolkitDef.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief Load interface.json and read agent configuration
+     *
+     * @param interface_path Path to the interface.json file
+     * @return MaaBool Whether the load was successful
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceLoad(const char* interface_path);
+
+    /**
+     * @brief Check if project interface is loaded
+     *
+     * @return MaaBool Whether the interface is loaded
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceLoaded();
+
+    /**
+     * @brief Bind resource to the agent
+     *
+     * @param resource The resource to bind
+     * @return MaaBool Whether the binding was successful
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceBindResource(MaaResource* resource);
+
+    /**
+     * @brief Start the agent using loaded configuration
+     *
+     * @return MaaBool Whether the start was successful
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceStartAgent();
+
+    /**
+     * @brief Stop the agent
+     */
+    MAA_TOOLKIT_API void MaaToolkitProjectInterfaceStopAgent();
+
+    /**
+     * @brief Check if the agent is running
+     *
+     * @return MaaBool Whether the agent is running
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceAgentRunning();
+
+    /**
+     * @brief Check if the agent is connected
+     *
+     * @return MaaBool Whether the agent is connected
+     */
+    MAA_TOOLKIT_API MaaBool MaaToolkitProjectInterfaceAgentConnected();
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/MaaToolkit/API/MaaToolkitProjectInterface.cpp
+++ b/source/MaaToolkit/API/MaaToolkitProjectInterface.cpp
@@ -1,0 +1,59 @@
+#include "MaaToolkit/ProjectInterface/MaaToolkitProjectInterface.h"
+
+#include "MaaUtils/Logger.h"
+#include "MaaUtils/Platform.h"
+#include "ProjectInterface/ProjectInterfaceMgr.h"
+
+MaaBool MaaToolkitProjectInterfaceLoad(const char* interface_path)
+{
+    LogInfo << VAR(interface_path);
+
+    if (!interface_path) {
+        LogError << "interface_path is null";
+        return false;
+    }
+
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    return mgr.load(MAA_NS::path(interface_path));
+}
+
+MaaBool MaaToolkitProjectInterfaceLoaded()
+{
+    return MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance().loaded();
+}
+
+MaaBool MaaToolkitProjectInterfaceBindResource(MaaResource* resource)
+{
+    LogFunc << VAR(resource);
+
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    return mgr.bind_resource(resource);
+}
+
+MaaBool MaaToolkitProjectInterfaceStartAgent()
+{
+    LogFunc;
+
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    return mgr.start_agent();
+}
+
+void MaaToolkitProjectInterfaceStopAgent()
+{
+    LogFunc;
+
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    mgr.stop_agent();
+}
+
+MaaBool MaaToolkitProjectInterfaceAgentRunning()
+{
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    return mgr.agent_running();
+}
+
+MaaBool MaaToolkitProjectInterfaceAgentConnected()
+{
+    auto& mgr = MAA_TOOLKIT_NS::ProjectInterfaceMgr::get_instance();
+    return mgr.agent_connected();
+}

--- a/source/MaaToolkit/CMakeLists.txt
+++ b/source/MaaToolkit/CMakeLists.txt
@@ -11,13 +11,13 @@ target_include_directories(
 target_compile_definitions(MaaToolkit PRIVATE MAA_TOOLKIT_EXPORTS)
 
 target_link_libraries(
-    MaaToolkit PRIVATE MaaUtils MaaFramework LibraryHolder Boost::system ${OpenCV_LIBS})
+    MaaToolkit PRIVATE MaaUtils MaaFramework MaaAgentClient LibraryHolder Boost::system ${OpenCV_LIBS})
 
 if(LINUX)
     target_link_libraries(MaaToolkit PRIVATE pthread dl)
 endif()
 
-add_dependencies(MaaToolkit MaaUtils MaaFramework LibraryHolder)
+add_dependencies(MaaToolkit MaaUtils MaaFramework MaaAgentClient LibraryHolder)
 
 install(
     TARGETS MaaToolkit

--- a/source/MaaToolkit/ProjectInterface/ProjectInterfaceMgr.cpp
+++ b/source/MaaToolkit/ProjectInterface/ProjectInterfaceMgr.cpp
@@ -1,0 +1,239 @@
+#include "ProjectInterfaceMgr.h"
+
+#include <meojson/json.hpp>
+
+#include "MaaAgentClient/MaaAgentClientAPI.h"
+#include "MaaFramework/MaaAPI.h"
+#include "MaaUtils/Encoding.h"
+#include "MaaUtils/Logger.h"
+#include "MaaUtils/Platform.h"
+#include "MaaUtils/StringMisc.hpp"
+
+MAA_TOOLKIT_NS_BEGIN
+
+#ifdef _WIN32
+static std::vector<std::wstring> conv_args(const std::vector<std::string>& args)
+{
+    std::vector<std::wstring> wargs;
+    for (const auto& arg : args) {
+        wargs.emplace_back(to_u16(arg));
+    }
+    return wargs;
+}
+#else
+static std::vector<std::string> conv_args(const std::vector<std::string>& args)
+{
+    return args;
+}
+#endif
+
+ProjectInterfaceMgr::~ProjectInterfaceMgr()
+{
+    stop_agent();
+}
+
+bool ProjectInterfaceMgr::load(const std::filesystem::path& interface_path)
+{
+    LogFunc << VAR(interface_path);
+
+    auto json_opt = json::open(interface_path, true, true);
+    if (!json_opt) {
+        LogError << "failed to parse" << interface_path;
+        return false;
+    }
+
+    const json::value& json = *json_opt;
+
+    // 只读取 agent 字段
+    auto agent_opt = json.find("agent");
+    if (!agent_opt || !agent_opt->is_object()) {
+        LogWarn << "agent field not found or not an object";
+        // 没有 agent 也可以算成功
+        loaded_ = true;
+        project_dir_ = interface_path.parent_path();
+        return true;
+    }
+
+    const auto& agent = *agent_opt;
+
+    agent_config_.child_exec = agent.get("child_exec", std::string {});
+    agent_config_.identifier = agent.get("identifier", std::string {});
+
+    auto args_opt = agent.find("child_args");
+    if (args_opt && args_opt->is_array()) {
+        for (const auto& arg : args_opt->as_array()) {
+            if (arg.is_string()) {
+                agent_config_.child_args.emplace_back(arg.as_string());
+            }
+        }
+    }
+
+    project_dir_ = interface_path.parent_path();
+    loaded_ = true;
+
+    LogInfo << "Agent config loaded" << VAR(agent_config_.child_exec) << VAR(agent_config_.child_args);
+    return true;
+}
+
+bool ProjectInterfaceMgr::bind_resource(MaaResource* resource)
+{
+    LogFunc << VAR(resource);
+
+    if (!resource) {
+        LogError << "resource is null";
+        return false;
+    }
+
+    resource_ = resource;
+    return true;
+}
+
+bool ProjectInterfaceMgr::start_agent()
+{
+    LogFunc;
+
+    if (!loaded_) {
+        LogError << "interface not loaded";
+        return false;
+    }
+
+    if (!resource_) {
+        LogError << "resource not bound";
+        return false;
+    }
+
+    if (agent_config_.child_exec.empty()) {
+        LogError << "agent child_exec is empty";
+        return false;
+    }
+
+    // 处理 {PROJECT_DIR} 占位符
+    constexpr std::string_view kProjectDir = "{PROJECT_DIR}";
+    std::string project_dir = path_to_utf8_string(project_dir_);
+
+    std::filesystem::path child_exec = path(string_replace_all(agent_config_.child_exec, kProjectDir, project_dir));
+
+    std::vector<std::string> child_args;
+    for (const auto& arg : agent_config_.child_args) {
+        child_args.emplace_back(string_replace_all(arg, kProjectDir, project_dir));
+    }
+
+    // 创建 AgentClient
+    MaaStringBuffer* id_buffer = nullptr;
+    if (!agent_config_.identifier.empty()) {
+        id_buffer = MaaStringBufferCreate();
+        MaaStringBufferSetEx(id_buffer, agent_config_.identifier.c_str(), agent_config_.identifier.size());
+    }
+
+    agent_ = MaaAgentClientCreateV2(id_buffer);
+    if (id_buffer) {
+        MaaStringBufferDestroy(id_buffer);
+    }
+
+    if (!agent_) {
+        LogError << "Failed to create agent client";
+        return false;
+    }
+
+    // 绑定资源
+    if (!MaaAgentClientBindResource(agent_, resource_)) {
+        LogError << "Failed to bind resource";
+        cleanup_agent();
+        return false;
+    }
+
+    // 获取 socket id
+    auto* socket_id_buffer = MaaStringBufferCreate();
+    if (!MaaAgentClientIdentifier(agent_, socket_id_buffer)) {
+        LogError << "Failed to get socket id";
+        MaaStringBufferDestroy(socket_id_buffer);
+        cleanup_agent();
+        return false;
+    }
+    std::string socket_id = MaaStringBufferGet(socket_id_buffer);
+    MaaStringBufferDestroy(socket_id_buffer);
+
+    // 准备参数
+    std::vector<std::string> args = child_args;
+    args.emplace_back(socket_id);
+
+    // 查找可执行文件
+    std::filesystem::path exec = child_exec;
+    if (!std::filesystem::exists(exec)) {
+        exec = boost::process::search_path(child_exec);
+    }
+    if (exec.empty() || !std::filesystem::exists(exec)) {
+        LogError << "Failed to find agent executable" << VAR(child_exec);
+        cleanup_agent();
+        return false;
+    }
+
+    auto os_args = conv_args(args);
+    LogInfo << "Starting Agent" << VAR(exec) << VAR(os_args);
+
+    try {
+        agent_child_ = boost::process::child(exec, os_args);
+    }
+    catch (const std::exception& e) {
+        LogError << "Failed to start agent process" << VAR(e.what());
+        cleanup_agent();
+        return false;
+    }
+
+    // 连接 Agent
+    if (!MaaAgentClientConnect(agent_)) {
+        LogError << "Failed to connect agent";
+        cleanup_agent();
+        return false;
+    }
+
+    LogInfo << "Agent started and connected successfully";
+    return true;
+}
+
+void ProjectInterfaceMgr::stop_agent()
+{
+    LogFunc;
+
+    if (agent_) {
+        MaaAgentClientDisconnect(agent_);
+    }
+
+    cleanup_agent();
+}
+
+bool ProjectInterfaceMgr::agent_running()
+{
+    return agent_child_.has_value() && agent_child_->running();
+}
+
+bool ProjectInterfaceMgr::agent_connected() const
+{
+    return agent_ && MaaAgentClientConnected(agent_);
+}
+
+void ProjectInterfaceMgr::cleanup_agent()
+{
+    LogFunc;
+
+    if (agent_child_.has_value()) {
+        try {
+            if (agent_child_->running()) {
+                agent_child_->terminate();
+            }
+            agent_child_->wait();
+        }
+        catch (const std::exception& e) {
+            LogWarn << "Exception while terminating agent child" << VAR(e.what());
+        }
+        agent_child_.reset();
+    }
+
+    if (agent_) {
+        MaaAgentClientDestroy(agent_);
+        agent_ = nullptr;
+    }
+}
+
+MAA_TOOLKIT_NS_END
+

--- a/source/MaaToolkit/ProjectInterface/ProjectInterfaceMgr.h
+++ b/source/MaaToolkit/ProjectInterface/ProjectInterfaceMgr.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Common/Conf.h"
+#include "MaaFramework/MaaDef.h"
+#include "MaaUtils/IOStream/BoostIO.hpp"
+#include "MaaUtils/SingletonHolder.hpp"
+
+MAA_TOOLKIT_NS_BEGIN
+
+class ProjectInterfaceMgr : public SingletonHolder<ProjectInterfaceMgr>
+{
+    friend class SingletonHolder<ProjectInterfaceMgr>;
+
+public:
+    struct AgentConfig
+    {
+        std::string child_exec;
+        std::vector<std::string> child_args;
+        std::string identifier;
+    };
+
+public:
+    // 加载 interface.json，只读取 agent 字段
+    bool load(const std::filesystem::path& interface_path);
+
+    bool loaded() const { return loaded_; }
+
+    const std::filesystem::path& project_dir() const { return project_dir_; }
+
+    const AgentConfig& agent_config() const { return agent_config_; }
+
+    // 绑定资源
+    bool bind_resource(MaaResource* resource);
+
+    // 启动 Agent（使用已加载的配置）
+    bool start_agent();
+
+    // 停止 Agent
+    void stop_agent();
+
+    // 检查 Agent 是否正在运行
+    bool agent_running();
+
+    // 检查 Agent 连接状态
+    bool agent_connected() const;
+
+private:
+    ProjectInterfaceMgr() = default;
+    ~ProjectInterfaceMgr();
+
+    void cleanup_agent();
+
+private:
+    bool loaded_ = false;
+    std::filesystem::path project_dir_;
+    AgentConfig agent_config_;
+
+    MaaAgentClient* agent_ = nullptr;
+    MaaResource* resource_ = nullptr;
+    std::optional<boost::process::child> agent_child_;
+};
+
+MAA_TOOLKIT_NS_END
+

--- a/source/binding/NodeJS/src/apis/global.cpp
+++ b/source/binding/NodeJS/src/apis/global.cpp
@@ -1,4 +1,5 @@
 #include "loader.h"
+#include "resource.h"
 
 #include <MaaFramework/MaaAPI.h>
 #include <MaaToolkit/MaaToolkitAPI.h>
@@ -79,6 +80,51 @@ void config_init_option(std::string user_path, maajs::OptionalParam<std::string>
     }
 }
 
+void pi_load(std::string interface_path)
+{
+    if (!MaaToolkitProjectInterfaceLoad(interface_path.c_str())) {
+        throw maajs::MaaError { "ProjectInterface load failed" };
+    }
+}
+
+bool pi_loaded()
+{
+    return MaaToolkitProjectInterfaceLoaded();
+}
+
+void pi_bind_resource(maajs::ValueType resource)
+{
+    auto* impl = maajs::native_class_unwrap<ResourceImpl>(resource);
+    if (!impl || !impl->resource) {
+        throw maajs::MaaError { "ProjectInterface bind_resource failed: invalid resource" };
+    }
+    if (!MaaToolkitProjectInterfaceBindResource(impl->resource)) {
+        throw maajs::MaaError { "ProjectInterface bind_resource failed" };
+    }
+}
+
+void pi_start_agent()
+{
+    if (!MaaToolkitProjectInterfaceStartAgent()) {
+        throw maajs::MaaError { "ProjectInterface start_agent failed" };
+    }
+}
+
+void pi_stop_agent()
+{
+    MaaToolkitProjectInterfaceStopAgent();
+}
+
+bool pi_agent_running()
+{
+    return MaaToolkitProjectInterfaceAgentRunning();
+}
+
+bool pi_agent_connected()
+{
+    return MaaToolkitProjectInterfaceAgentConnected();
+}
+
 maajs::ObjectType load_global(maajs::EnvType env)
 {
     auto globalObject = maajs::ObjectType::New(env);
@@ -90,6 +136,13 @@ maajs::ObjectType load_global(maajs::EnvType env)
     MAA_BIND_SETTER(globalObject, "stdout_level", set_stdout_level);
     MAA_BIND_SETTER(globalObject, "debug_mode", set_debug_mode);
     MAA_BIND_FUNC(globalObject, "config_init_option", config_init_option);
+    MAA_BIND_FUNC(globalObject, "pi_load", pi_load);
+    MAA_BIND_GETTER(globalObject, "pi_loaded", pi_loaded);
+    MAA_BIND_FUNC(globalObject, "pi_bind_resource", pi_bind_resource);
+    MAA_BIND_FUNC(globalObject, "pi_start_agent", pi_start_agent);
+    MAA_BIND_FUNC(globalObject, "pi_stop_agent", pi_stop_agent);
+    MAA_BIND_GETTER(globalObject, "pi_agent_running", pi_agent_running);
+    MAA_BIND_GETTER(globalObject, "pi_agent_connected", pi_agent_connected);
 
     return globalObject;
 }

--- a/source/binding/NodeJS/src/apis/global.d.ts
+++ b/source/binding/NodeJS/src/apis/global.d.ts
@@ -10,6 +10,22 @@ declare global {
             )
             set debug_mode(value: boolean)
             config_init_option(user_path: string, default_json?: string): void
+
+            // ProjectInterface APIs
+            /** Load interface.json and read agent configuration */
+            pi_load(interface_path: string): void
+            /** Check if interface.json is loaded */
+            get pi_loaded(): boolean
+            /** Bind resource for Agent */
+            pi_bind_resource(resource: maa.ResourceHandle): void
+            /** Start Agent using loaded configuration */
+            pi_start_agent(): void
+            /** Stop Agent */
+            pi_stop_agent(): void
+            /** Check if Agent is running */
+            get pi_agent_running(): boolean
+            /** Check if Agent is connected */
+            get pi_agent_connected(): boolean
         }
     }
 }

--- a/source/binding/Python/maa/toolkit.py
+++ b/source/binding/Python/maa/toolkit.py
@@ -6,6 +6,7 @@ from typing import Dict, List, Union, Optional, Any
 
 from .define import *
 from .library import Library
+from .resource import Resource
 
 
 @dataclass
@@ -51,7 +52,7 @@ class Toolkit:
 
     @staticmethod
     def find_adb_devices(
-        specified_adb: Optional[Union[str, Path]] = None
+        specified_adb: Optional[Union[str, Path]] = None,
     ) -> List[AdbDevice]:
         """搜索所有已知安卓模拟器 / Search all known Android emulators
 
@@ -141,6 +142,91 @@ class Toolkit:
 
         Library.toolkit().MaaToolkitDesktopWindowListDestroy(list_handle)
         return windows
+
+    @staticmethod
+    def pi_load(interface_path: Union[str, Path]) -> bool:
+        """加载 interface.json 并读取 agent 配置 / Load interface.json and read agent config
+
+        Args:
+            interface_path: interface.json 文件路径 / Path to interface.json
+
+        Returns:
+            bool: 是否成功 / Whether successful
+        """
+        Toolkit._set_api_properties()
+
+        return bool(
+            Library.toolkit().MaaToolkitProjectInterfaceLoad(
+                str(interface_path).encode()
+            )
+        )
+
+    @staticmethod
+    def pi_loaded() -> bool:
+        """判断 interface.json 是否已加载 / Check if interface.json is loaded
+
+        Returns:
+            bool: 是否已加载 / Whether loaded
+        """
+        Toolkit._set_api_properties()
+
+        return bool(Library.toolkit().MaaToolkitProjectInterfaceLoaded())
+
+    @staticmethod
+    def pi_bind_resource(resource: Resource) -> bool:
+        """为 Agent 绑定资源 / Bind resource for Agent
+
+        Args:
+            resource: 资源 / Resource
+
+        Returns:
+            bool: 是否成功 / Whether successful
+        """
+        Toolkit._set_api_properties()
+
+        return bool(
+            Library.toolkit().MaaToolkitProjectInterfaceBindResource(resource._handle)
+        )
+
+    @staticmethod
+    def pi_start_agent() -> bool:
+        """启动 Agent / Start Agent
+
+        Returns:
+            bool: 是否成功 / Whether successful
+        """
+        Toolkit._set_api_properties()
+
+        return bool(Library.toolkit().MaaToolkitProjectInterfaceStartAgent())
+
+    @staticmethod
+    def pi_stop_agent() -> None:
+        """停止 Agent / Stop Agent"""
+        Toolkit._set_api_properties()
+
+        Library.toolkit().MaaToolkitProjectInterfaceStopAgent()
+
+    @staticmethod
+    def pi_agent_running() -> bool:
+        """判断 Agent 是否正在运行 / Check if Agent is running
+
+        Returns:
+            bool: 是否正在运行 / Whether running
+        """
+        Toolkit._set_api_properties()
+
+        return bool(Library.toolkit().MaaToolkitProjectInterfaceAgentRunning())
+
+    @staticmethod
+    def pi_agent_connected() -> bool:
+        """判断 Agent 是否已连接 / Check if Agent is connected
+
+        Returns:
+            bool: 是否已连接 / Whether connected
+        """
+        Toolkit._set_api_properties()
+
+        return bool(Library.toolkit().MaaToolkitProjectInterfaceAgentConnected())
 
     ### private ###
 
@@ -264,3 +350,26 @@ class Toolkit:
         Library.toolkit().MaaToolkitDesktopWindowGetWindowName.argtypes = [
             MaaToolkitDesktopWindowHandle
         ]
+
+        Library.toolkit().MaaToolkitProjectInterfaceLoad.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceLoad.argtypes = [ctypes.c_char_p]
+
+        Library.toolkit().MaaToolkitProjectInterfaceLoaded.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceLoaded.argtypes = []
+
+        Library.toolkit().MaaToolkitProjectInterfaceBindResource.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceBindResource.argtypes = [
+            MaaResourceHandle
+        ]
+
+        Library.toolkit().MaaToolkitProjectInterfaceStartAgent.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceStartAgent.argtypes = []
+
+        Library.toolkit().MaaToolkitProjectInterfaceStopAgent.restype = None
+        Library.toolkit().MaaToolkitProjectInterfaceStopAgent.argtypes = []
+
+        Library.toolkit().MaaToolkitProjectInterfaceAgentRunning.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceAgentRunning.argtypes = []
+
+        Library.toolkit().MaaToolkitProjectInterfaceAgentConnected.restype = MaaBool
+        Library.toolkit().MaaToolkitProjectInterfaceAgentConnected.argtypes = []


### PR DESCRIPTION
@overflow65537 @weinibuliu 是不是你要的

## Summary by Sourcery

向 MaaToolkit 新增一个新的 Project Interface 子系统，用于加载 `interface.json`、管理 Agent 配置、控制外部 Agent 进程，并通过 C API 以及 Python 和 NodeJS 绑定对外暴露这些能力。

New Features:
- 引入 MaaToolkit Project Interface C API，用于加载项目 `interface.json`、绑定资源，以及在查询状态的同时启动或停止 Agent 进程。
- 新增 `ProjectInterfaceMgr` 单例，用于解析 Agent 配置、启动并管理 Agent 子进程，以及跟踪其连接状态和运行状态。
- 通过新的 Toolkit 静态方法，将 Project Interface 操作（加载、状态、绑定资源、启动/停止 Agent、状态检查）暴露给 Python 绑定。
- 通过新的全局函数和类型定义，将 Project Interface 操作暴露给 NodeJS 绑定。

Enhancements:
- 将 MaaToolkit 链接到 MaaAgentClient，并在 MaaToolkit 的公共 API 中加入新的 Project Interface 头文件。
- 在英文集成接口总览文档中，记录新的 `MaaToolkitProjectInterface` API 和 Agent 生命周期行为。

Build:
- 更新 MaaToolkit 的 CMake 配置，使其依赖并链接 MaaAgentClient，以进行 Agent 进程管理。

Documentation:
- 扩展英文文档，增加 `MaaToolkitProjectInterface` 函数的使用细节，包括加载配置和控制 Agent 生命周期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Project Interface subsystem to MaaToolkit that can load interface.json, manage Agent configuration, and control an external Agent process, and expose these capabilities through C API plus Python and NodeJS bindings.

New Features:
- Introduce MaaToolkit Project Interface C APIs for loading project interface.json, binding resources, and starting or stopping an Agent process while querying its state.
- Add a ProjectInterfaceMgr singleton to parse agent configuration, launch and manage the Agent child process, and track its connection and running status.
- Expose Project Interface operations (load, status, bind resource, start/stop Agent, state checks) to Python bindings via new Toolkit static methods.
- Expose Project Interface operations to NodeJS bindings via new global functions and type definitions.

Enhancements:
- Link MaaToolkit against MaaAgentClient and include the new Project Interface header in the public MaaToolkit API surface.
- Document the new MaaToolkitProjectInterface APIs and Agent lifecycle behavior in the English integrated interface overview.

Build:
- Update MaaToolkit CMake configuration to depend on and link with MaaAgentClient for Agent process management.

Documentation:
- Extend English documentation with usage details for MaaToolkitProjectInterface functions, including loading configuration and controlling the Agent lifecycle.

</details>