### PR TITLE
fix(binding): 补充缺失的action字段

### DIFF
--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -743,12 +743,14 @@ class RecognitionDetail:
 @dataclass
 class ClickActionResult:
     point: Point
+    contact: int
 
 
 @dataclass
 class LongPressActionResult:
     point: Point
     duration: int
+    contact: int
 
 
 @dataclass
@@ -759,6 +761,7 @@ class SwipeActionResult:
     duration: List[int]
     only_hover: bool
     starting: int
+    contact: int
 
 
 @dataclass
@@ -800,6 +803,14 @@ class TouchActionResult:
     pressure: int
 
 
+@dataclass
+class ShellActionResult:
+    cmd: str
+    timeout: int
+    success: bool
+    output: str
+
+
 ActionResult = Union[
     ClickActionResult,
     LongPressActionResult,
@@ -811,6 +822,7 @@ ActionResult = Union[
     AppActionResult,
     ScrollActionResult,
     TouchActionResult,
+    ShellActionResult,
     None,
 ]
 
@@ -833,7 +845,7 @@ ActionResultDict = {
     ActionEnum.KeyUp: ClickKeyActionResult,
     ActionEnum.StopTask: None,
     ActionEnum.Command: None,
-    ActionEnum.Shell: None,
+    ActionEnum.Shell: ShellActionResult,
     ActionEnum.Custom: None,
 }
 


### PR DESCRIPTION
## Summary by Sourcery

为新的输入和 shell 动作及其结果补全缺失的 Python 绑定支持。

新特性：
- 在 Python 绑定中为触控和按键事件引入对应的动作枚举条目。
- 为触控动作和 shell 命令添加结果数据类，并将它们纳入统一的 `ActionResult` 联合类型中。
- 扩展动作到结果类型的映射，使其涵盖新的触控、按键和 shell 动作，并关联合适的结果类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add missing Python binding support for new input and shell actions and their results.

New Features:
- Introduce action enum entries for touch and key press events in the Python binding.
- Add result dataclasses for touch actions and shell commands and include them in the unified ActionResult union.
- Extend the action-to-result-type mapping to cover the new touch, key, and shell actions with appropriate result types.

</details>