### PR TITLE
Revert "fix:关于mumu模拟器多窗口运行，adb路径导致控制窗口路径错误问题尝试修复 (#1253)"

### DIFF
--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -45,9 +45,7 @@ const AdbDeviceFinder::EmulatorConstDataMap& AdbDeviceWin32Finder::get_emulator_
         { "MuMuPlayer12 v5",
           {
               .keyword = "MuMuNxDevice.exe",
-              .adb_candidate_paths = { "..\\..\\..\\nx_device\\12.0\\shell\\adb.exe"_path,
-                                       "..\\..\\..\\nx_main\\adb.exe"_path,
-                                       "adb.exe"_path },
+              .adb_candidate_paths = { "..\\..\\..\\nx_main\\adb.exe"_path, "adb.exe"_path },
           } },
 
         { "MEmuPlayer", { .keyword = "MEmu", .adb_candidate_paths = { "adb.exe"_path }, .adb_common_serials = { "127.0.0.1:21503" } } },


### PR DESCRIPTION
This reverts commit 9866ec3f7b9de40173bddb0ef97a9f8d79182256.

@Windsland52 @SweetSmellFox 试一哈

## Summary by Sourcery

撤销此前对 MuMuPlayer12 v5 ADB 可执行文件搜索路径的修改，恢复之前用于检测该模拟器的候选路径集合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Revert the previous change to MuMuPlayer12 v5 ADB executable search paths, restoring the earlier set of candidate paths for detecting the emulator.

</details>