### PR TITLE
feat: 更新 interface.schema.json

### DIFF
--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -21,7 +21,7 @@
                 "name": {
                     "type": "string",
                     "title": "选项唯一标识符",
-                    "description": "用作选项ID"
+                    "description": "用作选项 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -31,7 +31,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -64,7 +64,7 @@
                 "name": {
                     "type": "string",
                     "title": "输入字段唯一标识符",
-                    "description": "用作输入字段ID"
+                    "description": "用作输入字段 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -74,7 +74,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "帮助用户理解输入要求。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "帮助用户理解输入要求。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "default": {
                     "type": "string",
@@ -127,7 +127,7 @@
                         "description": {
                             "$ref": "#/definitions/i18nString",
                             "title": "详细描述",
-                            "description": "帮助用户理解配置项的作用。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
                             "$ref": "#/definitions/i18nString",
@@ -145,7 +145,7 @@
                         "pipeline_override": {
                             "$ref": "#/definitions/pipelineOverride",
                             "title": "Pipeline 覆盖模板",
-                            "description": "支持使用 {名称} 格式引用输入字段的值"
+                            "description": "支持使用「名称」格式引用输入字段的值"
                         }
                     },
                     "required": [
@@ -170,7 +170,7 @@
                         "description": {
                             "$ref": "#/definitions/i18nString",
                             "title": "详细描述",
-                            "description": "帮助用户理解配置项的作用。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
                             "$ref": "#/definitions/i18nString",
@@ -212,7 +212,7 @@
                         "description": {
                             "$ref": "#/definitions/i18nString",
                             "title": "详细描述",
-                            "description": "帮助用户理解配置项的作用。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
                             "$ref": "#/definitions/i18nString",
@@ -250,7 +250,7 @@
                 "name": {
                     "type": "string",
                     "title": "唯一名称标识符",
-                    "description": "用作控制器ID"
+                    "description": "用作控制器 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -260,7 +260,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -371,7 +371,7 @@
                 "name": {
                     "type": "string",
                     "title": "唯一名称标识符",
-                    "description": "用作资源包ID"
+                    "description": "用作资源包 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -381,7 +381,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -418,7 +418,7 @@
                 "name": {
                     "type": "string",
                     "title": "任务唯一标识符",
-                    "description": "用作任务ID"
+                    "description": "用作任务 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -433,13 +433,13 @@
                 "default_check": {
                     "type": "boolean",
                     "title": "默认选中",
-                    "description": "是否默认选中该任务。Client在初始化时会根据该值决定是否默认勾选该任务",
+                    "description": "是否默认选中该任务。Client 在初始化时会根据该值决定是否默认勾选该任务",
                     "default": false
                 },
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "帮助用户理解任务功能。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "帮助用户理解任务功能。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "doc": {
                     "anyOf": [
@@ -492,7 +492,7 @@
         "agentConfig": {
             "type": "object",
             "title": "代理配置",
-            "description": "包含子进程(AgentServer)的信息",
+            "description": "包含子进程（AgentServer）的信息",
             "properties": {
                 "child_exec": {
                     "type": "string",
@@ -543,7 +543,7 @@
         "name": {
             "type": "string",
             "title": "项目唯一标识符",
-            "description": "用作项目ID"
+            "description": "用作项目 ID"
         },
         "label": {
             "$ref": "#/definitions/i18nString",
@@ -573,7 +573,7 @@
         "github": {
             "type": "string",
             "title": "GitHub 仓库地址",
-            "description": "项目GitHub仓库地址，用于版本更新检查和问题反馈",
+            "description": "项目 GitHub 仓库地址，用于版本更新检查和问题反馈",
             "format": "uri"
         },
         "version": {
@@ -584,22 +584,22 @@
         "contact": {
             "$ref": "#/definitions/i18nString",
             "title": "联系方式",
-            "description": "显示在\"关于\"页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
         },
         "license": {
             "$ref": "#/definitions/i18nString",
             "title": "许可证信息",
-            "description": "显示在\"关于\"页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
         },
         "welcome": {
             "$ref": "#/definitions/i18nString",
             "title": "欢迎消息",
-            "description": "在用户首次使用时弹窗显示，亦可作为公告使用。支持文件路径、URL或直接文本，内容支持Markdown格式。系统会记录显示内容，当内容更新时会再次弹窗显示"
+            "description": "在用户首次使用时弹窗显示，亦可作为公告使用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式。系统会记录显示内容，当内容更新时会再次弹窗显示"
         },
         "description": {
             "$ref": "#/definitions/i18nString",
             "title": "项目描述",
-            "description": "显示在\"关于\"页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
         },
         "controller": {
             "type": "array",


### PR DESCRIPTION
完整支持 ProjectInterface V2 协议
- 使用 oneOf 重构配置项类型系统(select/input/switch)
- 为所有主要配置对象添加 label 字段支持
- 添加支持国际化的 icon 字段
- 添加 doc 字段支持
- 添加 resource.controller 字段指定支持的控制器
- 添加 task.resource 字段指定支持的资源包
- 添加 display_raw 字段支持原始分辨率
- 添加 switch 类型约束(必须恰好 2 个选项)
- 改进字段描述并添加 V2 协议特定说明
- 为 input 类型添加 pipeline_type 和 verify 字段验证
- 更新 adb 控制器描述，说明 V2 中自动检测机制
- 明确资源和语言文件的相对路径处理规则
- 移除已废弃的 V1 协议字段

## Summary by Sourcery

更新接口模式，使其与 ProjectInterface V2 协议完全对齐，并移除已弃用的 V1 字段。

新特性：
- 使用 `oneOf` 扩展配置类型系统，以支持选择（select）、输入（input）和开关（switch）变体。
- 为主要配置对象添加 `label`、`icon`（支持 i18n）以及 `doc` 元数据字段。
- 引入 `resource.controller` 和 `task.resource` 字段，用于声明受支持的控制器和资源包。
- 新增 `display_raw` 标志位，用于控制是否使用原始解析结果，并澄清资源和语言文件的相对路径处理方式。

增强改进：
- 收紧对开关（switch）选项的校验，要求必须恰好包含两个选项，并为输入类型增加 `pipeline_type` 和 `verify` 校验。
- 使用 V2 专用文档改进字段描述，并更新 adb 控制器描述以说明 V2 自动检测行为。
- 从模式中移除来自已弃用 V1 协议的遗留字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the interface schema to fully align with the ProjectInterface V2 protocol and remove deprecated V1 fields.

New Features:
- Extend configuration type system using oneOf to support select, input, and switch variants.
- Add label, icon (with i18n), and doc metadata fields to primary configuration objects.
- Introduce resource.controller and task.resource fields to declare supported controllers and resource bundles.
- Add display_raw flag to control use of raw resolution and clarify relative path handling for resources and language files.

Enhancements:
- Tighten validation for switch options to require exactly two choices and add pipeline_type and verify validation for input types.
- Improve field descriptions with V2-specific documentation and update adb controller description to note V2 autodetection.
- Remove legacy fields from the deprecated V1 protocol from the schema.

</details>