### PR TITLE
fix: Repeat class

### DIFF
--- a/test/agent/agent_child_test.py
+++ b/test/agent/agent_child_test.py
@@ -144,7 +144,7 @@ class MyTaskerSink(TaskerEventSink):
 
 
 @AgentServer.context_sink()
-class MyResSink(ContextEventSink):
+class MyCtxSink(ContextEventSink):
     def on_raw_notification(self, context, msg: str, details: dict):
         print(f"context: {context}, msg: {msg}, details: {details} ")
 


### PR DESCRIPTION
## Sourcery 总结

测试：
- 将 `agent_child_test` 中的上下文汇聚测试辅助类重命名为一个不重复的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Rename the context sink test helper class in agent_child_test to use a distinct name.

</details>