### PR TITLE
feat: `10001` method for TemplateMatch

### DIFF
--- a/docs/en_us/3.1-PipelineProtocol.md
+++ b/docs/en_us/3.1-PipelineProtocol.md
@@ -313,13 +313,14 @@ This algorithm property requires additional fields:
 
 - `method`: *int*  
     Template matching algorithm, equivalent to cv::TemplateMatchModes. Optional, default is 5.  
-    For more details, refer to the [OpenCV official documentation](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html).
+    For more details, refer to the [OpenCV official documentation](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html).  
+    *10001 is the inverted version of TM_SQDIFF_NORMED, where higher scores indicate better matches (opposite to the original).*
 
-    | method | Algorithm Name | Matching Rule | Speed | Color Sensitivity | Lighting Robustness | Use Case |
-    |--------|----------------|---------------|-------|-------------------|---------------------|----------|
-    | 1 | TM_SQDIFF_NORMED | **Lower** score = better match | Fast | Sensitive | Poor | Precise matching, easy threshold setting |
-    | 3 | TM_CCORR_NORMED | Higher score = better match | Medium | Sensitive | Medium | Works well with bright templates |
-    | 5 | TM_CCOEFF_NORMED | Higher score = better match | Slower | Insensitive | Good | **Recommended**, easy threshold setting |
+    | method | Algorithm Name | Speed | Color Sensitivity | Lighting Robustness | Use Case |
+    |--------|----------------|-------|-------------------|---------------------|----------|
+    | 10001 | TM_SQDIFF_NORMED (Inverted) | Fast | Sensitive | Poor | Precise matching, easy threshold setting |
+    | 3 | TM_CCORR_NORMED | Medium | Sensitive | Medium | Works well with bright templates |
+    | 5 | TM_CCOEFF_NORMED | Slower | Insensitive | Good | **Recommended**, easy threshold setting |
 
 - `green_mask`: *bool*  
     Whether to apply a green mask. Optional, default is false.  

--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -314,13 +314,14 @@ Android 设置界面存在菜单 `显示`/`存储`/`无障碍`，其中 `存储`
 
 - `method`: *int*  
     模板匹配算法，即 cv::TemplateMatchModes。可选，默认 5 。  
-    详情请参考 [OpenCV 官方文档](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html)。
+    详情请参考 [OpenCV 官方文档](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html)。  
+    *10001 为 TM_SQDIFF_NORMED 的反转版本，分数越高越匹配（与原版相反）。*
 
-    | method | 算法名称 | 匹配规则 | 速度 | 颜色敏感度 | 光照鲁棒性 | 适用场景 |
-    |--------|---------|---------|------|-----------|-----------|---------|
-    | 1 | TM_SQDIFF_NORMED | 分越**低**越匹配 | 快 | 敏感 | 差 | 精确匹配，阈值易设定 |
-    | 3 | TM_CCORR_NORMED | 分越高越匹配 | 中等 | 敏感 | 中 | 模板较亮时效果好 |
-    | 5 | TM_CCOEFF_NORMED | 分越高越匹配 | 较慢 | 不敏感 | 好 | **推荐**，阈值易设定 |
+    | method | 算法名称 | 速度 | 颜色敏感度 | 光照鲁棒性 | 适用场景 |
+    |--------|---------|------|-----------|-----------|---------|
+    | 10001 | TM_SQDIFF_NORMED (Inverted) | 快 | 敏感 | 差 | 精确匹配，阈值易设定 |
+    | 3 | TM_CCORR_NORMED | 中等 | 敏感 | 中 | 模板较亮时效果好 |
+    | 5 | TM_CCOEFF_NORMED | 较慢 | 不敏感 | 好 | **推荐**，阈值易设定 |
 
 - `green_mask`: *bool*  
     是否进行绿色掩码。可选，默认 false 。  

