### PR TITLE
fix(win32): 使用 WM_ACTIVATE 替代 SetForegroundWindow 实现后台激活

### DIFF
--- a/source/MaaWin32ControlUnit/Input/InputUtils.h
+++ b/source/MaaWin32ControlUnit/Input/InputUtils.h
@@ -9,18 +9,20 @@
 
 MAA_CTRL_UNIT_NS_BEGIN
 
-// 窗口激活工具函数（基础版本，用于消息发送方式）
-inline void ensure_foreground(HWND hwnd)
+// 发送 WM_ACTIVATE 消息激活窗口（用于后台消息发送方式）
+// 让目标窗口认为自己被激活，但不实际改变前台窗口
+inline void send_activate_message(HWND hwnd, bool use_post = false)
 {
     if (!hwnd) {
         return;
     }
-    if (hwnd == GetForegroundWindow()) {
-        return;
+    // WM_ACTIVATE + WA_ACTIVE，lParam 为 0 表示没有前一个窗口
+    if (use_post) {
+        PostMessageW(hwnd, WM_ACTIVATE, WA_ACTIVE, 0);
     }
-    // ShowWindow(hwnd, SW_MINIMIZE);
-    // ShowWindow(hwnd, SW_RESTORE);
-    SetForegroundWindow(hwnd);
+    else {
+        SendMessageW(hwnd, WM_ACTIVATE, WA_ACTIVE, 0);
+    }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 }

--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -16,9 +16,10 @@ MessageInput::~MessageInput()
     }
 }
 
-void MessageInput::ensure_foreground()
+void MessageInput::send_activate()
 {
-    ::MaaNS::CtrlUnitNs::ensure_foreground(hwnd_);
+    bool use_post = (mode_ == Mode::PostMessage);
+    ::MaaNS::CtrlUnitNs::send_activate_message(hwnd_, use_post);
 }
 
 bool MessageInput::send_or_post_w(UINT message, WPARAM wParam, LPARAM lParam)
@@ -135,7 +136,7 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     if (block_input_) {
         BlockInput(TRUE);
@@ -210,7 +211,7 @@ bool MessageInput::touch_up(int contact)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     OnScopeLeave([this]() {
         if (block_input_) {
@@ -257,7 +258,7 @@ bool MessageInput::input_text(const std::string& text)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     // 文本输入仅发送 WM_CHAR
     for (const auto ch : to_u16(text)) {
@@ -278,7 +279,7 @@ bool MessageInput::key_down(int key)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     LPARAM lParam = make_keydown_lparam(key);
     return send_or_post_w(WM_KEYDOWN, static_cast<WPARAM>(key), lParam);
@@ -293,7 +294,7 @@ bool MessageInput::key_up(int key)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     LPARAM lParam = make_keyup_lparam(key);
     return send_or_post_w(WM_KEYUP, static_cast<WPARAM>(key), lParam);
@@ -308,7 +309,7 @@ bool MessageInput::scroll(int dx, int dy)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     if (block_input_) {
         BlockInput(TRUE);

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -48,7 +48,7 @@ public: // from InputBase
     virtual bool scroll(int dx, int dy) override;
 
 private:
-    void ensure_foreground();
+    void send_activate();
     bool send_or_post_w(UINT message, WPARAM wParam, LPARAM lParam);
 
     // 准备鼠标位置：with_cursor_pos_ 模式下移动真实光标，返回 lParam

--- a/source/MaaWin32ControlUnit/Input/PostThreadMessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/PostThreadMessageInput.cpp
@@ -17,9 +17,10 @@ PostThreadMessageInput::PostThreadMessageInput(HWND hwnd)
     }
 }
 
-void PostThreadMessageInput::ensure_foreground()
+void PostThreadMessageInput::send_activate()
 {
-    ::MaaNS::CtrlUnitNs::ensure_foreground(hwnd_);
+    // PostThreadMessage 模式使用 PostMessage 发送激活消息
+    ::MaaNS::CtrlUnitNs::send_activate_message(hwnd_, true);
 }
 
 std::pair<int, int> PostThreadMessageInput::get_target_pos() const
@@ -70,7 +71,7 @@ bool PostThreadMessageInput::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     touch_move(contact, x, y, pressure);
 
@@ -123,7 +124,7 @@ bool PostThreadMessageInput::touch_up(int contact)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     MouseMessageInfo msg_info;
     if (!contact_to_mouse_up_message(contact, msg_info)) {
@@ -156,7 +157,7 @@ bool PostThreadMessageInput::input_text(const std::string& text)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     // 文本输入仅发送 WM_CHAR
     for (const auto ch : to_u16(text)) {
@@ -173,7 +174,7 @@ bool PostThreadMessageInput::key_down(int key)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     LPARAM lParam = make_keydown_lparam(key);
     PostThreadMessage(thread_id_, WM_KEYDOWN, static_cast<WPARAM>(key), lParam);
@@ -187,7 +188,7 @@ bool PostThreadMessageInput::key_up(int key)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     LPARAM lParam = make_keyup_lparam(key);
     PostThreadMessage(thread_id_, WM_KEYUP, static_cast<WPARAM>(key), lParam);
@@ -203,7 +204,7 @@ bool PostThreadMessageInput::scroll(int dx, int dy)
         return false;
     }
 
-    ensure_foreground();
+    send_activate();
 
     auto target_pos = get_target_pos();
 

--- a/source/MaaWin32ControlUnit/Input/PostThreadMessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/PostThreadMessageInput.h
@@ -35,7 +35,7 @@ public: // from InputBase
     virtual bool scroll(int dx, int dy) override;
 
 private:
-    void ensure_foreground();
+    void send_activate();
     // 获取 last_pos_，若未设置则返回窗口客户区中心坐标
     std::pair<int, int> get_target_pos() const;
 


### PR DESCRIPTION
将 MessageInput 和 PostThreadMessageInput 中的 ensure_foreground() 改为 send_activate()，发送 WM_ACTIVATE + WA_ACTIVE 消息让目标窗口 认为自己被激活，而不实际将窗口抢到前台。同时根据输入模式选择
使用 SendMessage 或 PostMessage 发送激活消息。

## Summary by Sourcery

使用 WM_ACTIVATE 在后台激活窗口来替代前台激活，用于 Win32 输入处理。

Bug Fixes:
- 通过使用 WM_ACTIVATE 模拟激活而不是使用 SetForegroundWindow，防止输入操作强制将目标窗口切换到前台。

Enhancements:
- 引入一个可配置的 `send_activate` 辅助函数，根据输入模式通过 `SendMessage` 或 `PostMessage` 发送 `WM_ACTIVATE`，并在基于消息的输入路径中统一使用该函数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace foreground activation with background window activation using WM_ACTIVATE for Win32 input handling.

Bug Fixes:
- Prevent input operations from forcefully bringing target windows to the foreground by simulating activation via WM_ACTIVATE instead of SetForegroundWindow.

Enhancements:
- Introduce a configurable send_activate helper that dispatches WM_ACTIVATE using SendMessage or PostMessage based on input mode, and use it across message-based input paths.

</details>