### PR TITLE
feat: 根据V2文档修改

### DIFF
--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -361,17 +361,13 @@
                     "title": "PlayCover 控制器配置",
                     "description": "PlayCover 控制器的具体配置（仅 macOS）",
                     "properties": {
-                        "address": {
-                            "type": "string",
-                            "title": "服务地址",
-                            "description": "PlayTools 服务的地址，格式为 host:port。可选",
-                            "examples": ["127.0.0.1:1717"]
-                        },
                         "uuid": {
                             "type": "string",
                             "title": "Bundle Identifier",
                             "description": "可选。目标应用的 Bundle Identifier，不提供则使用默认 maa.playcover，仅作为控制器标识符，与被操控应用无关",
-                            "examples": ["com.hypergryph.arknights"]
+                            "examples": [
+                                "com.hypergryph.arknights"
+                            ]
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
Removed 'type' from required fields and updated descriptions for clarity.

## Summary by Sourcery

放宽接口 JSON 模式中的校验规则，并澄清字段描述。

增强内容：
- 将接口 JSON 模式中的 `type` 字段从必填改为可选。
- 修改模式字段描述，使其与 V2 文档更一致，并提高清晰度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax validation in the interface JSON schema and clarify field descriptions.

Enhancements:
- Make the 'type' field optional in the interface JSON schema instead of required.
- Revise schema field descriptions to better align with the V2 documentation and improve clarity.

</details>