### PR TITLE
docs(pipeline): update target type documentation

### DIFF
--- a/docs/en_us/3.1-PipelineProtocol.md
+++ b/docs/en_us/3.1-PipelineProtocol.md
@@ -941,7 +941,7 @@ Additional properties for this action:
   - Adb Controller: Finger id (0 for first finger, 1 for second finger, etc.)
   - Win32 Controller: Mouse button id (0 for left, 1 for right, 2 for middle, 3 for XBUTTON1, 4 for XBUTTON2)
 
-- `target`: *true* | *string* | *array<int, 4>*  
+- `target`: *true* | *string* | *array<int, 4>* | *array<int, 2>*  
     Touch target position. Optional, default `true`. Same semantics as `Click`.`target`.
 
 - `target_offset`: *array<int, 4>*  

--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -945,7 +945,7 @@ Pipeline v2 时，将这些字段放到 `recognition.param` 中即可。
   - Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）
   - Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）
 
-- `target`: *true* | *string* | *array<int, 4>*  
+- `target`: *true* | *string* | *array<int, 4>* | *array<int, 2>*  
     触控目标的位置。可选，默认 true ，取值含义同 `Click`.`target` 。
 
 - `target_offset`: *array<int, 4>*  


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 在流水线协议文档中澄清：`touch` 动作的 `target` 参数除了现有类型外，还接受 `array<int, 2>`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Clarify that the touch action target parameter accepts an array<int, 2> in addition to existing types in the pipeline protocol documentation.

</details>