### PR TITLE
fix(wlroots): send key events for non-lock modifiers

### DIFF
--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
@@ -331,7 +331,9 @@ bool WaylandClient::input_key(EventPhase phase, int key)
         default:;
         }
         zwp_virtual_keyboard_v1_modifiers(keyboard_.get(), current_depressed_modifiers_, 0, current_locked_modifiers_, 0);
-        return process_requests();
+        if (locked_modifier != 0) {
+            return process_requests();
+        }
     }
     switch (phase) {
     case EventPhase::Began:


### PR DESCRIPTION
在终末地上测试 Alt 键仅发送 modifiers 状态不够，需要发送按键状态才能生效

## Summary by Sourcery

Bug Fixes:
- 修复非锁定修饰键（例如 Alt）的按键事件缺失问题，方法是确保在仅有修饰键状态变化时仍继续进行处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix missing key events for non-lock modifier keys (e.g., Alt) by ensuring processing continues when only modifier state changes.

</details>