### PR TITLE
fix(wlroots): scroll 垂直滚动方向与 win32 保持一致

### DIFF
--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
@@ -311,7 +311,9 @@ bool WaylandClient::scroll(int dx, int dy) const
     }
 
     if (dy != 0) {
-        const int step_y = dy / 120;
+        // Wayland 的垂直滚动方向与 Maa 对外约定（dy > 0 表示向上滚动）相反，
+        // 这里对 dy 取反以与 Win32 等控制器保持一致行为。
+        const int step_y = -dy / 120;
         for (int i = 0; i < abs(step_y); ++i) {
             zwlr_virtual_pointer_v1_axis_discrete(
                 pointer_.get(),


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修正 Wayland 客户端中的垂直滚动方向，使正 dy 对应向上滚动，与外部规范保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct vertical scroll direction in the Wayland client so that positive dy corresponds to upward scrolling as externally specified.

</details>