### PR TITLE
fix(python): And 和 Or 识别后运行任意 Custom 动作报错

### DIFF
--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -705,16 +705,20 @@ class CustomRecognitionResult:
 
 @dataclass
 class AndRecognitionResult:
-    """And 算法识别结果，包含所有子识别的完整详情"""
-
-    sub_results: List["RecognitionDetail"]
+    reco_id: int
+    name: str
+    algorithm: str
+    box: Optional[Rect] = None
+    detail: Optional[Dict] = None
 
 
 @dataclass
 class OrRecognitionResult:
-    """Or 算法识别结果，包含已执行子识别的完整详情"""
-
-    sub_results: List["RecognitionDetail"]
+    reco_id: int
+    name: str
+    algorithm: str
+    box: Optional[Rect] = None
+    detail: Optional[Dict] = None
 
 
 RecognitionResult = Union[


### PR DESCRIPTION
fix https://github.com/MaaXYZ/MaaFramework/issues/1042

## Summary by Sourcery

修复 Python 绑定中 And/Or 识别结果的解析方式，以正确传递子识别详情，并在运行 Custom 动作时避免错误。

Bug Fixes:
- 通过递归解析嵌套的子识别结果来正确处理 And/Or 识别的原始详情，而不是依赖基于 reco_id 的查找。

Enhancements:
- 重新定义 AndRecognitionResult 和 OrRecognitionResult，使其携带基础识别元数据和原始详情负载，而不是预先解析好的子识别结果列表，从而与其他识别结果类型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix parsing of And/Or recognition results in the Python binding to correctly propagate child recognition details and avoid errors when running Custom actions.

Bug Fixes:
- Correct handling of And/Or recognition raw details by recursively parsing nested child recognitions instead of relying on reco_id-based lookup.

Enhancements:
- Redefine AndRecognitionResult and OrRecognitionResult to carry basic recognition metadata and raw detail payload rather than pre-resolved child recognition lists, aligning them with other recognition result types.

</details>