### PR TITLE
fix: 修复override为空时依然遍历task导致耗时问题

### DIFF
--- a/source/MaaFramework/Task/Context.cpp
+++ b/source/MaaFramework/Task/Context.cpp
@@ -194,6 +194,11 @@ bool Context::override_pipeline(const json::value& pipeline_override)
 {
     LogTrace << VAR(getptr()) << VAR(pipeline_override);
 
+    if ((pipeline_override.is_object() && pipeline_override.as_object().empty())
+        || (pipeline_override.is_array() && pipeline_override.as_array().empty())) {
+        return true;
+    }
+
     if (!tasker_) {
         LogError << "tasker is null";
         return false;

--- a/source/MaaFramework/Task/Context.cpp
+++ b/source/MaaFramework/Task/Context.cpp
@@ -194,8 +194,7 @@ bool Context::override_pipeline(const json::value& pipeline_override)
 {
     LogTrace << VAR(getptr()) << VAR(pipeline_override);
 
-    if ((pipeline_override.is_object() && pipeline_override.as_object().empty())
-        || (pipeline_override.is_array() && pipeline_override.as_array().empty())) {
+    if (pipeline_override.empty()) {
         return true;
     }
 


### PR DESCRIPTION
现象：调用单节点action时，这一步耗时30ms，在自动战斗中不可接受
<img width="1524" height="930" alt="image" src="https://github.com/user-attachments/assets/bb06f6fe-d405-4ad7-92b1-0347829cfd71" />
<img width="1450" height="1035" alt="image" src="https://github.com/user-attachments/assets/111a09b6-7af6-47d8-ab48-3722ec3eb927" />
<img width="1404" height="1010" alt="image" src="https://github.com/user-attachments/assets/5860c3e8-8f22-4617-a8af-5d2d2f26b44d" />

## Summary by Sourcery

Bug Fixes:
- 当 pipeline 覆盖配置的 JSON 是空对象或空数组时，避免遍历任务并避免产生额外的延迟。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid traversing tasks and incurring extra latency when the pipeline override JSON is an empty object or array.

</details>