### PR TITLE
fix: 修复adb控制器的isconnected不奏效的bug

### DIFF
--- a/source/MaaAdbControlUnit/General/Connection.cpp
+++ b/source/MaaAdbControlUnit/General/Connection.cpp
@@ -153,7 +153,7 @@ bool Connection::is_alive() const
     if (!monitor_ios_) {
         return false;
     }
-    return monitor_ios_->is_open();
+    return monitor_ios_->running();
 }
 
 MAA_CTRL_UNIT_NS_END


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过使用监视器的运行状态而不是其打开状态，修复了连接存活性检测问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix connection liveness detection by using the monitor's running state instead of its open state.

</details>