### PR TITLE
feat: android native control unit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,7 +402,8 @@ jobs:
                     -DANDROID_ABI=${{ matrix.arch == 'x86_64' && 'x86_64' || 'arm64-v8a' }} \
                     -DANDROID_PLATFORM=android-23 \
                     -DMAADEPS_TRIPLET='maa-${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-android' \
-                    -DMAA_HASH_VERSION='${{ needs.meta.outputs.tag }}'
+                    -DMAA_HASH_VERSION='${{ needs.meta.outputs.tag }}' \
+                    -DWITH_ANDROID_NATIVE_CONTROLLER=ON
 
                   cmake --build build --preset 'NinjaMulti - ${{ inputs.build_config || needs.meta.outputs.build_config }}' -j 16
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.28)
 
 project(MaaFw)
 
-set(CMAKE_CXX_SCAN_FOR_MODULES  OFF)
+set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 
 include(source/MaaUtils/MaaUtils.cmake)
 
@@ -10,6 +10,14 @@ option(WITH_ADB_CONTROLLER "build with adb controller" ON)
 option(WITH_WIN32_CONTROLLER "build with win32 controller" ON)
 option(WITH_DBG_CONTROLLER "build with debugging controller" OFF)
 option(WITH_CUSTOM_CONTROLLER "build with custom controller" ON)
+
+# Android Native Controller 只在 Android 平台可用
+if(ANDROID)
+    option(WITH_ANDROID_NATIVE_CONTROLLER "build with android native controller" ON)
+else()
+    set(WITH_ANDROID_NATIVE_CONTROLLER OFF CACHE BOOL "build with android native controller" FORCE)
+endif()
+
 option(WITH_NODEJS_BINDING "build with nodejs binding" OFF)
 option(WITH_QUICKJS_BINDING "build with quickjs binding" OFF)
 option(WITH_MAA_AGENT "build with MaaAgent" ON)

--- a/include/MaaFramework/Instance/MaaController.h
+++ b/include/MaaFramework/Instance/MaaController.h
@@ -40,6 +40,19 @@ extern "C"
     MAA_FRAMEWORK_API MaaController*
         MaaDbgControllerCreate(const char* read_path, const char* write_path, MaaDbgControllerType type, const char* config);
 
+    /**
+     * @brief Create an Android native controller.
+     *
+     * This controller uses Android's native APIs for screenshots and input injection.
+     * It runs directly on the Android device without requiring adb.
+     *
+     * @return MaaController* The created controller handle, or nullptr on failure.
+     *
+     * @note This controller only works when MaaFramework is running on Android.
+     * @note Requires appropriate permissions (INJECT_EVENTS for input, CAPTURE_VIDEO_OUTPUT for screencap).
+     */
+    MAA_FRAMEWORK_API MaaController* MaaAndroidNativeControllerCreate();
+
     MAA_FRAMEWORK_API void MaaControllerDestroy(MaaController* ctrl);
 
     MAA_FRAMEWORK_API MaaSinkId MaaControllerAddSink(MaaController* ctrl, MaaEventCallback sink, void* trans_arg);

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,6 +6,10 @@ if(WITH_WIN32_CONTROLLER)
     add_subdirectory(MaaWin32ControlUnit)
 endif()
 
+if(WITH_ANDROID_NATIVE_CONTROLLER)
+    add_subdirectory(MaaAndroidNativeControlUnit)
+endif()
+
 if(WITH_DBG_CONTROLLER)
     add_subdirectory(MaaDbgControlUnit)
 endif()

--- a/source/MaaAndroidNativeControlUnit/API/AndroidNativeControlUnitAPI.cpp
+++ b/source/MaaAndroidNativeControlUnit/API/AndroidNativeControlUnitAPI.cpp
@@ -1,0 +1,30 @@
+#include "ControlUnit/AndroidNativeControlUnitAPI.h"
+
+#include "MaaUtils/Logger.h"
+#include "Manager/AndroidNativeControlUnitMgr.h"
+
+const char* MaaAndroidNativeControlUnitGetVersion()
+{
+#pragma message("MaaAndroidNativeControlUnit MAA_VERSION: " MAA_VERSION)
+
+    return MAA_VERSION;
+}
+
+MaaAndroidNativeControlUnitHandle MaaAndroidNativeControlUnitCreate()
+{
+    using namespace MAA_CTRL_UNIT_NS;
+
+    LogFunc;
+
+    auto unit_mgr = new AndroidNativeControlUnitMgr();
+    return unit_mgr;
+}
+
+void MaaAndroidNativeControlUnitDestroy(MaaAndroidNativeControlUnitHandle handle)
+{
+    LogFunc << VAR_VOIDP(handle);
+
+    if (handle) {
+        delete handle;
+    }
+}

