### PR TITLE
feat: Win32 Window Pos 不再反复将窗口挪回去

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -91,7 +91,7 @@ void MessageInput::restore_cursor_pos()
 
 void MessageInput::save_window_pos()
 {
-    // 保留首次进入 WithWindowPos 会话前的位置，供 inactive/析构统一恢复。
+    // 保留首次进入 WithWindowPos 会话前的位置，依赖 inactive/析构路径统一恢复并清空标记。
     if (window_pos_saved_) {
         return;
     }
@@ -118,6 +118,17 @@ void MessageInput::restore_window_pos()
         LogError << "SetWindowPos failed during restore" << VAR(hwnd_) << VAR(GetLastError());
     }
     window_pos_saved_ = false;
+}
+
+void MessageInput::start_window_tracking(int x, int y)
+{
+    tracking_x_ = x;
+    tracking_y_ = y;
+    pending_mouse_x_ = 0;
+    pending_mouse_y_ = 0;
+    has_pending_mouse_ = false;
+    s_active_instance_ = this;
+    tracking_active_ = true;
 }
 
 void MessageInput::stop_window_tracking()
@@ -209,11 +220,7 @@ LPARAM MessageInput::prepare_mouse_position(int x, int y)
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
     else if (config_.with_window_pos) {
-        tracking_x_ = x;
-        tracking_y_ = y;
-        s_active_instance_ = this;
-        tracking_active_ = true;
-
+        start_window_tracking(x, y);
         move_window_to_align_cursor(x, y);
     }
     return MAKELPARAM(x, y);

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -68,6 +68,7 @@ private:
     void restore_cursor_pos();
     void save_window_pos();
     void restore_window_pos();
+    void start_window_tracking(int x, int y);
     void stop_window_tracking();
 
     // 保存/恢复当前模式对应的位置
@@ -115,6 +116,7 @@ private:
     POINT saved_cursor_pos_ = { 0, 0 };
     bool cursor_pos_saved_ = false;
     RECT saved_window_rect_ = { 0, 0, 0, 0 };
+    // WithWindowPos 会话的原始窗口位置，仅在 inactive/析构恢复后清空。
     bool window_pos_saved_ = false;
 };
 


### PR DESCRIPTION
## Summary by Sourcery

在 Win32 输入会话期间调整窗口位置的处理方式，以避免反复恢复窗口位置，同时保持清理逻辑的集中化。

增强内容：
- 在每个 WithWindowPos 会话中仅保存一次初始窗口位置，并将其恢复动作延迟到非活跃阶段或析构阶段执行。
- 引入专用的 `stop_window_tracking` 助手函数和 `finish_pos` 步骤，用于集中处理光标/窗口跟踪的拆解逻辑，而不立即恢复窗口位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust window position handling during Win32 input sessions to avoid repeatedly restoring the window while keeping cleanup centralized.

Enhancements:
- Preserve the initial window position only once per WithWindowPos session and defer its restoration to inactive/destructor phases.
- Introduce a dedicated stop_window_tracking helper and a finish_pos step to centralize cursor/window tracking teardown logic without immediately restoring the window position.

</details>