### PR TITLE
ci: format 应该只在上游执行

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     format:
+        if: ${{ github.repository_owner == 'MaaXYZ' }}
         runs-on: macos-latest
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 添加仓库所有者条件，使格式化工作流仅在由 MaaXYZ 组织触发时执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add a repository-owner condition so the format workflow only executes when triggered in the MaaXYZ org.

</details>