### PR TITLE
fix: 一些遗漏的函数

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ MaaFramework/
 
 - [ ] 在 `include/` 中添加 C API 声明
 - [ ] 在 `source/` 中实现功能
+- [ ] 更新 C++20 模块导出（`source/modules/MaaFramework.cppm`）
 - [ ] 更新 MaaAgent（如涉及 Context/Tasker/Resource/Controller 接口）
 - [ ] 更新 Python/NodeJS 绑定
 - [ ] 更新 Pipeline Schema（如涉及）

--- a/source/LibraryHolder/CMakeLists.txt
+++ b/source/LibraryHolder/CMakeLists.txt
@@ -19,6 +19,10 @@ if(WITH_WIN32_CONTROLLER)
     add_dependencies(LibraryHolder MaaWin32ControlUnit)
 endif()
 
+if(WITH_PLAYCOVER_CONTROLLER)
+    add_dependencies(LibraryHolder MaaPlayCoverControlUnit)
+endif()
+
 if(WITH_DBG_CONTROLLER)
     add_dependencies(LibraryHolder MaaDbgControlUnit)
 endif()

--- a/source/MaaAgentServer/API/MaaAgentServerNotImpl.cpp
+++ b/source/MaaAgentServer/API/MaaAgentServerNotImpl.cpp
@@ -26,6 +26,12 @@ MaaController* MaaDbgControllerCreate(const char*, const char*, MaaDbgController
     return nullptr;
 }
 
