### PR TITLE
chore: 添加`WlRoots`控制器的schema

### DIFF
--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -400,12 +400,14 @@
                 "type": {
                     "type": "string",
                     "title": "控制器类型",
-                    "enum": [
+                        "enum": [
                         "Adb",
                         "Win32",
                         "MacOS",
                         "PlayCover",
                         "Gamepad"
+                        "Gamepad",
+                        "WlRoots"
                     ]
                 },
                 "display_short_side": {
@@ -600,6 +602,19 @@
                                 "PrintWindow",
                                 "ScreenDC"
                             ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "wlroots": {
+                    "type": "object",
+                    "title": "WlRoots 控制器配置",
+                    "description": "WlRoots 控制器的具体配置（仅 Linux）",
+                    "properties": {
+                        "wlr_socket_path": {
+                            "type": "string",
+                            "title": "Wayland Socket 路径",
+                            "description": "可选。Wayland Socket 路径，不提供则使用默认"
                         }
                     },
                     "additionalProperties": false

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -400,12 +400,11 @@
                 "type": {
                     "type": "string",
                     "title": "控制器类型",
-                        "enum": [
+                    "enum": [
                         "Adb",
                         "Win32",
                         "MacOS",
                         "PlayCover",
-                        "Gamepad"
                         "Gamepad",
                         "WlRoots"
                     ]

--- a/tools/interface_config.schema.json
+++ b/tools/interface_config.schema.json
@@ -13,7 +13,7 @@
                 "type": {
                     "title": "控制器类型",
                     "type": "string",
-                    "enum": ["Adb", "Win32", "PlayCover"]
+                    "enum": ["Adb", "Win32", "PlayCover", "WlRoots"]
                 }
             }
         },
@@ -49,6 +49,16 @@
                 },
                 "uuid": {
                     "title": "Bundle Identifier",
+                    "type": "string"
+                }
+            }
+        },
+        "wlroots": {
+            "title": "WlRoots配置",
+            "type": "object",
+            "properties": {
+                "wlr_socket_path": {
+                    "title": "Wayland Socket路径",
                     "type": "string"
                 }
             }


### PR DESCRIPTION
Added 'WlRoots' to the controller type enum and introduced WlRoots controller configuration properties.

## Summary by Sourcery

在接口 JSON 模式中添加对 WlRoots 控制器的支持。

新功能：
- 在接口模式中将 WlRoots 引入为有效的控制器类型。
- 在接口配置模式中为 WlRoots 控制器定义配置属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for the WlRoots controller in the interface JSON schemas.

New Features:
- Introduce WlRoots as a valid controller type in the interface schema.
- Define configuration properties for the WlRoots controller in the interface configuration schema.

</details>