### PR TITLE
feat: Win32 Window Pos 不再反复将窗口挪回去

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -124,7 +124,7 @@ void MessageInput::start_window_tracking(int x, int y)
 {
     ++tracking_generation_;
     tracking_stop_generation_ = 0;
-    tracking_stop_deadline_ = std::chrono::steady_clock::time_point {};
+    tracking_stop_deadline_ticks_ = 0;
     tracking_x_ = x;
     tracking_y_ = y;
     pending_mouse_x_ = 0;
@@ -142,7 +142,7 @@ void MessageInput::request_stop_window_tracking()
 
     // 记住当前 tracking 代次，避免旧的 stop 请求在后续 touch_move 重启 tracking 后误停新一轮会话。
     tracking_stop_generation_ = tracking_generation_.load();
-    tracking_stop_deadline_ = std::chrono::steady_clock::now() + std::chrono::milliseconds(10);
+    tracking_stop_deadline_ticks_ = (TrackingClock::now() + std::chrono::milliseconds(10)).time_since_epoch().count();
 }
 
 void MessageInput::maybe_stop_window_tracking()
@@ -151,9 +151,9 @@ void MessageInput::maybe_stop_window_tracking()
         return;
     }
 
-    auto deadline = tracking_stop_deadline_.load();
-    auto now = std::chrono::steady_clock::now();
-    if (deadline == std::chrono::steady_clock::time_point {} || now < deadline) {
+    auto deadline_ticks = tracking_stop_deadline_ticks_.load();
+    auto now = TrackingClock::now();
+    if (deadline_ticks == 0 || now < TrackingClock::time_point(TrackingClock::duration(deadline_ticks))) {
         return;
     }
 
@@ -162,9 +162,9 @@ void MessageInput::maybe_stop_window_tracking()
         return;
     }
 
-    auto expected_deadline = deadline;
+    auto expected_deadline_ticks = deadline_ticks;
     // 只有清掉自己看到的 deadline 才能说明这次 stop 没有被更新的请求覆盖。