+MaaController* MaaPlayCoverControllerCreate(const char*, const char*)
+{
+    LogError << "MaaAgentServer Not implement this API, Please use MaaFramework";
+    return nullptr;
+}
+
 void MaaControllerDestroy(MaaController*)
 {
     LogError << "MaaAgentServer Not implement this API, Please use MaaFramework";

--- a/source/modules/MaaFramework.cppm
+++ b/source/modules/MaaFramework.cppm
@@ -17,6 +17,7 @@ export using ::MaaTaskId;
 export using ::MaaRecoId;
 export using ::MaaActId;
 export using ::MaaNodeId;
+export using ::MaaSinkId;
 export constexpr auto _MaaInvalidId = MaaInvalidId;
 
 export using ::MaaStringBuffer;
@@ -81,20 +82,34 @@ export constexpr auto _MaaWin32ScreencapMethod_None = MaaWin32ScreencapMethod_No
 export constexpr auto _MaaWin32ScreencapMethod_GDI = MaaWin32ScreencapMethod_GDI;
 export constexpr auto _MaaWin32ScreencapMethod_FramePool = MaaWin32ScreencapMethod_FramePool;
 export constexpr auto _MaaWin32ScreencapMethod_DXGI_DesktopDup = MaaWin32ScreencapMethod_DXGI_DesktopDup;
+export constexpr auto _MaaWin32ScreencapMethod_DXGI_DesktopDup_Window = MaaWin32ScreencapMethod_DXGI_DesktopDup_Window;
+export constexpr auto _MaaWin32ScreencapMethod_PrintWindow = MaaWin32ScreencapMethod_PrintWindow;
+export constexpr auto _MaaWin32ScreencapMethod_ScreenDC = MaaWin32ScreencapMethod_ScreenDC;
 
 export using ::MaaWin32InputMethod;
 export constexpr auto _MaaWin32InputMethod_None = MaaWin32InputMethod_None;
 export constexpr auto _MaaWin32InputMethod_Seize = MaaWin32InputMethod_Seize;
 export constexpr auto _MaaWin32InputMethod_SendMessage = MaaWin32InputMethod_SendMessage;
+export constexpr auto _MaaWin32InputMethod_PostMessage = MaaWin32InputMethod_PostMessage;
+export constexpr auto _MaaWin32InputMethod_LegacyEvent = MaaWin32InputMethod_LegacyEvent;
+export constexpr auto _MaaWin32InputMethod_PostThreadMessage = MaaWin32InputMethod_PostThreadMessage;
+export constexpr auto _MaaWin32InputMethod_SendMessageWithCursorPos = MaaWin32InputMethod_SendMessageWithCursorPos;
+export constexpr auto _MaaWin32InputMethod_PostMessageWithCursorPos = MaaWin32InputMethod_PostMessageWithCursorPos;
 
 export using ::MaaDbgControllerType;
 export constexpr auto _MaaDbgControllerType_None = MaaDbgControllerType_None;
 export constexpr auto _MaaDbgControllerType_CarouselImage = MaaDbgControllerType_CarouselImage;
 export constexpr auto _MaaDbgControllerType_ReplayRecording = MaaDbgControllerType_ReplayRecording;
 
+export using ::MaaControllerFeature;
+export constexpr auto _MaaControllerFeature_None = MaaControllerFeature_None;
+export constexpr auto _MaaControllerFeature_UseMouseDownAndUpInsteadOfClick = MaaControllerFeature_UseMouseDownAndUpInsteadOfClick;
+export constexpr auto _MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick = MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
+
 export using ::MaaRect;
 
 export using ::MaaNotificationCallback;
+export using ::MaaEventCallback;
 export using ::MaaCustomRecognitionCallback;
 export using ::MaaCustomActionCallback;
 
@@ -105,9 +120,15 @@ export using ::MaaContextRunRecognition;
 export using ::MaaContextRunAction;
 export using ::MaaContextOverridePipeline;
 export using ::MaaContextOverrideNext;
+export using ::MaaContextOverrideImage;
+export using ::MaaContextGetNodeData;
 export using ::MaaContextGetTaskId;
 export using ::MaaContextGetTasker;
 export using ::MaaContextClone;
+export using ::MaaContextSetAnchor;
+export using ::MaaContextGetAnchor;
+export using ::MaaContextGetHitCount;
+export using ::MaaContextClearHitCount;
 
 // Instance/MaaController.h
 
@@ -116,7 +137,11 @@ export using ::MaaAdbControllerCreate;
 export using ::MaaWin32ControllerCreate;
 export using ::MaaCustomControllerCreate;
 export using ::MaaDbgControllerCreate;
+export using ::MaaPlayCoverControllerCreate;
 export using ::MaaControllerDestroy;
+export using ::MaaControllerAddSink;
+export using ::MaaControllerRemoveSink;
+export using ::MaaControllerClearSinks;
 export using ::MaaControllerSetOption;
 export using ::MaaControllerPostConnection;
 export using ::MaaControllerPostClick;
@@ -131,6 +156,9 @@ export using ::MaaControllerPostTouchDown;
 export using ::MaaControllerPostTouchMove;
 export using ::MaaControllerPostTouchUp;
 export using ::MaaControllerPostScreencap;
+export using ::MaaControllerPostScroll;
+export using ::MaaControllerPostShell;
+export using ::MaaControllerGetShellOutput;
 export using ::MaaControllerStatus;
 export using ::MaaControllerWait;
 export using ::MaaControllerConnected;
@@ -145,6 +173,9 @@ export using ::MaaCustomControllerCallbacks;
 
 export using ::MaaResourceCreate;
 export using ::MaaResourceDestroy;
+export using ::MaaResourceAddSink;
+export using ::MaaResourceRemoveSink;
+export using ::MaaResourceClearSinks;
 export using ::MaaResourceRegisterCustomRecognition;
 export using ::MaaResourceUnregisterCustomRecognition;
 export using ::MaaResourceClearCustomRecognition;
@@ -157,6 +188,8 @@ export using ::MaaResourcePostPipeline;
 export using ::MaaResourcePostImage;
 export using ::MaaResourceOverridePipeline;
 export using ::MaaResourceOverrideNext;
+export using ::MaaResourceOverrideImage;
+export using ::MaaResourceGetNodeData;
 export using ::MaaResourceClear;
 export using ::MaaResourceStatus;
 export using ::MaaResourceWait;
@@ -164,16 +197,26 @@ export using ::MaaResourceLoaded;
 export using ::MaaResourceSetOption;
 export using ::MaaResourceGetHash;
 export using ::MaaResourceGetNodeList;
+export using ::MaaResourceGetCustomRecognitionList;
+export using ::MaaResourceGetCustomActionList;
 
 // Instance/MaaTasker.h
 
 export using ::MaaTaskerCreate;
 export using ::MaaTaskerDestroy;
+export using ::MaaTaskerAddSink;
+export using ::MaaTaskerRemoveSink;
+export using ::MaaTaskerClearSinks;
+export using ::MaaTaskerAddContextSink;
+export using ::MaaTaskerRemoveContextSink;
+export using ::MaaTaskerClearContextSinks;
 export using ::MaaTaskerSetOption;
 export using ::MaaTaskerBindResource;
 export using ::MaaTaskerBindController;
 export using ::MaaTaskerInited;
 export using ::MaaTaskerPostTask;
+export using ::MaaTaskerPostRecognition;
+export using ::MaaTaskerPostAction;
 export using ::MaaTaskerStatus;
 export using ::MaaTaskerWait;
 export using ::MaaTaskerRunning;
@@ -230,15 +273,16 @@ export using ::MaaImageListBufferAt;
 export using ::MaaImageListBufferAppend;
 export using ::MaaImageListBufferRemove;
 export using ::MaaImageListBufferClear;
-// export using ::MaaRectCreate;
-// export using ::MaaRectDestroy;
-// export using ::MaaRectGetX;
-// export using ::MaaRectGetY;
-// export using ::MaaRectGetW;
-// export using ::MaaRectGetH;
-// export using ::MaaRectSet;
+export using ::MaaRectCreate;
+export using ::MaaRectDestroy;
+export using ::MaaRectGetX;
+export using ::MaaRectGetY;
+export using ::MaaRectGetW;
+export using ::MaaRectGetH;
+export using ::MaaRectSet;
 
-// Utility/MaaUtility.h
+// Global/MaaGlobal.h & Utility/MaaUtility.h
 
 export using ::MaaVersion;
 export using ::MaaGlobalSetOption;
+export using ::MaaGlobalLoadPlugin;

--- a/test/dlopen/CMakeLists.txt
+++ b/test/dlopen/CMakeLists.txt
@@ -24,6 +24,10 @@ if(WITH_WIN32_CONTROLLER)
     target_compile_definitions(DlopenTesting PRIVATE WITH_WIN32_CONTROLLER)
 endif()
 
+if(WITH_PLAYCOVER_CONTROLLER)
+    target_compile_definitions(DlopenTesting PRIVATE WITH_PLAYCOVER_CONTROLLER)
+endif()
+
 if(WITH_DBG_CONTROLLER)
     target_compile_definitions(DlopenTesting PRIVATE WITH_DBG_CONTROLLER)
 endif()

--- a/test/dlopen/main.cpp
+++ b/test/dlopen/main.cpp
@@ -36,6 +36,17 @@ int main()
 
 #endif
 
+#ifdef WITH_PLAYCOVER_CONTROLLER
+
+    std::cout << "********** PlayCoverControlUnitLibraryHolder::create_control_unit **********" << std::endl;
+    auto playcover_handle = MAA_NS::PlayCoverControlUnitLibraryHolder::create_control_unit("127.0.0.1:1717", "com.example.app");
+    if (!playcover_handle) {
+        std::cerr << "Failed to create playcover control unit" << std::endl;
+        return -1;
+    }
+
+#endif
+
 #ifdef WITH_DBG_CONTROLLER
 
     std::cout << "********** DbgControlUnitLibraryHolder::create_control_unit **********" << std::endl;


### PR DESCRIPTION
## Summary by Sourcery

导出之前遗漏的框架 API，添加 PlayCover 控制器集成钩子，并更新相关的构建、测试和文档条目。

New Features:
- 通过 C++20 `MaaFramework` 模块暴露更多的 controller、tasker、resource、global 和 context API。
- 为框架和 `dlopen` 测试工具添加 PlayCover 控制器创建支持。

Bug Fixes:
- 确保所有现有的 C API 在 C++20 `MaaFramework` 模块中都被正确重新导出，以避免符号缺失问题。

Enhancements:
- 扩展 agent server stub，以处理 PlayCover 控制器创建，并给出清晰的“尚未实现”消息。'],'build':['通过 CMake 选项将 PlayCover 控制器库接入 `LibraryHolder` 目标和 `dlopen` 测试构建。'],

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Export previously omitted framework APIs, add PlayCover controller integration hooks, and update related build, test, and documentation entries.

New Features:
- Expose additional controller, tasker, resource, global, and context APIs through the C++20 MaaFramework module.
- Add PlayCover controller creation support to the framework and dlopen test harness.

Bug Fixes:
- Ensure all existing C APIs are properly re-exported in the C++20 MaaFramework module to avoid missing symbol issues.

Enhancements:
- Extend agent server stubs to handle PlayCover controller creation with a clear not-implemented message.'],'build':['Wire the PlayCover controller library into the LibraryHolder target and dlopen test build via CMake options.'],

</details>