### PR TITLE
feat: 默认不再 BlockInput

### DIFF
--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -88,7 +88,7 @@ bool Win32ControlUnitMgr::connect()
     auto make_input = [&](MaaWin32InputMethod method) -> std::shared_ptr<InputBase> {
         switch (method) {
         case MaaWin32InputMethod_Seize:
-            return std::make_shared<SeizeInput>(hwnd_, true);
+            return std::make_shared<SeizeInput>(hwnd_, false);
         case MaaWin32InputMethod_SendMessage:
             return std::make_shared<MessageInput>(hwnd_, MessageInput::Mode::SendMessage, false, false);
         case MaaWin32InputMethod_PostMessage:
@@ -98,9 +98,9 @@ bool Win32ControlUnitMgr::connect()
         case MaaWin32InputMethod_PostThreadMessage:
             return std::make_shared<PostThreadMessageInput>(hwnd_);
         case MaaWin32InputMethod_SendMessageWithCursorPos:
-            return std::make_shared<MessageInput>(hwnd_, MessageInput::Mode::SendMessage, true, true);
+            return std::make_shared<MessageInput>(hwnd_, MessageInput::Mode::SendMessage, true, false);
         case MaaWin32InputMethod_PostMessageWithCursorPos:
-            return std::make_shared<MessageInput>(hwnd_, MessageInput::Mode::PostMessage, true, true);
+            return std::make_shared<MessageInput>(hwnd_, MessageInput::Mode::PostMessage, true, false);
         default:
             LogError << "Unknown input method: " << static_cast<int>(method);
             return nullptr;


### PR DESCRIPTION
## Summary by Sourcery

放宽 Win32 seize 和基于光标位置的消息输入方式的默认输入捕获行为，以避免阻塞本地用户输入。

增强内容：
- 调整 Win32 seize 输入，使其默认情况下不再阻塞本地用户输入。
- 更新基于光标位置的 Send/Post 消息输入方式，默认避免阻塞本地用户输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax default input capture behavior for Win32 seize and cursor-position message input methods to avoid blocking local user input.

Enhancements:
- Adjust Win32 seize input to no longer block local user input by default.
- Update cursor-position Send/Post message input methods to avoid blocking local user input by default.

</details>
- 放宽对 `seize` 和 `cursor-position` 消息输入方式的输入捕获行为，使其在默认情况下不会阻塞本地用户输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

放宽 Win32 seize 和基于光标位置的消息输入方式的默认输入捕获行为，以避免阻塞本地用户输入。

增强内容：
- 调整 Win32 seize 输入，使其默认情况下不再阻塞本地用户输入。
- 更新基于光标位置的 Send/Post 消息输入方式，默认避免阻塞本地用户输入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax default input capture behavior for Win32 seize and cursor-position message input methods to avoid blocking local user input.

Enhancements:
- Adjust Win32 seize input to no longer block local user input by default.
- Update cursor-position Send/Post message input methods to avoid blocking local user input by default.

</details>

</details>