### PR TITLE
Fix(NodeJS):  修复clang-cl编译时的operator[]调用歧义

### DIFF
--- a/source/binding/NodeJS/src/foundation/spec/convert.h
+++ b/source/binding/NodeJS/src/foundation/spec/convert.h
@@ -375,7 +375,7 @@ struct JSConvert<std::tuple<Args...>>
             }
             T result;
             [&]<size_t... I>(std::index_sequence<I...>) {
-                ((std::get<I>(result) = JSConvert<std::tuple_element_t<I, T>>::from_value(arr[I])), ...);
+                ((std::get<I>(result) = JSConvert<std::tuple_element_t<I, T>>::from_value(arr[static_cast<uint32_t>(I)])), ...);
             }(std::make_index_sequence<std::tuple_size_v<T>>());
             return result;
         }


### PR DESCRIPTION
## 一、简介

修复在使用`clang-cl`(包括可能的其他64位严格编译器)构建时的编译错误：

> 在使用`std::index_sequence`时，索引类型是`size_t`，而`Napi::Array::operator[]`期望接收`uint32_t`。这导致`ambiguous operator[]`错误，编译器无法在隐式转换为`uint32_t`或其他重载之间做出明确选择。

错误日志如下：

```log
error: use of overloaded operator '[]' is ambiguous (with operand types 'Napi::Array' and 'unsigned long long')
((std::get<I>(result) = JSConvert<std::tuple_element_t<I, T>>::from_value(arr[I])), ...);
                                                                          ~~~^~
```

## 二、修改内容

1. 将`arr[I]`修改为`arr[static_cast<uint32_t>(I)]`。

## Summary by Sourcery

错误修复：
- 通过在元组转换过程中将 `index_sequence` 的索引显式转换为 `uint32_t`，修复了在 clang-cl 和其他严格的 64 位编译器下 `Napi::Array` 的 `operator[]` 解析不明确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix ambiguous Napi::Array operator[] resolution under clang-cl and other strict 64-bit compilers by explicitly casting index_sequence indices to uint32_t during tuple conversion.

</details>