### PR TITLE
feat(binding): add scroll action and result handling for python binding

### DIFF
--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -647,6 +647,7 @@ class ActionEnum(StrEnum):
     InputText = "InputText"
     StartApp = "StartApp"
     StopApp = "StopApp"
+    Scroll = "Scroll"
     StopTask = "StopTask"
     Command = "Command"
     Shell = "Shell"
@@ -781,6 +782,12 @@ class AppActionResult:
     package: str
 
 
+@dataclass
+class ScrollActionResult:
+    dx: int
+    dy: int
+
+
 ActionResult = Union[
     ClickActionResult,
     LongPressActionResult,
@@ -790,6 +797,7 @@ ActionResult = Union[
     LongPressKeyActionResult,
     InputTextActionResult,
     AppActionResult,
+    ScrollActionResult,
     None,
 ]
 
@@ -804,6 +812,7 @@ ActionResultDict = {
     ActionEnum.InputText: InputTextActionResult,
     ActionEnum.StartApp: AppActionResult,
     ActionEnum.StopApp: AppActionResult,
+    ActionEnum.Scroll: ScrollActionResult,
     ActionEnum.StopTask: None,
     ActionEnum.Command: None,
     ActionEnum.Shell: None,


### PR DESCRIPTION
Power by Claude Opus 4.5

## Summary by Sourcery

在 Python 绑定中新增对 Scroll 动作的支持，并定义其对应的结果类型。

新功能：
- 在 Python 绑定的动作定义中加入一个新的 Scroll 动作枚举值。
- 定义 `ScrollActionResult` 数据类，用于携带水平和垂直滚动偏移量。
- 扩展动作到结果类型的映射，以便为 Scroll 动作包含新的 `ScrollActionResult`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a new Scroll action in the Python binding and define its corresponding result type.

New Features:
- Introduce a Scroll action enum value in the Python binding action definitions.
- Define a ScrollActionResult dataclass carrying horizontal and vertical scroll offsets.
- Extend the action-to-result type mapping to include the new ScrollActionResult for Scroll actions.

</details>