### PR TITLE
fix: 修复 jumpback 和 anchor 混用时的问题

### DIFF
--- a/source/include/Common/TaskResultTypes.h
+++ b/source/include/Common/TaskResultTypes.h
@@ -44,6 +44,7 @@ struct NodeDetail
     MaaRecoId reco_id = MaaInvalidId;
     MaaActId action_id = MaaInvalidId;
     bool completed = false;
+    bool jump_back = false;
 
     MEO_TOJSON(node_id, name, reco_id, action_id, completed);
 };


### PR DESCRIPTION
fix https://github.com/MaaXYZ/MaaFramework/issues/1162

## Summary by Sourcery

调整流水线任务节点的处理方式，使其能够在与锚点（anchor）更新相互独立的情况下确定并传递回跳（jump-back）行为，从而修复在同时使用 `jump_back` 和 `anchor` 时出现的不正确行为。

Bug Fixes:
- 修复当在流水线节点中同时使用 `jump_back` 和 `anchor` 配置时，对回跳行为处理不正确的问题。

Enhancements:
- 通过 `NodeDetail` 结果传递 `jump_back` 状态，使下游处理能够感知并基于回跳决策进行相应处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust pipeline task node processing to determine and propagate jump-back behavior independently of anchor updates, fixing incorrect behavior when jump_back and anchor are used together.

Bug Fixes:
- Fix incorrect jump-back handling when jump_back and anchor configurations are used together in pipeline nodes.

Enhancements:
- Propagate jump_back status through NodeDetail results to make downstream processing aware of jump-back decisions.

</details>

## Summary by Sourcery

通过将回跳（jump-back）解析与锚点（anchor）更新解耦，并通过节点执行结果传播回跳状态，修复在流水线任务与锚点一起使用时的不正确回跳处理问题。

Bug 修复：
- 当同时使用 `jump_back` 和锚点配置时，纠正流水线节点的回跳行为。

增强功能：
- 通过 `NodeDetail` 传播 `jump_back` 状态，使下游的流水线处理能够对回跳决策作出响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix incorrect jump-back handling in pipeline tasks when used together with anchors by decoupling jump-back resolution from anchor updates and propagating jump-back state via node execution results.

Bug Fixes:
- Correct jump-back behavior in pipeline nodes when both jump_back and anchor configurations are used simultaneously.

Enhancements:
- Propagate jump_back status through NodeDetail so downstream pipeline processing can react to jump-back decisions.

</details>