### PR TITLE
docs: 补充文档控制器介绍的遗漏

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -97,7 +97,7 @@ The so-called `ProjectInterface` is a standardized project structure declaration
     Controller icon file path, relative to the project root directory. _Optional._ Supports internationalization (starting with `$`).
 
   - **type** `'Adb' | 'Win32' | 'PlayCover' | 'Gamepad'`  
-    Controller type; valid values are `Adb`, `Win32`, `PlayCover` (macOS only), and `Gamepad` (Windows only).
+    Controller type; valid values are `Adb`, `Win32` (Windows only), `PlayCover` (macOS only), and `Gamepad` (Windows only).
 
   - **display_short_side** `number`  
     The short side length of the default scaled resolution, used for screen adaptation. _Optional_, defaults to 720. Mutually exclusive with `display_long_side` and `display_raw`.

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -98,7 +98,7 @@
     控制器图标文件路径，相对于项目根目录。可选。支持国际化（以`$`开头）。
 
   - type `'Adb' | 'Win32' | 'PlayCover' | 'Gamepad'`  
-    控制器类型，取值为 `Adb`、`Win32`、`PlayCover`（仅 macOS）和 `Gamepad`（仅 Windows）。
+    控制器类型，取值为 `Adb`、`Win32`（仅 Windows）、`PlayCover`（仅 macOS）和 `Gamepad`（仅 Windows）。
 
   - display_short_side `number`  
     默认缩放分辨率的短边长度，用于屏幕适配。可选，默认720。与`display_long_side`和`display_raw`互斥。


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- 在 ProjectInterfaceV2 控制器配置部分中记录 Win32 控制器类型仅在 Windows 上受支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document that the Win32 controller type is only supported on Windows in the ProjectInterfaceV2 controller configuration section.

</details>