### PR TITLE
fix:关于mumu模拟器多窗口运行，adb路径导致控制窗口路径错误问题尝试修复

### DIFF
--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -243,7 +243,7 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
         if (!seen_adb_paths.insert(adb_path).second) {
             continue;
         }
-        
+
         Emulator emulator {
             .name = find_it->first,
             .process_path = *process_path,

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -213,6 +213,7 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
     LogFunc;
 
     std::vector<Emulator> result;
+    std::unordered_set<std::filesystem::path> seen_adb_paths;
 
     auto all_processes = list_processes();
 
@@ -238,6 +239,11 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
             continue;
         }
 
+        // Deduplicate by adb_path to distinguish multiple instances or installations
+        if (!seen_adb_paths.insert(adb_path).second) {
+            continue;
+        }
+        
         Emulator emulator {
             .name = find_it->first,
             .process_path = *process_path,

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -213,7 +213,6 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
     LogFunc;
 
     std::vector<Emulator> result;
-    std::unordered_set<std::filesystem::path> seen_adb_paths;
 
     auto all_processes = list_processes();
 
@@ -236,11 +235,6 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
 
         if (adb_path.empty()) {
             LogWarn << "adb_path is empty or does not exist" << VAR(adb_path);
-            continue;
-        }
-
-        // Deduplicate by adb_path to distinguish multiple instances or installations
-        if (!seen_adb_paths.insert(adb_path).second) {
             continue;
         }
 

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -45,7 +45,9 @@ const AdbDeviceFinder::EmulatorConstDataMap& AdbDeviceWin32Finder::get_emulator_
         { "MuMuPlayer12 v5",
           {
               .keyword = "MuMuNxDevice.exe",
-              .adb_candidate_paths = { "..\\..\\..\\nx_main\\adb.exe"_path, "adb.exe"_path },
+              .adb_candidate_paths = { "..\\..\\..\\nx_device\\12.0\\shell\\adb.exe"_path,
+                                       "..\\..\\..\\nx_main\\adb.exe"_path,
+                                       "adb.exe"_path },
           } },
 
         { "MEmuPlayer", { .keyword = "MEmu", .adb_candidate_paths = { "adb.exe"_path }, .adb_common_serials = { "127.0.0.1:21503" } } },


### PR DESCRIPTION
### 修复内容
针对 mumu 模拟器多窗口运行时，adb 路径导致控制窗口路径错误的问题进行了尝试修复。

### 关联 Issue
Fixes #1212

## Summary by Sourcery

调整模拟器 ADB 在 MuMu 多窗口环境下的检测逻辑，并改进路径处理。

Bug 修复：
- 允许检测到具有不同 ADB 路径的多个模拟器实例，而不是按 ADB 路径去重。
- 更新 MuMuPlayer12 v5 的 ADB 备选路径，以包含适用于多窗口环境的正确 `nx_device` shell adb 位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust emulator ADB detection for MuMu multi-window setups and improve path handling.

Bug Fixes:
- Allow multiple emulator instances with distinct ADB paths to be detected instead of deduplicating by ADB path.
- Update MuMuPlayer12 v5 ADB candidate paths to include the correct nx_device shell adb location for multi-window environments.

</details>