### PR TITLE
docs: PI 2.3.1 - 强调一下不兼容选项行为

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -23,7 +23,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-01-30 | v2.1.0  | Standalone release |
 | 2026-01-30 | v2.2.0  | Added `attach_resource_path` and `import` fields |
 | 2026-02-23 | v2.3.0  | Added `checkbox` multi-select type, `option.controller`, `option.resource`, global/resource/controller-level options, `focus.display` display channel tag, `preset` field, `import` supports importing `preset` |
-| 2026-03-05 | v2.3.1  | Clarified option applicability filtering: when an option does not support the current controller/resource, none of its `pipeline_override` is applied (including nested `option.option` and references from `resource.option`/`controller.option`/`global_option`) |
+| 2026-03-05 | v2.3.1  | Clarified option applicability filtering |
 
 ## `interface.json`
 

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -23,7 +23,7 @@
 | 2026-1-30 | v2.1.0 | 独立版本发布 |
 | 2026-1-30 | v2.2.0 | 新增 `attach_resource_path` 和 `import` 字段 |
 | 2026-2-23 | v2.3.0 | 新增 `checkbox` 多选类型、`option.controller`、`option.resource`、全局/resource/controller 级 option、`focus.display` 展示渠道标签、`preset` 预设配置字段、`import` 支持导入 `preset` |
-| 2026-3-5 | v2.3.1 | 明确 option 适用性过滤规则：当 option 不支持当前 controller/resource 时，不应用其任何 `pipeline_override`（含嵌套 `option.option`，以及 `resource.option`/`controller.option`/`global_option` 引用） |
+| 2026-3-5 | v2.3.1 | 明确 option 适用性过滤规则 |
 
 ## `interface.json`
 


### PR DESCRIPTION
fix https://github.com/MaaXYZ/MaaFramework/issues/1168

## Summary by Sourcery

澄清 Project Interface v2.3.1 文档中，controller/resource 适用性约束如何影响选项激活以及 `pipeline_override` 合并行为。

Documentation:
- 说明当选项的 controller/resource 约束条件不满足时，该选项应被视为未激活，且不得对 `pipeline_override` 做出任何贡献；这一规则同样适用于嵌套选项以及从 resource/controller/global 选项中引用的选项。
- 更新 Project Interface v2 的版本历史，加入 v2.3.1，并在其中明确说明选项适用性及 `pipeline_override` 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify how controller/resource applicability constraints affect option activation and pipeline_override merging in the Project Interface v2.3.1 documentation.

Documentation:
- Document that options whose controller/resource constraints are not satisfied are treated as inactive and must not contribute any pipeline_override, including nested options and those referenced from resource/controller/global options.
- Update the Project Interface v2 version history to include v2.3.1 with the clarified option applicability and pipeline_override behavior.

</details>