### PR TITLE
feat(pipeline): 添加 action 循环执行功能

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## 目录结构
 
-```
+```text
 MaaFramework/
 ├── include/                    # C 语言头文件（公开 API）
 │   ├── MaaFramework/           # 核心框架 API
@@ -79,7 +79,7 @@ MaaFramework/
 
 ### 执行流程
 
-```
+```text
 1. 创建 Resource → 加载资源
 2. 创建 Controller → 连接设备
 3. 创建 Tasker → 绑定 Resource 和 Controller
@@ -128,6 +128,10 @@ MaaFramework/
 - C++ 使用 C++20 标准
 - 使用 clang-format 格式化代码
 - 头文件使用 `#pragma once`
+
+#### 函数拆分与 lambda 使用
+
+- **避免长 lambda**：lambda 适合做轻量的适配/回调（通常几行内即可读懂）。当 lambda 内包含较长的 `switch`/循环/复杂控制流或超过可读的长度时，应提取为具名函数/成员方法，提升可读性、可测试性与复用性。
 
 #### 控制流与嵌套
 
@@ -217,28 +221,14 @@ bool process(Resource* res, const Input& input)
 
 ## 常见开发场景
 
-### 添加新的识别算法
+### 添加新的 Pipeline 字段
 
-1. 在 `source/MaaFramework/Vision/` 添加算法实现
-2. 在 `source/MaaFramework/Task/Component/Recognizer.cpp` 注册算法
-3. 在 `source/MaaFramework/Resource/PipelineParser.cpp` 添加解析逻辑
-4. 在 `source/MaaFramework/Resource/PipelineDumper.cpp` 添加序列化逻辑
-5. 更新 Python 绑定中的 `get_node_object` 解析逻辑（如有新的结果格式）
-6. 更新 `tools/pipeline.schema.json`
-7. 更新中英文文档 `docs/*/3.1-*`
-
-> **说明**：Python 绑定的 `get_node_object` 数据来源于 `PipelineDumper` 序列化的 JSON，而非原始 Pipeline JSON。
-
-### 添加新的动作类型
-
-1. 在 `source/MaaFramework/Task/Component/Actuator.cpp` 实现动作
+1. 在 `source/MaaFramework/` 添加字段本身的功能性代码
 2. 在 `source/MaaFramework/Resource/PipelineParser.cpp` 添加解析逻辑
 3. 在 `source/MaaFramework/Resource/PipelineDumper.cpp` 添加序列化逻辑
-4. 更新 Python 绑定中的 `get_node_object` 解析逻辑（如有新的结果格式）
+4. 更新 `source/binding` 中的解析逻辑（注意：binding 中的数据来源于 `PipelineDumper` 序列化的 JSON，而非原始 Pipeline JSON。）
 5. 更新 `tools/pipeline.schema.json`
-6. 更新中英文文档
-
-> **说明**：Python 绑定的 `get_node_object` 数据来源于 `PipelineDumper` 序列化的 JSON，而非原始 Pipeline JSON。
+6. 更新中英文文档 `docs/*/3.1-*`
 
 ### 修改回调消息（MaaMsg）
 

--- a/docs/en_us/3.1-PipelineProtocol.md
+++ b/docs/en_us/3.1-PipelineProtocol.md
@@ -208,6 +208,19 @@ There are menus `Display`/`Storage`/`Accessibility` in the Android settings inte
     Time in milliseconds to wait for the screen to stop changing between executing the action and recognizing the "next" nodes. Optional, default is 0 (no waiting).  
     Other logic is the same as `pre_wait_freezes`.
 