-    if (!tracking_stop_deadline_.compare_exchange_strong(expected_deadline, std::chrono::steady_clock::time_point {})) {
+    if (!tracking_stop_deadline_ticks_.compare_exchange_strong(expected_deadline_ticks, 0)) {
         return;
     }
 
@@ -178,7 +178,7 @@ void MessageInput::maybe_stop_window_tracking()
 void MessageInput::stop_window_tracking()
 {
     tracking_stop_generation_ = 0;
-    tracking_stop_deadline_ = std::chrono::steady_clock::time_point {};
+    tracking_stop_deadline_ticks_ = 0;
     tracking_active_ = false;
     s_active_instance_ = nullptr;
     pending_mouse_x_ = 0;
@@ -200,7 +200,10 @@ bool MessageInput::handle_hardware_mouse_move(const MSLLHOOKSTRUCT& mouse_info)
     // pt 是系统根据 "当前光标位置 + 硬件原始delta" 计算出的目标位置
     // 光标被我们冻住了，所以 delta = pt - 当前冻住的光标位置
     POINT cursor;
-    GetCursorPos(&cursor);
+    if (!GetCursorPos(&cursor)) {
+        LogError << "GetCursorPos failed in mouse hook, fallback to hook point" << VAR(GetLastError());
+        cursor = mouse_info.pt;
+    }
     int dx = mouse_info.pt.x - cursor.x;
     int dy = mouse_info.pt.y - cursor.y;
 
@@ -479,9 +482,9 @@ void MessageInput::tracking_thread_func()
     }
     OnScopeLeave([&]() { UnhookWindowsHookEx(hHook); });
 
-    // 120fps 节流：每帧间隔约 8.33ms
+    // 60fps 节流：每帧间隔约 16.67ms
     using clock = std::chrono::steady_clock;
-    static constexpr auto frame_interval = std::chrono::nanoseconds(1'000'000'000 / 120);
+    static constexpr auto frame_interval = std::chrono::nanoseconds(1'000'000'000 / 60);
     auto last_frame = clock::now();
 
     MSG msg;

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -54,6 +54,9 @@ public: // from InputBase
     virtual void inactive() override;
 
 private:
+    using TrackingClock = std::chrono::steady_clock;
+    using TrackingDeadlineTicks = TrackingClock::duration::rep;
+
     void send_activate();
     bool send_or_post_w(UINT message, WPARAM wParam, LPARAM lParam);
 
@@ -96,7 +99,7 @@ private:
     std::atomic_int tracking_y_ = 0;
     std::atomic_uint64_t tracking_generation_ = 0;
     std::atomic_uint64_t tracking_stop_generation_ = 0;
-    std::atomic<std::chrono::steady_clock::time_point> tracking_stop_deadline_ = std::chrono::steady_clock::time_point {};
+    std::atomic<TrackingDeadlineTicks> tracking_stop_deadline_ticks_ = 0;
 
     // 钩子先累积硬件鼠标位移，再由 tracking 线程按固定帧率统一释放，避免每次移动都同步挪窗。
     std::atomic_int pending_mouse_x_ = 0;


### PR DESCRIPTION
## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

Bug 修复：
- 防止在连续的 WithWindowPos 交互过程中，窗口被反复移动回过时的原始位置。
- 在跟踪用于窗口重新定位的硬件鼠标移动时，避免由注入的鼠标事件导致的自反馈问题。

增强：
- 为 WithWindowPos 窗口跟踪引入显式的启动/停止辅助方法和基于“代数（generation）”的状态跟踪，以集中管理生命周期和清理逻辑。
- 将输入操作完成与窗口位置恢复解耦，使窗口跟踪可以在触控/滚动操作结束后稍微延迟、平滑地结束。
- 优化底层鼠标钩子，将移动处理委托给当前活动的 MessageInput 实例，并以更高的帧率节流窗口更新，以获得更流畅的跟踪效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

</details>

新功能：
- 引入显式的开始/停止辅助方法用于窗口位置跟踪，以集中管理状态和清理逻辑。

错误修复：
- 确保在每个 `WithWindowPos` 会话中只保存一次窗口位置，避免反复将窗口拉回到过期的位置。
- 防止在窗口跟踪过程中由注入鼠标事件引发自反馈循环，从而避免窗口发生错误漂移。

增强优化：
- 优化底层鼠标钩子和跟踪线程，以固定帧率累积硬件鼠标移动，并在停止跟踪前提供短暂的宽限期。
- 将输入操作的完成过程与窗口位置的恢复分离，使触控和滚动交互能够在窗口被移回之前干净地完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

Bug 修复：
- 防止在连续的 WithWindowPos 交互过程中，窗口被反复移动回过时的原始位置。
- 在跟踪用于窗口重新定位的硬件鼠标移动时，避免由注入的鼠标事件导致的自反馈问题。

增强：
- 为 WithWindowPos 窗口跟踪引入显式的启动/停止辅助方法和基于“代数（generation）”的状态跟踪，以集中管理生命周期和清理逻辑。
- 将输入操作完成与窗口位置恢复解耦，使窗口跟踪可以在触控/滚动操作结束后稍微延迟、平滑地结束。
- 优化底层鼠标钩子，将移动处理委托给当前活动的 MessageInput 实例，并以更高的帧率节流窗口更新，以获得更流畅的跟踪效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

</details>

</details>

增强内容：
- 确保在每个 WithWindowPos 会话中仅保存一次窗口位置，避免反复将窗口移回原位置。
- 引入显式的窗口位置跟踪启动/停止辅助方法，以集中管理跟踪状态和清理逻辑。
- 将输入操作的结束与窗口位置的恢复解耦，使操作能够干净结束，而窗口位置的恢复在生命周期的后期进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

Bug 修复：
- 防止在连续的 WithWindowPos 交互过程中，窗口被反复移动回过时的原始位置。
- 在跟踪用于窗口重新定位的硬件鼠标移动时，避免由注入的鼠标事件导致的自反馈问题。

增强：
- 为 WithWindowPos 窗口跟踪引入显式的启动/停止辅助方法和基于“代数（generation）”的状态跟踪，以集中管理生命周期和清理逻辑。
- 将输入操作完成与窗口位置恢复解耦，使窗口跟踪可以在触控/滚动操作结束后稍微延迟、平滑地结束。
- 优化底层鼠标钩子，将移动处理委托给当前活动的 MessageInput 实例，并以更高的帧率节流窗口更新，以获得更流畅的跟踪效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

</details>

新功能：
- 引入显式的开始/停止辅助方法用于窗口位置跟踪，以集中管理状态和清理逻辑。

错误修复：
- 确保在每个 `WithWindowPos` 会话中只保存一次窗口位置，避免反复将窗口拉回到过期的位置。
- 防止在窗口跟踪过程中由注入鼠标事件引发自反馈循环，从而避免窗口发生错误漂移。

增强优化：
- 优化底层鼠标钩子和跟踪线程，以固定帧率累积硬件鼠标移动，并在停止跟踪前提供短暂的宽限期。
- 将输入操作的完成过程与窗口位置的恢复分离，使触控和滚动交互能够在窗口被移回之前干净地完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

Bug 修复：
- 防止在连续的 WithWindowPos 交互过程中，窗口被反复移动回过时的原始位置。
- 在跟踪用于窗口重新定位的硬件鼠标移动时，避免由注入的鼠标事件导致的自反馈问题。

增强：
- 为 WithWindowPos 窗口跟踪引入显式的启动/停止辅助方法和基于“代数（generation）”的状态跟踪，以集中管理生命周期和清理逻辑。
- 将输入操作完成与窗口位置恢复解耦，使窗口跟踪可以在触控/滚动操作结束后稍微延迟、平滑地结束。
- 优化底层鼠标钩子，将移动处理委托给当前活动的 MessageInput 实例，并以更高的帧率节流窗口更新，以获得更流畅的跟踪效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进 Win32 的 WithWindowPos 窗口跟踪机制，使其具有有状态（stateful）、代次感知（generation-aware）且更加平滑的行为，同时避免反馈循环。

新特性：
- 为 WithWindowPos 模式下的窗口位置跟踪添加显式的启动/停止辅助方法以及完整的生命周期管理。

错误修复：
- 确保窗口位置在每次 WithWindowPos 会话中只保存一次，防止重复恢复到过时的位置。
- 在硬件跟踪中忽略注入的鼠标事件，以避免导致窗口偏移的自反馈。

增强：
- 优化后台鼠标跟踪，通过基于代次（generation-based）的停止请求和短暂宽限期，使在触摸/滚动交互结束后跟踪可以更加平滑地停止。
- 通过当前激活的 `MessageInput` 实例来委托低层鼠标移动处理，并以固定帧率节流窗口更新，从而获得更平滑的移动效果。
- 通过统一的结束步骤集中处理光标/窗口清理，将输入完成与窗口位置恢复解耦。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Win32 WithWindowPos window tracking to be stateful, generation-aware, and smoother while avoiding feedback loops.

New Features:
- Add explicit start/stop helpers and lifecycle management for window position tracking in WithWindowPos mode.

Bug Fixes:
- Ensure window position is saved only once per WithWindowPos session to prevent repeatedly restoring to stale positions.
- Ignore injected mouse events in hardware tracking to avoid self-feedback that drifts the window.

Enhancements:
- Refine background mouse tracking with generation-based stop requests and a short grace period so tracking ends smoothly after touch/scroll interactions.
- Delegate low-level mouse move handling through the active MessageInput instance and throttle window updates at a fixed frame rate for smoother motion.
- Centralize cursor/window cleanup via a unified finish step, decoupling input completion from window position restoration.

</details>

</details>

</details>

</details>