### PR TITLE
docs: update DirectHit algorithm section in documentation

### DIFF
--- a/docs/en_us/3.1-PipelineProtocol.md
+++ b/docs/en_us/3.1-PipelineProtocol.md
@@ -443,10 +443,12 @@ Direct hit, meaning no recognition is performed, and the action is executed dire
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Recognition area coordinates. Optional, default [0, 0, 0, 0], i.e. full screen.
+  - *array<int, 4>*: Recognition area coordinates [x, y, w, h]. Supports negative values **💡 v5.6**: negative x/y means calculating from right/bottom edge; w/h of 0 means extending to edge, negative means taking absolute value and treating (x, y) as bottom-right corner.
+  - *string*: Fill in the node name, and identify within the target range identified by a previously executed node.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Move additionally based on `roi` as the range, and add the four values separately. Optional, default [0, 0, 0, 0].
 
 ### `TemplateMatch`
 
@@ -455,12 +457,10 @@ Template matching, also known as "find image."
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Recognition area coordinates. Optional, default [0, 0, 0, 0], i.e. full screen.
-  - *array<int, 4>*: Recognition area coordinates [x, y, w, h]. Supports negative values **💡 v5.6**: negative x/y means calculating from right/bottom edge; w/h of 0 means extending to edge, negative means taking absolute value and treating (x, y) as bottom-right corner.
-  - *string*: Fill in the node name, and identify within the target range identified by a previously executed node.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Move additionally based on `roi` as the range, and add the four values ​​separately. Optional, default [0, 0, 0, 0].
+    Same as `DirectHit`.`roi_offset`.
 
 - `template`: *string* | *list<string, >*  
     Path to the template image, relative to the "image" folder. Required.  
@@ -503,10 +503,10 @@ Feature matching, a more powerful "find image" with better generalization, resis
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 - `template`: *string* | *list<string, >*  
     Path to the template image, relative to the "image" folder. Required.  
@@ -554,10 +554,10 @@ Color matching, also known as "find color."
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 - `method`: *int*  
     Color matching method, equivalent to cv::ColorConversionCodes. Optional, default is 4 (RGB).  
@@ -594,10 +594,10 @@ Text recognition.
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 - `expected`: *string* | *list<string, >*  
     The expected results, supports regular expressions. Optional, default matches all.
@@ -636,10 +636,10 @@ Deep learning classification, to determine if the image in a **fixed position** 
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 - `labels`: *list<string, >*  
     Labels, meaning the names of each category. Optional.  
@@ -681,10 +681,10 @@ The main difference from classification is the flexibility to find objects at ar
 This algorithm property requires additional fields:
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`.
+    Same as `DirectHit`.`roi`.
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 - `labels`: *list<string, >*  
     Labels, meaning the names of each category. Optional.  
@@ -863,10 +863,10 @@ This algorithm property requires additional fields:
     Recognition parameter, any type, will be passed through `MaaCustomRecognitionCallback`.`custom_recognition_param`. Optional, default `null`.
 
 - `roi`: *array<int, 4>* | *string*  
-    Same as `TemplateMatch`.`roi`, will be passed through `MaaCustomRecognitionCallback`.`roi`. Optional, default [0, 0, 0, 0].
+    Same as `DirectHit`.`roi`, will be passed through `MaaCustomRecognitionCallback`.`roi`. Optional, default [0, 0, 0, 0].
 
 - `roi_offset`: *array<int, 4>*  
-    Same as `TemplateMatch`.`roi_offset`.
+    Same as `DirectHit`.`roi_offset`.
 
 ## Action Types
 

--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -449,10 +449,12 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。  
+  - *array<int, 4>*: 识别区域坐标 [x, y, w, h]。支持负数 **💡 v5.6**：x/y 负数表示从右/下边缘计算；w/h 为 0 表示延伸至边缘，为负数时取绝对值并将 (x, y) 视为右下角。
+  - *string*: 填写节点名，在之前执行过的某节点识别到的目标范围内识别。  
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    在 `roi` 的基础上额外移动再作为范围，四个值分别相加。可选，默认 [0, 0, 0, 0] 。
 
 ### `TemplateMatch`
 
@@ -461,12 +463,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。  
-  - *array<int, 4>*: 识别区域坐标 [x, y, w, h]。支持负数 **💡 v5.6**：x/y 负数表示从右/下边缘计算；w/h 为 0 表示延伸至边缘，为负数时取绝对值并将 (x, y) 视为右下角。
-  - *string*: 填写节点名，在之前执行过的某节点识别到的目标范围内识别。  
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    在 `roi` 的基础上额外移动再作为范围，四个值分别相加。可选，默认 [0, 0, 0, 0] 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `template`: *string* | *list<string, >*  
     模板图片路径，需要 `image` 文件夹的相对路径。必选。  
@@ -509,10 +509,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `template`: *string* | *list<string, >*  
     模板图片路径，需要 `image` 文件夹的相对路径。必选。  
@@ -560,10 +560,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `method`: *int*  
     颜色匹配方式。即 cv::ColorConversionCodes。可选，默认 4 (RGB) 。  
@@ -600,10 +600,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `expected`: *string* | *list<string, >*  
     期望的结果，支持正则。可选，默认匹配所有结果。
@@ -643,10 +643,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `labels`: *list<string, >*  
     标注，即每个分类的名字。可选。  
@@ -689,10 +689,10 @@ MaaResourcePostPath(resource, "resource/debug");  // debug 节点使用 rate_lim
 该算法属性需额外部分字段：
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi` 。
+    同 `DirectHit`.`roi` 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 - `labels`: *list<string, >*  
     标注，即每个分类的名字。可选。  
@@ -872,10 +872,10 @@ Pipeline v2 时，将这些字段放到 `recognition.param` 中即可。
     识别参数，任意类型，会通过 `MaaCustomRecognitionCallback`.`custom_recognition_param` 传出。可选，默认 `null` 。
 
 - `roi`: *array<int, 4>* | *string*  
-    同 `TemplateMatch`.`roi`，会通过 `MaaCustomRecognitionCallback`.`roi` 传出。可选，默认 [0, 0, 0, 0] 。
+    同 `DirectHit`.`roi`，会通过 `MaaCustomRecognitionCallback`.`roi` 传出。可选，默认 [0, 0, 0, 0] 。
 
 - `roi_offset`: *array<int, 4>*  
-    同 `TemplateMatch`.`roi_offset` 。
+    同 `DirectHit`.`roi_offset` 。
 
 ## 动作类型
 


### PR DESCRIPTION
Added additional fields for the DirectHit algorithm in the documentation.

## 由 Sourcery 提供的摘要

文档：
- 在中文版用户指南中记录 DirectHit 算法的更多配置字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- 在英文 pipeline 协议文档中描述 DirectHit 算法的 `roi` 和 `roi_offset` 配置字段，并在其他算法章节中引用这些字段以避免重复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Describe `roi` and `roi_offset` configuration fields for the DirectHit algorithm in the English pipeline protocol documentation and reference these fields from other algorithm sections to avoid duplication.

</details>

</details>