+- `repeat`: *uint*  
+    Number of times to repeat the action. Optional, default is 1 (no repeat).  
+    The execution flow is `action` - [`repeat_wait_freezes` - `repeat_delay` - `action`] × (repeat-1).
+
+- `repeat_delay`: *uint*  
+    Delay between each repeated action in milliseconds. Optional, default is 0.  
+    Only effective when `repeat` > 1, waits before the second and subsequent action executions.
+
+- `repeat_wait_freezes`: *uint* | *object*  
+    Time in milliseconds to wait for the screen to stop changing between each repeated action. Optional, default is 0 (no waiting).  
+    Only effective when `repeat` > 1, waits for the screen to stabilize before the second and subsequent action executions.  
+    If it's an object, more parameters can be set, see [Waiting for the Screen to Stabilize](#waiting-for-the-screen-to-stabilize) for details.
+
 - `focus`: *any*  
     Focus on the node, resulting in additional callback messages. Optional, default is null (no messages).  
     See [Node Notifications](#node-notifications) for details.
@@ -224,7 +237,11 @@ The lifecycle of a node is as follows:
         A[enter the node] --> B[pre_wait_freezes]
         B --> C[pre_delay]
         C --> D[action]
-        D --> E[post_wait_freezes]
+        D --> M{repeat > 1?}
+        M -->|yes| N[repeat_wait_freezes]
+        N --> O[repeat_delay]
+        O --> D
+        M -->|no| E[post_wait_freezes]
         E --> F[post_delay]
         F --> G[recognize next]
         G --> H{successfully identified nodes}

--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -209,6 +209,19 @@ Android 设置界面存在菜单 `显示`/`存储`/`无障碍`，其中 `存储`
     行动动作后 到 识别 next，等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。  
     其余逻辑同 `pre_wait_freezes`。
 
+- `repeat`: *uint*  
+    动作重复执行次数。可选，默认 1 ，即不重复。  
+    执行流程为 `action` - [`repeat_wait_freezes` - `repeat_delay` - `action`] × (repeat-1) 。
+
+- `repeat_delay`: *uint*  
+    每次重复动作之间的延迟，毫秒。可选，默认 0 。  
+    仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待。
+
+- `repeat_wait_freezes`: *uint* | *object*  
+    每次重复动作之间等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。  
+    仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待画面静止。  
+    若为 object，可设置更多参数，详见 [等待画面静止](#等待画面静止)。
+
 - `focus`: *any*  
     关注节点，会额外产生部分回调消息。可选，默认 null，不产生回调消息。  
     详见 [节点通知](#节点通知)。
@@ -225,7 +238,11 @@ Android 设置界面存在菜单 `显示`/`存储`/`无障碍`，其中 `存储`
         A[进入节点] --> B[pre_wait_freezes]
         B --> C[pre_delay]
         C --> D[action]
-        D --> E[post_wait_freezes]
+        D --> M{repeat > 1?}
+        M -->|是| N[repeat_wait_freezes]
+        N --> O[repeat_delay]
+        O --> D
+        M -->|否| E[post_wait_freezes]
         E --> F[post_delay]
         F --> G[识别next]
         G --> H{是否有识别成功的节点}

--- a/source/MaaFramework/Resource/PipelineDumper.cpp
+++ b/source/MaaFramework/Resource/PipelineDumper.cpp
@@ -384,6 +384,10 @@ json::object PipelineDumper::dump(const PipelineData& pp)
     data.pre_wait_freezes = dump_wait_freezes(pp.pre_wait_freezes);
     data.post_wait_freezes = dump_wait_freezes(pp.post_wait_freezes);
 
+    data.repeat = pp.repeat;
+    data.repeat_delay = pp.repeat_delay.count();
+    data.repeat_wait_freezes = dump_wait_freezes(pp.repeat_wait_freezes);
+
     data.max_hit = pp.max_hit;
     data.attach = pp.attach;
 

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -293,6 +293,23 @@ bool PipelineParser::parse_node(
         return false;
     }
 
+    if (!get_and_check_value(input, "repeat", data.repeat, default_value.repeat)) {
+        LogError << "failed to get_and_check_value repeat" << VAR(input);
+        return false;
+    }
+
+    auto repeat_delay = default_value.repeat_delay.count();
+    if (!get_and_check_value(input, "repeat_delay", repeat_delay, repeat_delay)) {
+        LogError << "failed to get_and_check_value repeat_delay" << VAR(input);
+        return false;
+    }
+    data.repeat_delay = std::chrono::milliseconds(repeat_delay);
+
+    if (!parse_wait_freezes_param(input, "repeat_wait_freezes", data.repeat_wait_freezes, default_value.repeat_wait_freezes)) {
+        LogError << "failed to repeat_wait_freezes" << VAR(input);
+        return false;
+    }
+
     if (!get_and_check_value(input, "max_hit", data.max_hit, default_value.max_hit)) {
         LogError << "failed to get_and_check_value max_hit" << VAR(input);
         return false;

--- a/source/MaaFramework/Resource/PipelineTypes.h
+++ b/source/MaaFramework/Resource/PipelineTypes.h
@@ -331,6 +331,10 @@ struct PipelineData
     WaitFreezesParam pre_wait_freezes;
     WaitFreezesParam post_wait_freezes;
 
+    uint repeat = 1;
+    std::chrono::milliseconds repeat_delay = std::chrono::milliseconds(0);
+    WaitFreezesParam repeat_wait_freezes;
+
     uint max_hit = std::numeric_limits<uint>::max();
 
     json::value focus;

--- a/source/MaaFramework/Resource/PipelineTypesV2.h
+++ b/source/MaaFramework/Resource/PipelineTypesV2.h
@@ -268,7 +268,7 @@ struct JCustomAction
     std::string custom_action;
     json::value custom_action_param;
 
-    MEO_TOJSON(custom_action, custom_action_param);
+    MEO_TOJSON(target, target_offset, custom_action, custom_action_param);
 };
 
 using JActionParam = std::variant<
@@ -327,6 +327,9 @@ struct JPipelineData
     int64_t post_delay = 0;
     JWaitFreezes pre_wait_freezes;
     JWaitFreezes post_wait_freezes;
+    uint32_t repeat = 0;
+    int64_t repeat_delay = 0;
+    JWaitFreezes repeat_wait_freezes;
     uint32_t max_hit = 0;
     json::value focus;
     json::object attach;
@@ -345,6 +348,9 @@ struct JPipelineData
         post_delay,
         pre_wait_freezes,
         post_wait_freezes,
+        repeat,
+        repeat_delay,
+        repeat_wait_freezes,
         max_hit,
         focus,
         attach);

--- a/source/MaaFramework/Task/Component/Actuator.h
+++ b/source/MaaFramework/Task/Component/Actuator.h
@@ -31,6 +31,9 @@ private:
     inline static std::atomic<MaaActId> s_global_action_id = 500'000'000;
 
 private:
+    ActionResult execute_action(
+        const cv::Rect& reco_hit, MaaRecoId reco_id, const PipelineData& pipeline_data, const std::string& entry);
+
     ActionResult click(const MAA_RES_NS::Action::ClickParam& param, const cv::Rect& box, const std::string& name);
     ActionResult long_press(const MAA_RES_NS::Action::LongPressParam& param, const cv::Rect& box, const std::string& name);
     ActionResult swipe(const MAA_RES_NS::Action::SwipeParam& param, const cv::Rect& box, const std::string& name);

--- a/source/binding/NodeJS/src/apis/pipeline.d.ts
+++ b/source/binding/NodeJS/src/apis/pipeline.d.ts
@@ -190,9 +190,11 @@ declare global {
         type ActionSwipe = {
             begin?: true | NodeName | Rect
             begin_offset?: Rect
-            end?: true | NodeName | Rect
-            end_offset?: Rect
-            duration?: number
+            end?: true | NodeName | Rect | (true | NodeName | Rect)[]
+            end_offset?: Rect | Rect[]
+            duration?: number | number[]
+            end_hold?: number | number[]
+            only_hover?: boolean
             contact?: number
         }
 
@@ -202,9 +204,11 @@ declare global {
                     starting?: number
                     begin?: true | NodeName | Rect
                     begin_offset?: Rect
-                    end?: true | NodeName | Rect
-                    end_offset?: Rect
-                    duration?: number
+                    end?: true | NodeName | Rect | (true | NodeName | Rect)[]
+                    end_offset?: Rect | Rect[]
+                    duration?: number | number[]
+                    end_hold?: number | number[]
+                    only_hover?: boolean
                     contact?: number
                 }[]
             },
@@ -387,10 +391,13 @@ declare global {
             inverse?: boolean
             enabled?: boolean
             max_hit?: number
-            pre_delay?: boolean
-            post_delay?: boolean
+            pre_delay?: number
+            post_delay?: number
             pre_wait_freezes?: RemoveIfDump<number, Mode> | WaitFreeze
             post_wait_freezes?: RemoveIfDump<number, Mode> | WaitFreeze
+            repeat?: number
+            repeat_delay?: number
+            repeat_wait_freezes?: RemoveIfDump<number, Mode> | WaitFreeze
             focus?: unknown
             attach?: Record<string, unknown>
         }

--- a/source/binding/Python/maa/pipeline.py
+++ b/source/binding/Python/maa/pipeline.py
@@ -2,9 +2,11 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, List, Optional, Tuple, Union, Dict
 from strenum import StrEnum
+
 # Type aliases to match C++ std::variant types
 JRect = Tuple[int, int, int, int]  # std::array<int, 4>
 JTarget = Union[bool, str, JRect]  # std::variant<bool, std::string, JRect>
+
 
 # strenum
 class JRecognitionType(StrEnum):
@@ -16,6 +18,7 @@ class JRecognitionType(StrEnum):
     NeuralNetworkClassify = "NeuralNetworkClassify"
     NeuralNetworkDetect = "NeuralNetworkDetect"
     Custom = "Custom"
+
 
 class JActionType(StrEnum):
     DoNothing = "DoNothing"
@@ -36,7 +39,9 @@ class JActionType(StrEnum):
     StopTask = "StopTask"
     Scroll = "Scroll"
     Command = "Command"
+    Shell = "Shell"
     Custom = "Custom"
+
 
 # Recognition parameter dataclasses (matching C++ JRecognitionParam variants)
 @dataclass
@@ -241,6 +246,12 @@ class JCommand:
 
 
 @dataclass
+class JShell:
+    cmd: str  # 必选
+    timeout: int = 20000
+
+
+@dataclass
 class JCustomAction:
     custom_action: str  # 必选
     target: JTarget = True
@@ -266,6 +277,7 @@ JActionParam = Union[
     JStopTask,
     JScroll,
     JCommand,
+    JShell,
     JCustomAction,
 ]
 
@@ -316,6 +328,9 @@ class JPipelineData:
     post_delay: int = 200
     pre_wait_freezes: Optional[JWaitFreezes] = None
     post_wait_freezes: Optional[JWaitFreezes] = None
+    repeat: int = 1
+    repeat_delay: int = 0
+    repeat_wait_freezes: Optional[JWaitFreezes] = None
     max_hit: int = 4294967295  # UINT_MAX
     focus: Any = None
     attach: Dict = field(default_factory=dict)
@@ -337,7 +352,11 @@ class JPipelineParser:
 
     @classmethod
     def _parse_param(
-        cls, param_type: Union[JRecognitionType, JActionType], param_data: dict, param_type_map: dict, default_class
+        cls,
+        param_type: Union[JRecognitionType, JActionType],
+        param_data: dict,
+        param_type_map: dict,
+        default_class,
     ) -> Union[JRecognitionParam, JActionParam]:
         """Generic function to parse parameters based on type map."""
         param_class = param_type_map.get(param_type)
@@ -373,7 +392,9 @@ class JPipelineParser:
         return cls._parse_param(param_type, param_data, param_type_map, JDirectHit)
 
     @classmethod
-    def _parse_action_param(cls, param_type: JActionType, param_data: dict) -> JActionParam:
+    def _parse_action_param(
+        cls, param_type: JActionType, param_data: dict
+    ) -> JActionParam:
         """Convert dict to appropriate JActionParam variant based on type."""
         param_type_map = {
             JActionType.DoNothing: JDoNothing,
@@ -394,6 +415,7 @@ class JPipelineParser:
             JActionType.StopTask: JStopTask,
             JActionType.Scroll: JScroll,
             JActionType.Command: JCommand,
+            JActionType.Shell: JShell,
             JActionType.Custom: JCustomAction,
         }
 
@@ -414,7 +436,9 @@ class JPipelineParser:
 
         # Convert recognition
         recognition_data: dict = data.get("recognition")
-        recognition_type: JRecognitionType = JRecognitionType(recognition_data.get("type"))
+        recognition_type: JRecognitionType = JRecognitionType(
+            recognition_data.get("type")
+        )
         recognition_param_data: dict = recognition_data.get("param")
         recognition_param = cls._parse_recognition_param(
             recognition_type, recognition_param_data
@@ -430,6 +454,7 @@ class JPipelineParser:
 
         pre_wait_freezes = cls._parse_wait_freezes(data.get("pre_wait_freezes"))  # type: ignore
         post_wait_freezes = cls._parse_wait_freezes(data.get("post_wait_freezes"))  # type: ignore
+        repeat_wait_freezes = cls._parse_wait_freezes(data.get("repeat_wait_freezes"))  # type: ignore
 
         # Create JPipelineData with converted data
         return JPipelineData(
@@ -446,6 +471,9 @@ class JPipelineParser:
             post_delay=data.get("post_delay"),
             pre_wait_freezes=pre_wait_freezes,  # type: ignore
             post_wait_freezes=post_wait_freezes,  # type: ignore
+            repeat=data.get("repeat"),
+            repeat_delay=data.get("repeat_delay"),
+            repeat_wait_freezes=repeat_wait_freezes,  # type: ignore
             max_hit=data.get("max_hit"),
             focus=data.get("focus"),
             attach=data.get("attach"),

--- a/tools/pipeline.schema.json
+++ b/tools/pipeline.schema.json
@@ -3889,6 +3889,26 @@
                     "$ref": "#/$defs/WaitFreezesOrNInt64",
                     "markdownDescription": "*uint* | *object*\n\n行动动作后 到 识别 next，等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。\n\n连续 `pre_wait_freezes` 毫秒 画面 **没有较大变化** 才会退出动作。\n\n若为 object，可设置更多参数，详见 [等待画面静止](#等待画面静止)。\n\n具体的顺序为 `pre_wait_freezes` - `pre_delay` - `action` - `post_wait_freezes` - `post_delay` 。"
                 },
+                "repeat": {
+                    "title": "Repeat Property",
+                    "description": "动作重复执行次数。可选，默认 1 ，即不重复。",
+                    "$ref": "#/$defs/jsonUInt32",
+                    "default": 1,
+                    "markdownDescription": "*uint*\n\n动作重复执行次数。可选，默认 1 ，即不重复。\n\n执行流程为 `pre_wait_freezes` - `pre_delay` - `action` - [`repeat_wait_freezes` - `repeat_delay` - `action`] × (repeat-1) - `post_wait_freezes` - `post_delay` 。"
+                },
+                "repeat_delay": {
+                    "title": "Repeat Delay Property",
+                    "description": "每次重复动作之间的延迟，毫秒。可选，默认 0 。",
+                    "$ref": "#/$defs/jsonNInt64",
+                    "default": 0,
+                    "markdownDescription": "*uint*\n\n每次重复动作之间的延迟，毫秒。可选，默认 0 。\n\n仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待。"
+                },
+                "repeat_wait_freezes": {
+                    "title": "Repeat Wait Freezes Property",
+                    "description": "每次重复动作之间等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。",
+                    "$ref": "#/$defs/WaitFreezesOrNInt64",
+                    "markdownDescription": "*uint* | *object*\n\n每次重复动作之间等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。\n\n仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待画面静止。\n\n若为 object，可设置更多参数，详见 [等待画面静止](#等待画面静止)。"
+                },
                 "focus": {
                     "title": "Focus Property",
                     "description": "关注节点，会额外产生部分回调消息。可选，默认 null，不产生回调消息。",


### PR DESCRIPTION
新增三个字段控制 action 的重复执行：
- repeat: 动作重复执行次数，默认 1
- repeat_delay: 每次重复之间的延迟（毫秒），默认 0
- repeat_wait_freezes: 每次重复之间等待画面静止

执行流程：action -> [repeat_wait_freezes -> repeat_delay -> action] × (repeat-1)

## 由 Sourcery 提供的总结

为流水线动作新增可配置的重复执行支持，并将这些新字段贯穿到核心流水线类型、解析器、导出工具以及绑定层，同时改进相关文档和类型定义。

新功能：
- 在执行器中引入可重复的动作执行机制，由流水线数据中的 `repeat`、`repeat_delay` 和 `repeat_wait_freezes` 字段进行控制。
- 通过 Python 和 NodeJS 绑定暴露新的与重复相关的流水线字段，并更新相关的 schema 和协议文档。

增强：
- 将执行器中的动作分发重构为独立的 `execute_action` 方法，以简化主运行流程并实现复用。
- 扩展动作参数支持，在 Python 绑定中加入对 shell 命令的支持，并修正/扩展若干绑定类型定义（例如滑动参数、延迟等）。
- 明确关于新增流水线字段的贡献者文档，并补充关于 lambda/函数拆分的指引，同时更新代码块注释以提升可读性。

文档：
- 记录新的 `repeat`、`repeat_delay` 和 `repeat_wait_freezes` 流水线字段，并更新生命周期图和贡献者指南，覆盖英文和中文文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable repeat-execution support for pipeline actions and propagate the new fields through core pipeline types, parsers, dumpers, and bindings, while improving related documentation and type definitions.

New Features:
- Introduce repeatable action execution in the actuator, controlled by repeat, repeat_delay, and repeat_wait_freezes fields in pipeline data.
- Expose the new repeat-related pipeline fields through Python and NodeJS bindings, including schema and protocol documentation updates.

Enhancements:
- Refactor actuator action dispatch into a dedicated execute_action method to simplify the main run flow and enable reuse.
- Extend action parameter support to include shell commands in Python bindings and correct/expand several binding type definitions (e.g., swipe parameters, delays).
- Clarify contributor documentation for adding new pipeline fields and document lambda/function-splitting guidance, updating code block annotations for better readability.

Documentation:
- Document the new repeat, repeat_delay, and repeat_wait_freezes pipeline fields and update lifecycle diagrams and contributor guides in both English and Chinese docs.

</details>