--- a/source/MaaFramework/Vision/TemplateComparator.cpp
+++ b/source/MaaFramework/Vision/TemplateComparator.cpp
@@ -57,8 +57,18 @@ void TemplateComparator::cherry_pick()
 
 double TemplateComparator::comp(const cv::Mat& lhs, const cv::Mat& rhs, int method)
 {
+    bool invert_score = false;
+    if (method >= TemplateMatcherParam::kMethodInvertBase) {
+        invert_score = true;
+        method -= TemplateMatcherParam::kMethodInvertBase;
+    }
+
     cv::Mat matched;
     cv::matchTemplate(lhs, rhs, matched, method);
+
+    if (invert_score) {
+        matched = 1.0f - matched;
+    }
 
     double min_val = 0.0, max_val = 0.0;
     cv::Point min_loc {}, max_loc {};

--- a/source/MaaFramework/Vision/TemplateMatcher.cpp
+++ b/source/MaaFramework/Vision/TemplateMatcher.cpp
@@ -47,8 +47,20 @@ TemplateMatcher::ResultsVec TemplateMatcher::template_match(const cv::Mat& templ
         return {};
     }
 
+    bool invert_score = false;
+
+    int method = param_.method;
+    if (method >= TemplateMatcherParam::kMethodInvertBase) {
+        invert_score = true;
+        method -= TemplateMatcherParam::kMethodInvertBase;
+    }
+
     cv::Mat matched;
-    cv::matchTemplate(image, templ, matched, param_.method, create_mask(templ, param_.green_mask));
+    cv::matchTemplate(image, templ, matched, method, create_mask(templ, param_.green_mask));
+
+    if (invert_score) {
+        matched = 1.0f - matched;
+    }
 
     ResultsVec raw_results;
     Result closest_result;

--- a/source/MaaFramework/Vision/VisionTypes.h
+++ b/source/MaaFramework/Vision/VisionTypes.h
@@ -57,6 +57,7 @@ struct TemplateMatcherParam
 {
     inline static constexpr double kDefaultThreshold = 0.7;
     inline static constexpr int kDefaultMethod = 5; // cv::TM_CCOEFF_NORMED
+    inline static constexpr int kMethodInvertBase = 10000;
 
     Target roi_target;
     std::vector<std::string> template_;

--- a/tools/pipeline.schema.json
+++ b/tools/pipeline.schema.json
@@ -602,20 +602,21 @@
                     "enum": [
                         1,
                         3,
-                        5
+                        5,
+                        10001
                     ],
-                    "markdownDescription": "*int*\n\n模板匹配算法，即 cv::TemplateMatchModes。可选，默认 5 。\n\n详情请参考 [OpenCV 官方文档](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html)。\n\n| method | 算法名称 | 匹配规则 | 速度 | 颜色敏感度 | 光照鲁棒性 | 适用场景 |\n|--------|---------|---------|------|-----------|-----------|----------|\n| 1 | TM_SQDIFF_NORMED | 分越**低**越匹配 | 快 | 敏感 | 差 | 精确匹配，阈值易设定 |\n| 3 | TM_CCORR_NORMED | 分越高越匹配 | 中等 | 敏感 | 中 | 模板较亮时效果好 |\n| 5 | TM_CCOEFF_NORMED | 分越高越匹配 | 较慢 | 不敏感 | 好 | **推荐**，阈值易设定 |",
+                    "markdownDescription": "*int*\n\n模板匹配算法，即 cv::TemplateMatchModes。可选，默认 5 。\n\n详情请参考 [OpenCV 官方文档](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html)。\n\n*10001 为 TM_SQDIFF_NORMED 的反转版本，分数越高越匹配（与原版相反）。*\n\n| method | 算法名称 | 速度 | 颜色敏感度 | 光照鲁棒性 | 适用场景 |\n|--------|---------|------|-----------|-----------|----------|\n| 10001 | TM_SQDIFF_NORMED | 快 | 敏感 | 差 | 精确匹配，阈值易设定 |\n| 3 | TM_CCORR_NORMED | 中等 | 敏感 | 中 | 模板较亮时效果好 |\n| 5 | TM_CCOEFF_NORMED | 较慢 | 不敏感 | 好 | **推荐**，阈值易设定 |",
                     "defaultSnippets": [
                         {
-                            "label": "SQDIFF",
-                            "body": 1
+                            "label": "SQDIFF_NORMED_INVERTED",
+                            "body": 10001
                         },
                         {
-                            "label": "CCORR",
+                            "label": "CCORR_NORMED",
                             "body": 3
                         },
                         {
-                            "label": "CCOEFF",
+                            "label": "CCOEFF_NORMED",
                             "body": 5
                         }
                     ],


### PR DESCRIPTION
@Windsland52 来试试（）

## Summary by Sourcery

添加对反向模板匹配方法的支持，并更新相关视觉参数和文档。

新特性：
- 引入基于 `TM_SQDIFF_NORMED` 的反向模板匹配模式，使用从 `10001` 开始的 method 值。

增强内容：
- 扩展 `TemplateMatcher` 和 `TemplateComparator`，将高基值的 method 编码解析为反向模式，并相应地转换匹配分数。

文档：
- 在英文和中文的 pipeline 协议文档中记录新的反向模板匹配方法，并调整方法参考表。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for an inverted template matching method while updating related vision parameters and documentation.

New Features:
- Introduce an inverted template matching mode based on TM_SQDIFF_NORMED using method values starting at 10001.

Enhancements:
- Extend TemplateMatcher and TemplateComparator to interpret high-base method codes as inverted modes and transform match scores accordingly.

Documentation:
- Document the new inverted template matching method and adjust the method reference table in both English and Chinese pipeline protocol docs.

</details>