### PR TITLE
fix(wlroots): add missing scroll

### DIFF
--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
@@ -306,6 +306,10 @@ bool WaylandClient::pointer(EventPhase phase, int x, int y, int contact)
 
 bool WaylandClient::scroll(int dx, int dy) const
 {
+    if (!connected_) {
+        return false;
+    }
+
     if (dy != 0) {
         const int step_y = dy / 120;
         for (int i = 0; i < abs(step_y); ++i) {

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
@@ -304,6 +304,42 @@ bool WaylandClient::pointer(EventPhase phase, int x, int y, int contact)
     return process_requests();
 }
 
+bool WaylandClient::scroll(int dx, int dy) const
+{
+    if (dy != 0) {
+        const int step_y = dy / 120;
+        for (int i = 0; i < abs(step_y); ++i) {
+            zwlr_virtual_pointer_v1_axis_discrete(
+                pointer_.get(),
+                WaylandHelper::get_ms(),
+                WL_POINTER_AXIS_VERTICAL_SCROLL,
+                wl_fixed_from_int(step_y >= 0 ? 10 : -10),
+                step_y >= 0 ? 1 : -1);
+            zwlr_virtual_pointer_v1_frame(pointer_.get());
+            if (!process_requests()) {
+                return false;
+            }
+        }
+    }
+
+    if (dx != 0) {
+        const int step_x = dx / 120;
+        for (int i = 0; i < abs(step_x); ++i) {
+            zwlr_virtual_pointer_v1_axis_discrete(
+                pointer_.get(),
+                WaylandHelper::get_ms(),
+                WL_POINTER_AXIS_HORIZONTAL_SCROLL,
+                wl_fixed_from_int(step_x >= 0 ? 10 : -10),
+                step_x >= 0 ? 1 : -1);
+            zwlr_virtual_pointer_v1_frame(pointer_.get());
+            if (!process_requests()) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 bool WaylandClient::input_key(EventPhase phase, int key)
 {
     if (!connected_) {

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.h
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.h
@@ -33,6 +33,7 @@ public:
 
     bool screencap(void** buffer, uint32_t& width, uint32_t& height, uint32_t& format);
     bool pointer(EventPhase phase, int x, int y, int contact);
+    bool scroll(int dx, int dy) const;
     bool input_key(EventPhase phase, int key);
     bool input_str(const std::string& str);
     std::pair<int, int> screen_size() const;
@@ -58,6 +59,7 @@ private:
     bool process_requests() const;
     bool switch_keymap(Keymap new_map);
 
+    // Registry objects
     std::unique_ptr<wl_display> display_;
     std::unique_ptr<wl_registry> registry_;
     std::unique_ptr<wl_output> output_;
@@ -67,24 +69,24 @@ private:
     std::unique_ptr<zwlr_virtual_pointer_manager_v1> pointer_manager_;
     std::unique_ptr<zwlr_virtual_pointer_v1> pointer_;
 
+    // Device objects
     std::unique_ptr<zwp_virtual_keyboard_manager_v1> keyboard_manager_;
     std::unique_ptr<MemfdBuffer> ascii_keymap_buffer_;
     std::unique_ptr<MemfdBuffer> scancode_keymap_buffer_;
     std::unique_ptr<zwp_virtual_keyboard_v1> keyboard_;
+
+    // Virtual keyboard status
     Keymap current_keymap_ = Keymap::Unknown;
     int current_depressed_modifiers_ = 0;
     int current_locked_modifiers_ = 0;
 
-    std::pair<int, int> screen_size_ { 0, 0 };
-
-    wl_registry_listener registry_listener_ = { };
-
-    std::filesystem::path socket_path_;
-
+    // Capture status
     bool connected_ = false;
     bool capture_waiting_ = false;
     bool capture_successful_ = false;
+    std::pair<int, int> screen_size_ { 0, 0 };
 
+    // Capture objects
     std::unique_ptr<MemfdBuffer> buffer_;
     std::unique_ptr<wl_shm_pool> shm_pool_;
     std::unique_ptr<wl_buffer> buffer_obj_;
@@ -92,6 +94,11 @@ private:
     int buffer_height_ = 0;
     int buffer_format_ = 0;
     int buffer_stride_ = 0;
+
+    // Utils
+    wl_registry_listener registry_listener_ = { };
+
+    std::filesystem::path socket_path_;
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.h
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.h
@@ -67,9 +67,11 @@ private:
     std::unique_ptr<wl_seat> seat_;
     std::unique_ptr<zwlr_screencopy_manager_v1> screencopy_manager_;
     std::unique_ptr<zwlr_virtual_pointer_manager_v1> pointer_manager_;
+
+    // Virtuan pointer object
     std::unique_ptr<zwlr_virtual_pointer_v1> pointer_;
 
-    // Device objects
+    // Virtual keyboard objects
     std::unique_ptr<zwp_virtual_keyboard_manager_v1> keyboard_manager_;
     std::unique_ptr<MemfdBuffer> ascii_keymap_buffer_;
     std::unique_ptr<MemfdBuffer> scancode_keymap_buffer_;

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.h
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.h
@@ -68,7 +68,7 @@ private:
     std::unique_ptr<zwlr_screencopy_manager_v1> screencopy_manager_;
     std::unique_ptr<zwlr_virtual_pointer_manager_v1> pointer_manager_;
 
-    // Virtuan pointer object
+    // Virtual pointer object
     std::unique_ptr<zwlr_virtual_pointer_v1> pointer_;
 
     // Virtual keyboard objects

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
@@ -229,6 +229,16 @@ bool WlRootsControlUnitMgr::key_up(int key)
     return client_->input_key(WaylandClient::EventPhase::Ended, key);
 }
 
+bool WlRootsControlUnitMgr::scroll(int dx, int dy)
+{
+    if (!client_) {
+        LogError << "client_ is nullptr";
+        return false;
+    }
+
+    return client_->scroll(dx, dy);
+}
+
 bool WlRootsControlUnitMgr::stop_app(const std::string& intent)
 {
     // TODO

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
@@ -14,7 +14,7 @@ MAA_CTRL_UNIT_NS_BEGIN
 
 class WaylandClient;
 
-class WlRootsControlUnitMgr : public ControlUnitAPI
+class WlRootsControlUnitMgr : public ControlUnitAPI, public ScrollableUnit
 {
 public:
     WlRootsControlUnitMgr(std::filesystem::path wlr_socket_path);
@@ -44,6 +44,8 @@ public:
 
     virtual bool key_down(int key) override;
     virtual bool key_up(int key) override;
+
+    virtual bool scroll(int dx, int dy) override;
 
     virtual bool inactive() override;
 


### PR DESCRIPTION
为 WlRoots 控制器实现 ScrollableUnit，并补全意外删除的 scroll 实现

## 由 Sourcery 提供的摘要

为 wlroots 控制单元实现滚动处理，并通过 Wayland 客户端和管理器进行串联。

新功能：
- 使用离散的水平和垂直轴事件，为 Wayland 客户端添加滚动支持。
- 通过实现 `ScrollableUnit` 接口，在 wlroots 控制单元管理器中暴露滚动功能。

增强内容：
- 通过使用注释对成员进行分组（注册表、设备、虚拟键盘状态、捕获状态、捕获对象以及工具字段），重新组织并澄清 `WaylandClient` 的成员布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement scroll handling for the wlroots control unit and wire it through the Wayland client and manager.

New Features:
- Add scroll support to the Wayland client using discrete horizontal and vertical axis events.
- Expose scroll functionality via the wlroots control unit manager by implementing the ScrollableUnit interface.

Enhancements:
- Reorganize and clarify WaylandClient member layout with comments grouping registry, device, virtual keyboard status, capture status, capture objects, and utility fields.

</details>