--- a/source/MaaAndroidNativeControlUnit/Base/InputBase.h
+++ b/source/MaaAndroidNativeControlUnit/Base/InputBase.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+
+#include "Conf/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+class InputBase
+{
+public:
+    virtual ~InputBase() = default;
+
+    virtual bool init(int display_width, int display_height) = 0;
+
+    virtual bool click(int x, int y) = 0;
+    virtual bool swipe(int x1, int y1, int x2, int y2, int duration) = 0;
+
+    virtual bool touch_down(int contact, int x, int y, int pressure) = 0;
+    virtual bool touch_move(int contact, int x, int y, int pressure) = 0;
+    virtual bool touch_up(int contact) = 0;
+
+    virtual bool click_key(int key) = 0;
+    virtual bool input_text(const std::string& text) = 0;
+
+    virtual bool key_down(int key) = 0;
+    virtual bool key_up(int key) = 0;
+
+    virtual bool start_app(const std::string& intent) = 0;
+    virtual bool stop_app(const std::string& intent) = 0;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/Base/ScreencapBase.h
+++ b/source/MaaAndroidNativeControlUnit/Base/ScreencapBase.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Conf/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+class ScreencapBase
+{
+public:
+    virtual ~ScreencapBase() = default;
+
+    virtual bool init() = 0;
+    virtual bool screencap(cv::Mat& image) = 0;
+    virtual std::pair<int, int> get_resolution() const = 0;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/CMakeLists.txt
+++ b/source/MaaAndroidNativeControlUnit/CMakeLists.txt
@@ -1,0 +1,22 @@
+file(GLOB_RECURSE maa_android_native_control_unit_src *.h *.hpp *.cpp)
+file(GLOB_RECURSE maa_android_native_control_unit_header ${MAA_PRIVATE_INC}/ControlUnit/AndroidNativeControlUnitAPI.h ${MAA_PRIVATE_INC}/ControlUnit/ControlUnitAPI.h)
+
+add_library(MaaAndroidNativeControlUnit SHARED ${maa_android_native_control_unit_src} ${maa_android_native_control_unit_header})
+
+target_include_directories(MaaAndroidNativeControlUnit
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${MAA_PRIVATE_INC} ${MAA_PUBLIC_INC})
+
+target_link_libraries(MaaAndroidNativeControlUnit PRIVATE MaaUtils ${OpenCV_LIBS} ZLIB::ZLIB Boost::system)
+target_link_libraries(MaaAndroidNativeControlUnit PRIVATE android log)
+
+target_compile_definitions(MaaAndroidNativeControlUnit PRIVATE MAA_CONTROL_UNIT_EXPORTS)
+
+add_dependencies(MaaAndroidNativeControlUnit MaaUtils)
+
+install(
+    TARGETS MaaAndroidNativeControlUnit
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION bin
+)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${maa_android_native_control_unit_src})

--- a/source/MaaAndroidNativeControlUnit/Input/NativeInput.cpp
+++ b/source/MaaAndroidNativeControlUnit/Input/NativeInput.cpp
@@ -1,0 +1,337 @@
+#include "NativeInput.h"
+
+#include <chrono>
+#include <thread>
+
+#include "MaaUtils/Logger.h"
+
+// Android MotionEvent action constants
+#define AMOTION_EVENT_ACTION_DOWN 0
+#define AMOTION_EVENT_ACTION_UP 1
+#define AMOTION_EVENT_ACTION_MOVE 2
+#define AMOTION_EVENT_ACTION_POINTER_DOWN 5
+#define AMOTION_EVENT_ACTION_POINTER_UP 6
+
+// Android KeyEvent action constants
+#define AKEY_EVENT_ACTION_DOWN 0
+#define AKEY_EVENT_ACTION_UP 1
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+NativeInput::~NativeInput()
+{
+    LogFunc;
+
+    if (input_helper_ && jvm_) {
+        JNIEnv* env = nullptr;
+        if (jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) == JNI_OK && env) {
+            env->DeleteGlobalRef(input_helper_);
+        }
+    }
+}
+
+bool NativeInput::init(int display_width, int display_height)
+{
+    LogFunc << VAR(display_width) << VAR(display_height);
+
+    display_width_ = display_width;
+    display_height_ = display_height;
+
+    // JNI 初始化将在外部完成
+    // 这里只记录显示尺寸
+
+    return true;
+}
+
+bool NativeInput::inject_touch_event(int action, int x, int y, int pointer_id)
+{
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!input_helper_ || !inject_touch_method_) {
+        LogError << "input helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    jboolean result = env->CallBooleanMethod(input_helper_, inject_touch_method_, action, x, y, pointer_id);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return result == JNI_TRUE;
+}
+
+bool NativeInput::inject_key_event(int action, int keycode)
+{
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!input_helper_ || !inject_key_method_) {
+        LogError << "input helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    jboolean result = env->CallBooleanMethod(input_helper_, inject_key_method_, action, keycode);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return result == JNI_TRUE;
+}
+
+bool NativeInput::click(int x, int y)
+{
+    LogInfo << VAR(x) << VAR(y);
+
+    if (!touch_down(0, x, y, 50)) {
+        return false;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    return touch_up(0);
+}
+
+bool NativeInput::swipe(int x1, int y1, int x2, int y2, int duration)
+{
+    LogInfo << VAR(x1) << VAR(y1) << VAR(x2) << VAR(y2) << VAR(duration);
+
+    if (!touch_down(0, x1, y1, 50)) {
+        return false;
+    }
+
+    const int steps = duration / 10;
+    const double dx = static_cast<double>(x2 - x1) / steps;
+    const double dy = static_cast<double>(y2 - y1) / steps;
+
+    for (int i = 1; i <= steps; ++i) {
+        int x = static_cast<int>(x1 + dx * i);
+        int y = static_cast<int>(y1 + dy * i);
+
+        if (!touch_move(0, x, y, 50)) {
+            return false;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    return touch_up(0);
+}
+
+bool NativeInput::touch_down(int contact, int x, int y, [[maybe_unused]] int pressure)
+{
+    int action = (contact == 0) ? AMOTION_EVENT_ACTION_DOWN : (AMOTION_EVENT_ACTION_POINTER_DOWN | (contact << 8));
+    return inject_touch_event(action, x, y, contact);
+}
+
+bool NativeInput::touch_move(int contact, int x, int y, [[maybe_unused]] int pressure)
+{
+    return inject_touch_event(AMOTION_EVENT_ACTION_MOVE, x, y, contact);
+}
+
+bool NativeInput::touch_up(int contact)
+{
+    int action = (contact == 0) ? AMOTION_EVENT_ACTION_UP : (AMOTION_EVENT_ACTION_POINTER_UP | (contact << 8));
+    return inject_touch_event(action, 0, 0, contact);
+}
+
+bool NativeInput::click_key(int key)
+{
+    LogInfo << VAR(key);
+
+    if (!key_down(key)) {
+        return false;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    return key_up(key);
+}
+
+bool NativeInput::input_text(const std::string& text)
+{
+    LogInfo << VAR(text);
+
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!input_helper_ || !inject_text_method_) {
+        LogError << "input helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    jstring jtext = env->NewStringUTF(text.c_str());
+    jboolean result = env->CallBooleanMethod(input_helper_, inject_text_method_, jtext);
+    env->DeleteLocalRef(jtext);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return result == JNI_TRUE;
+}
+
+bool NativeInput::key_down(int key)
+{
+    return inject_key_event(AKEY_EVENT_ACTION_DOWN, key);
+}
+
+bool NativeInput::key_up(int key)
+{
+    return inject_key_event(AKEY_EVENT_ACTION_UP, key);
+}
+
+bool NativeInput::start_app(const std::string& intent)
+{
+    LogFunc << VAR(intent);
+
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!input_helper_ || !start_app_method_) {
+        LogError << "input helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    jstring jintent = env->NewStringUTF(intent.c_str());
+    jboolean result = env->CallBooleanMethod(input_helper_, start_app_method_, jintent);
+    env->DeleteLocalRef(jintent);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return result == JNI_TRUE;
+}
+
+bool NativeInput::stop_app(const std::string& intent)
+{
+    LogFunc << VAR(intent);
+
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!input_helper_ || !stop_app_method_) {
+        LogError << "input helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    jstring jintent = env->NewStringUTF(intent.c_str());
+    jboolean result = env->CallBooleanMethod(input_helper_, stop_app_method_, jintent);
+    env->DeleteLocalRef(jintent);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return result == JNI_TRUE;
+}
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/Input/NativeInput.h
+++ b/source/MaaAndroidNativeControlUnit/Input/NativeInput.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <jni.h>
+
+#include "Base/InputBase.h"
+
+#include "Conf/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+// 使用 Instrumentation 或 InputManager 注入输入事件
+class NativeInput : public InputBase
+{
+public:
+    NativeInput() = default;
+    virtual ~NativeInput() override;
+
+public:
+    virtual bool init(int display_width, int display_height) override;
+
+    virtual bool click(int x, int y) override;
+    virtual bool swipe(int x1, int y1, int x2, int y2, int duration) override;
+
+    virtual bool touch_down(int contact, int x, int y, int pressure) override;
+    virtual bool touch_move(int contact, int x, int y, int pressure) override;
+    virtual bool touch_up(int contact) override;
+
+    virtual bool click_key(int key) override;
+    virtual bool input_text(const std::string& text) override;
+
+    virtual bool key_down(int key) override;
+    virtual bool key_up(int key) override;
+
+    virtual bool start_app(const std::string& intent) override;
+    virtual bool stop_app(const std::string& intent) override;
+
+private:
+    bool inject_touch_event(int action, int x, int y, int pointer_id = 0);
+    bool inject_key_event(int action, int keycode);
+
+    int display_width_ = 0;
+    int display_height_ = 0;
+
+    // JNI 相关
+    JavaVM* jvm_ = nullptr;
+    jobject input_helper_ = nullptr;
+    jmethodID inject_touch_method_ = nullptr;
+    jmethodID inject_key_method_ = nullptr;
+    jmethodID inject_text_method_ = nullptr;
+    jmethodID start_app_method_ = nullptr;
+    jmethodID stop_app_method_ = nullptr;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/Manager/AndroidNativeControlUnitMgr.cpp
+++ b/source/MaaAndroidNativeControlUnit/Manager/AndroidNativeControlUnitMgr.cpp
@@ -1,0 +1,207 @@
+#include "AndroidNativeControlUnitMgr.h"
+
+#include "Input/NativeInput.h"
+#include "Screencap/NativeScreencap.h"
+
+#include "MaaUtils/Logger.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+AndroidNativeControlUnitMgr::AndroidNativeControlUnitMgr()
+{
+    LogFunc;
+}
+
+AndroidNativeControlUnitMgr::~AndroidNativeControlUnitMgr()
+{
+    LogFunc;
+}
+
+bool AndroidNativeControlUnitMgr::connect()
+{
+    LogFunc;
+
+    screencap_ = std::make_shared<NativeScreencap>();
+    if (!screencap_->init()) {
+        LogError << "failed to init screencap";
+        return false;
+    }
+
+    auto resolution = screencap_->get_resolution();
+    display_width_ = resolution.first;
+    display_height_ = resolution.second;
+
+    LogInfo << "Display resolution:" << display_width_ << "x" << display_height_;
+
+    input_ = std::make_shared<NativeInput>();
+    if (!input_->init(display_width_, display_height_)) {
+        LogError << "failed to init input";
+        return false;
+    }
+
+    return true;
+}
+
+bool AndroidNativeControlUnitMgr::request_uuid(std::string& uuid)
+{
+    LogFunc;
+
+    // 使用 Android ID 或其他唯一标识
+    uuid = "android_native_device";
+    return true;
+}
+
+MaaControllerFeature AndroidNativeControlUnitMgr::get_features() const
+{
+    return MaaControllerFeature_None;
+}
+
+bool AndroidNativeControlUnitMgr::start_app(const std::string& intent)
+{
+    LogFunc << VAR(intent);
+
+    // 通过 JNI 调用 startActivity
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+    return input_->start_app(intent);
+}
+
+bool AndroidNativeControlUnitMgr::stop_app(const std::string& intent)
+{
+    LogFunc << VAR(intent);
+
+    // 通过 JNI 调用 forceStopPackage
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+    return input_->stop_app(intent);
+}
+
+bool AndroidNativeControlUnitMgr::screencap(cv::Mat& image)
+{
+    if (!screencap_) {
+        LogError << "screencap_ is nullptr";
+        return false;
+    }
+
+    return screencap_->screencap(image);
+}
+
+bool AndroidNativeControlUnitMgr::click(int x, int y)
+{
+    LogInfo << VAR(x) << VAR(y);
+
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->click(x, y);
+}
+
+bool AndroidNativeControlUnitMgr::swipe(int x1, int y1, int x2, int y2, int duration)
+{
+    LogInfo << VAR(x1) << VAR(y1) << VAR(x2) << VAR(y2) << VAR(duration);
+
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->swipe(x1, y1, x2, y2, duration);
+}
+
+bool AndroidNativeControlUnitMgr::touch_down(int contact, int x, int y, int pressure)
+{
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->touch_down(contact, x, y, pressure);
+}
+
+bool AndroidNativeControlUnitMgr::touch_move(int contact, int x, int y, int pressure)
+{
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->touch_move(contact, x, y, pressure);
+}
+
+bool AndroidNativeControlUnitMgr::touch_up(int contact)
+{
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->touch_up(contact);
+}
+
+bool AndroidNativeControlUnitMgr::click_key(int key)
+{
+    LogInfo << VAR(key);
+
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->click_key(key);
+}
+
+bool AndroidNativeControlUnitMgr::input_text(const std::string& text)
+{
+    LogInfo << VAR(text);
+
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->input_text(text);
+}
+
+bool AndroidNativeControlUnitMgr::key_down(int key)
+{
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->key_down(key);
+}
+
+bool AndroidNativeControlUnitMgr::key_up(int key)
+{
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    return input_->key_up(key);
+}
+
+bool AndroidNativeControlUnitMgr::scroll(int dx, int dy)
+{
+    LogInfo << VAR(dx) << VAR(dy);
+
+    if (!input_) {
+        LogError << "input_ is nullptr";
+        return false;
+    }
+
+    // 使用 swipe 模拟滚动
+    int cx = display_width_ / 2;
+    int cy = display_height_ / 2;
+
+    return input_->swipe(cx, cy, cx + dx, cy + dy, 200);
+}
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/Manager/AndroidNativeControlUnitMgr.h
+++ b/source/MaaAndroidNativeControlUnit/Manager/AndroidNativeControlUnitMgr.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <memory>
+
+#include "ControlUnit/ControlUnitAPI.h"
+#include "MaaFramework/MaaDef.h"
+#include "MaaUtils/NoWarningCVMat.hpp"
+
+#include "Conf/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+class ScreencapBase;
+class InputBase;
+
+class AndroidNativeControlUnitMgr : public ControlUnitAPI
+{
+public:
+    AndroidNativeControlUnitMgr();
+    virtual ~AndroidNativeControlUnitMgr() override;
+
+public: // from ControlUnitAPI
+    virtual bool connect() override;
+
+    virtual bool request_uuid(/*out*/ std::string& uuid) override;
+    virtual MaaControllerFeature get_features() const override;
+
+    virtual bool start_app(const std::string& intent) override;
+    virtual bool stop_app(const std::string& intent) override;
+
+    virtual bool screencap(/*out*/ cv::Mat& image) override;
+
+    virtual bool click(int x, int y) override;
+    virtual bool swipe(int x1, int y1, int x2, int y2, int duration) override;
+
+    virtual bool touch_down(int contact, int x, int y, int pressure) override;
+    virtual bool touch_move(int contact, int x, int y, int pressure) override;
+    virtual bool touch_up(int contact) override;
+
+    virtual bool click_key(int key) override;
+    virtual bool input_text(const std::string& text) override;
+
+    virtual bool key_down(int key) override;
+    virtual bool key_up(int key) override;
+
+    virtual bool scroll(int dx, int dy) override;
+
+private:
+    std::shared_ptr<ScreencapBase> screencap_;
+    std::shared_ptr<InputBase> input_;
+
+    int display_width_ = 0;
+    int display_height_ = 0;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/README.md
+++ b/source/MaaAndroidNativeControlUnit/README.md
@@ -1,0 +1,102 @@
+# MaaAndroidNativeControlUnit
+
+Android 原生控制单元，用于在 Android 设备上直接运行 MaaFramework 时提供截图和输入功能。
+
+## 概述
+
+该模块使用 Android 原生 API（通过 JNI）实现截图和输入注入功能，无需 adb 连接。适用于 MaaFramework 直接在 Android 设备上作为 .so 库运行的场景。
+
+## 使用方法
+
+```cpp
+#include <MaaFramework/MaaAPI.h>
+
+// 创建 Android 原生控制器（仅在 Android 设备上可用）
+MaaController* controller = MaaAndroidNativeControllerCreate();
+
+// 连接
+MaaControllerPostConnection(controller);
+MaaControllerWait(controller, id);
+
+// 截图
+MaaControllerPostScreencap(controller);
+
+// 点击
+MaaControllerPostClick(controller, x, y);
+
+// 销毁（使用通用的 MaaControllerDestroy）
+MaaControllerDestroy(controller);
+```
+
+## 权限要求
+
+- **截图**: 需要 `android.permission.CAPTURE_VIDEO_OUTPUT` 或通过 MediaProjection API
+- **输入注入**: 需要 `android.permission.INJECT_EVENTS` (系统权限)
+
+### 获取权限的方式
+
+1. **系统应用**: 将应用签名为系统应用
+2. **Root 权限**: 使用 root 权限运行
+3. **Shizuku**: 使用 Shizuku 获取 shell 权限
+4. **MediaProjection**: 对于截图，可以使用 MediaProjection API（需要用户授权）
+
+## JNI 集成
+
+该模块通过 JNI 调用 Android Java API。调用方需要：
+
+1. 在 Java 层创建 Helper 类，提供截图和输入注入的方法
+2. 通过 JNI 将 Helper 对象传递给 Native 层
+3. 确保 JavaVM 已正确初始化
+
+### Java Helper 示例
+
+```java
+public class MaaScreencapHelper {
+    public Bitmap takeScreenshot() {
+        // 使用 SurfaceControl.screenshot() 或 MediaProjection
+        // 需要相应权限
+    }
+}
+
+public class MaaInputHelper {
+    public boolean injectTouch(int action, int x, int y, int pointerId) {
+        // 使用 InputManager.injectInputEvent()
+        // 需要 INJECT_EVENTS 权限
+    }
+    
+    public boolean injectKey(int action, int keyCode) {
+        // 使用 InputManager.injectInputEvent()
+    }
+}
+```
+
+## 编译
+
+该模块仅在 Android 平台自动编译：
+
+```bash
+# Android 交叉编译
+cmake --preset 'NinjaMulti' \
+    -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake \
+    -DANDROID_ABI=arm64-v8a \
+    -DANDROID_PLATFORM=android-23
+
+cmake --build build --preset 'NinjaMulti - Release'
+```
+
+## 与其他控制单元的对比
+
+| 特性 | AdbControlUnit | AndroidNativeControlUnit |
+|------|----------------|--------------------------|
+| 运行位置 | PC 端 | Android 设备本地 |
+| 连接方式 | USB/WiFi adb | 直接调用 |
+| 延迟 | 较高（网络传输） | 较低 |
+| 权限要求 | adb 调试权限 | 系统/Root 权限 |
+| 适用场景 | PC 远程控制 | 设备本地自动化 |
+
+## 限制
+
+1. 仅在 Android 平台可用
+2. 需要系统级权限才能实现输入注入
+3. 截图功能可能需要 MediaProjection 授权
+4. 不支持多设备同时控制（本地控制）

--- a/source/MaaAndroidNativeControlUnit/Screencap/NativeScreencap.cpp
+++ b/source/MaaAndroidNativeControlUnit/Screencap/NativeScreencap.cpp
@@ -1,0 +1,188 @@
+#include "NativeScreencap.h"
+
+#include <android/bitmap.h>
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
+
+#include "MaaUtils/Logger.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+NativeScreencap::~NativeScreencap()
+{
+    LogFunc;
+
+    if (screencap_helper_ && jvm_) {
+        JNIEnv* env = nullptr;
+        if (jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6) == JNI_OK && env) {
+            env->DeleteGlobalRef(screencap_helper_);
+        }
+    }
+}
+
+bool NativeScreencap::init()
+{
+    LogFunc;
+
+    if (!init_display_info()) {
+        LogError << "failed to init display info";
+        return false;
+    }
+
+    return true;
+}
+
+bool NativeScreencap::init_display_info()
+{
+    LogFunc;
+
+    // 通过 JNI 获取屏幕分辨率
+    // 这需要外部传入 JNIEnv 或者通过其他方式获取
+    // 暂时使用默认值，实际使用时需要从 Java 层获取
+
+    // 获取当前线程的 JNIEnv
+    JNIEnv* env = nullptr;
+
+    if (!jvm_) {
+        // 尝试获取 JavaVM
+        // 这通常在 JNI_OnLoad 中保存
+        LogWarn << "JavaVM not set, using default resolution";
+        display_width_ = 1920;
+        display_height_ = 1080;
+        return true;
+    }
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    // 获取 DisplayMetrics
+    jclass display_metrics_class = env->FindClass("android/util/DisplayMetrics");
+    if (!display_metrics_class) {
+        LogError << "failed to find DisplayMetrics class";
+        return false;
+    }
+
+    // 这里需要通过 Context 获取 WindowManager，然后获取 DisplayMetrics
+    // 简化处理，假设已经有分辨率信息
+    LogWarn << "Using default resolution, actual implementation needs Context";
+    display_width_ = 1920;
+    display_height_ = 1080;
+
+    return true;
+}
+
+bool NativeScreencap::screencap(cv::Mat& image)
+{
+    return screencap_screenshot_api(image);
+}
+
+bool NativeScreencap::screencap_screenshot_api(cv::Mat& image)
+{
+    LogFunc;
+
+    if (!jvm_) {
+        LogError << "JavaVM not set";
+        return false;
+    }
+
+    JNIEnv* env = nullptr;
+    bool need_detach = false;
+
+    int status = jvm_->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_6);
+    if (status == JNI_EDETACHED) {
+        if (jvm_->AttachCurrentThread(&env, nullptr) != JNI_OK) {
+            LogError << "failed to attach current thread";
+            return false;
+        }
+        need_detach = true;
+    }
+    else if (status != JNI_OK) {
+        LogError << "failed to get JNIEnv";
+        return false;
+    }
+
+    if (!screencap_helper_ || !take_screenshot_method_) {
+        LogError << "screencap helper not initialized";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    // 调用 Java 方法获取截图
+    jobject bitmap = env->CallObjectMethod(screencap_helper_, take_screenshot_method_);
+    if (!bitmap) {
+        LogError << "failed to take screenshot";
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    // 将 Bitmap 转换为 cv::Mat
+    AndroidBitmapInfo info;
+    if (AndroidBitmap_getInfo(env, bitmap, &info) != ANDROID_BITMAP_RESULT_SUCCESS) {
+        LogError << "failed to get bitmap info";
+        env->DeleteLocalRef(bitmap);
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    void* pixels = nullptr;
+    if (AndroidBitmap_lockPixels(env, bitmap, &pixels) != ANDROID_BITMAP_RESULT_SUCCESS) {
+        LogError << "failed to lock bitmap pixels";
+        env->DeleteLocalRef(bitmap);
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    // 根据 Bitmap 格式创建 cv::Mat
+    cv::Mat tmp;
+    switch (info.format) {
+    case ANDROID_BITMAP_FORMAT_RGBA_8888:
+        tmp = cv::Mat(info.height, info.width, CV_8UC4, pixels);
+        cv::cvtColor(tmp, image, cv::COLOR_RGBA2BGR);
+        break;
+    case ANDROID_BITMAP_FORMAT_RGB_565:
+        tmp = cv::Mat(info.height, info.width, CV_8UC2, pixels);
+        cv::cvtColor(tmp, image, cv::COLOR_BGR5652BGR);
+        break;
+    default:
+        LogError << "unsupported bitmap format:" << info.format;
+        AndroidBitmap_unlockPixels(env, bitmap);
+        env->DeleteLocalRef(bitmap);
+        if (need_detach) {
+            jvm_->DetachCurrentThread();
+        }
+        return false;
+    }
+
+    AndroidBitmap_unlockPixels(env, bitmap);
+    env->DeleteLocalRef(bitmap);
+
+    if (need_detach) {
+        jvm_->DetachCurrentThread();
+    }
+
+    return !image.empty();
+}
+
+std::pair<int, int> NativeScreencap::get_resolution() const
+{
+    return { display_width_, display_height_ };
+}
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaAndroidNativeControlUnit/Screencap/NativeScreencap.h
+++ b/source/MaaAndroidNativeControlUnit/Screencap/NativeScreencap.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <jni.h>
+
+#include "Base/ScreencapBase.h"
+#include "MaaUtils/NoWarningCVMat.hpp"
+
+#include "Conf/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+// 使用 Android ScreenCapture API (需要 MediaProjection 权限) 或 SurfaceControl (需要系统权限)
+class NativeScreencap : public ScreencapBase
+{
+public:
+    NativeScreencap() = default;
+    virtual ~NativeScreencap() override;
+
+public:
+    virtual bool init() override;
+    virtual bool screencap(cv::Mat& image) override;
+    virtual std::pair<int, int> get_resolution() const override;
+
+private:
+    bool init_display_info();
+    bool screencap_screenshot_api(cv::Mat& image);
+
+    int display_width_ = 0;
+    int display_height_ = 0;
+
+    // JNI 相关
+    JavaVM* jvm_ = nullptr;
+    jobject screencap_helper_ = nullptr;
+    jmethodID take_screenshot_method_ = nullptr;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaFramework/API/MaaFramework.cpp
+++ b/source/MaaFramework/API/MaaFramework.cpp
@@ -116,6 +116,28 @@ MaaController* MaaDbgControllerCreate(const char* read_path, const char* write_p
     return new MAA_CTRL_NS::ControllerAgent(std::move(control_unit));
 }
 
+MaaController* MaaAndroidNativeControllerCreate()
+{
+    LogFunc;
+
+#ifndef __ANDROID__
+
+    LogError << "This API" << __FUNCTION__ << "is only available on Android";
+    return nullptr;
+
+#else
+
+    auto control_unit = MAA_NS::AndroidNativeControlUnitLibraryHolder::create_control_unit();
+
+    if (!control_unit) {
+        LogError << "Failed to create control unit";
+        return nullptr;
+    }
+
+    return new MAA_CTRL_NS::ControllerAgent(std::move(control_unit));
+#endif
+}
+
 void MaaControllerDestroy(MaaController* ctrl)
 {
     LogFunc << VAR_VOIDP(ctrl);

--- a/source/include/ControlUnit/AndroidNativeControlUnitAPI.h
+++ b/source/include/ControlUnit/AndroidNativeControlUnitAPI.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "ControlUnit/ControlUnitAPI.h"
+#include "MaaFramework/MaaDef.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    MAA_CONTROL_UNIT_API const char* MaaAndroidNativeControlUnitGetVersion();
+
+    MAA_CONTROL_UNIT_API MaaControlUnitHandle MaaAndroidNativeControlUnitCreate();
+
+    MAA_CONTROL_UNIT_API void MaaAndroidNativeControlUnitDestroy(MaaControlUnitHandle handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/include/LibraryHolder/ControlUnit.h
+++ b/source/include/LibraryHolder/ControlUnit.h
@@ -76,4 +76,16 @@ private:
     inline static const std::string destroy_func_name_ = "MaaCustomControlUnitDestroy";
 };
 
+class AndroidNativeControlUnitLibraryHolder : public LibraryHolder<AndroidNativeControlUnitLibraryHolder>
+{
+public:
+    static std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> create_control_unit();
+
+private:
+    inline static const std::filesystem::path libname_ = MAA_NS::path("MaaAndroidNativeControlUnit");
+    inline static const std::string version_func_name_ = "MaaAndroidNativeControlUnitGetVersion";
+    inline static const std::string create_func_name_ = "MaaAndroidNativeControlUnitCreate";
+    inline static const std::string destroy_func_name_ = "MaaAndroidNativeControlUnitDestroy";
+};
+
 MAA_NS_END


### PR DESCRIPTION
总之先把 Copilot request 用完.jpg

## 由 Sourcery 提供的总结

引入一个在 Android 设备上直接运行的 Android 原生控制单元和控制器，通过基于 JNI 的屏幕捕获和输入注入工作，并将其接入核心框架和构建系统。

新功能：
- 新增 `AndroidNativeControlUnit` 实现，当 MaaFramework 在设备端运行时，使用 Android 原生 API 提供截图和输入能力。
- 暴露新的 `MaaAndroidNativeControllerCreate` API，用于在 Android 平台上构建一个由 Android 原生控制单元驱动的控制器。

增强：
- 扩展控制单元加载器，以支持带版本检查的 Android 原生控制单元动态库加载。
- 将 Android 原生控制单元接入 CMake 构建，在 Android 平台以及 Android CI 构建矩阵中按条件启用。

文档：
- 为 Android 原生控制单元新增 README 文档，涵盖使用方式、权限要求、JNI 集成、构建说明及限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an Android-native control unit and controller that run directly on Android devices using JNI-based screen capture and input injection, and wire it into the core framework and build system.

New Features:
- Add an AndroidNativeControlUnit implementation providing screenshot and input capabilities via Android native APIs when MaaFramework runs on-device.
- Expose a new MaaAndroidNativeControllerCreate API to construct a controller backed by the Android native control unit on Android platforms.

Enhancements:
- Extend the control unit loader to support dynamically loading the Android native control unit library with version checks.
- Wire the Android native control unit into the CMake build, enabling it conditionally on Android and in the Android CI build matrix.

Documentation:
- Add README documentation for the Android native control unit, covering usage, permissions, JNI integration, build instructions, and limitations.

</details>