### PR TITLE
feat(wlroots): 添加 relative move

### DIFF
--- a/include/MaaControlUnit/ControlUnitAPI.h
+++ b/include/MaaControlUnit/ControlUnitAPI.h
@@ -112,6 +112,15 @@ public:
     virtual ~MacOSControlUnitAPI() = default;
 };
 
+class WlRootsControlUnitAPI
+    : public ControlUnitAPI
+    , public ScrollableUnit
+    , public RelativeMovableUnit
+{
+public:
+    virtual ~WlRootsControlUnitAPI() = default;
+};
+
 class CustomControlUnitAPI
     : public ControlUnitAPI
     , public ScrollableUnit
@@ -144,6 +153,7 @@ using MaaControlUnitHandle = MAA_CTRL_UNIT_NS::ControlUnitAPI*;
 using MaaAdbControlUnitHandle = MAA_CTRL_UNIT_NS::AdbControlUnitAPI*;
 using MaaWin32ControlUnitHandle = MAA_CTRL_UNIT_NS::Win32ControlUnitAPI*;
 using MaaMacOSControlUnitHandle = MAA_CTRL_UNIT_NS::MacOSControlUnitAPI*;
+using MaaWlRootsControlUnitHandle = MAA_CTRL_UNIT_NS::WlRootsControlUnitAPI*;
 using MaaGamepadControlUnitHandle = MAA_CTRL_UNIT_NS::GamepadControlUnitAPI*;
 using MaaCustomControlUnitHandle = MAA_CTRL_UNIT_NS::CustomControlUnitAPI*;
 using MaaReplayControlUnitHandle = MAA_CTRL_UNIT_NS::FullControlUnitAPI*;

--- a/include/MaaControlUnit/WlRootsControlUnitAPI.h
+++ b/include/MaaControlUnit/WlRootsControlUnitAPI.h
@@ -10,9 +10,9 @@ extern "C"
 
     MAA_CONTROL_UNIT_API const char* MaaWlRootsControlUnitGetVersion();
 
-    MAA_CONTROL_UNIT_API MaaControlUnitHandle MaaWlRootsControlUnitCreate(const char* wlr_socket_path);
+    MAA_CONTROL_UNIT_API MaaWlRootsControlUnitHandle MaaWlRootsControlUnitCreate(const char* wlr_socket_path);
 
-    MAA_CONTROL_UNIT_API void MaaWlRootsControlUnitDestroy(MaaControlUnitHandle handle);
+    MAA_CONTROL_UNIT_API void MaaWlRootsControlUnitDestroy(MaaWlRootsControlUnitHandle handle);
 
 #ifdef __cplusplus
 }

--- a/source/LibraryHolder/ControlUnit/ControlUnit.cpp
+++ b/source/LibraryHolder/ControlUnit/ControlUnit.cpp
@@ -328,7 +328,7 @@ std::shared_ptr<MAA_CTRL_UNIT_NS::FullControlUnitAPI>
     return std::shared_ptr<MAA_CTRL_UNIT_NS::FullControlUnitAPI>(control_unit_handle, destroy_control_unit_func);
 }
 
-std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> WlRootsControlUnitLibraryHolder::create_control_unit(const char* wlr_socket_path)
+std::shared_ptr<MAA_CTRL_UNIT_NS::WlRootsControlUnitAPI> WlRootsControlUnitLibraryHolder::create_control_unit(const char* wlr_socket_path)
 {
     if (!load_library(library_dir() / libname_)) {
         LogError << "Failed to load library" << VAR(library_dir()) << VAR(libname_);
@@ -356,7 +356,7 @@ std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> WlRootsControlUnitLibraryHolde
         return nullptr;
     }
 
-    return std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI>(control_unit_handle, destroy_control_unit_func);
+    return std::shared_ptr<MAA_CTRL_UNIT_NS::WlRootsControlUnitAPI>(control_unit_handle, destroy_control_unit_func);
 }
 
 std::shared_ptr<MAA_CTRL_UNIT_NS::MacOSControlUnitAPI> MacOSControlUnitLibraryHolder::create_control_unit(

--- a/source/MaaWlRootsControlUnit/API/WlRootsControlUnitAPI.cpp
+++ b/source/MaaWlRootsControlUnit/API/WlRootsControlUnitAPI.cpp
@@ -10,7 +10,7 @@ const char* MaaWlRootsControlUnitGetVersion()
     return MAA_VERSION;
 }
 
-MaaControlUnitHandle MaaWlRootsControlUnitCreate(const char* wlr_socket_path)
+MaaWlRootsControlUnitHandle MaaWlRootsControlUnitCreate(const char* wlr_socket_path)
 {
     using namespace MAA_CTRL_UNIT_NS;
 
@@ -25,7 +25,7 @@ MaaControlUnitHandle MaaWlRootsControlUnitCreate(const char* wlr_socket_path)
     return unit_mgr.release();
 }
 
-void MaaWlRootsControlUnitDestroy(MaaControlUnitHandle handle)
+void MaaWlRootsControlUnitDestroy(MaaWlRootsControlUnitHandle handle)
 {
     LogFunc << VAR_VOIDP(handle);
 

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.cpp
@@ -304,6 +304,18 @@ bool WaylandClient::pointer(EventPhase phase, int x, int y, int contact)
     return process_requests();
 }
 
+bool WaylandClient::relative_move(int dx, int dy)
+{
+    if (!connected_) {
+        return false;
+    }
+
+    const uint32_t event_time = WaylandHelper::get_ms();
+    zwlr_virtual_pointer_v1_motion(pointer_.get(), event_time, wl_fixed_from_int(dx), wl_fixed_from_int(dy));
+    zwlr_virtual_pointer_v1_frame(pointer_.get());
+    return process_requests();
+}
+
 bool WaylandClient::scroll(int dx, int dy) const
 {
     if (!connected_) {

--- a/source/MaaWlRootsControlUnit/Client/WaylandClient.h
+++ b/source/MaaWlRootsControlUnit/Client/WaylandClient.h
@@ -33,6 +33,7 @@ public:
 
     bool screencap(void** buffer, uint32_t& width, uint32_t& height, uint32_t& format);
     bool pointer(EventPhase phase, int x, int y, int contact);
+    bool relative_move(int dx, int dy);
     bool scroll(int dx, int dy) const;
     bool input_key(EventPhase phase, int key);
     bool input_str(const std::string& str);

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
@@ -229,6 +229,16 @@ bool WlRootsControlUnitMgr::key_up(int key)
     return client_->input_key(WaylandClient::EventPhase::Ended, key);
 }
 
+bool WlRootsControlUnitMgr::relative_move(int dx, int dy)
+{
+    if (!client_) {
+        LogError << "client_ is nullptr";
+        return false;
+    }
+
+    return client_->relative_move(dx, dy);
+}
+
 bool WlRootsControlUnitMgr::scroll(int dx, int dy)
 {
     if (!client_) {

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
@@ -15,8 +15,7 @@ MAA_CTRL_UNIT_NS_BEGIN
 class WaylandClient;
 
 class WlRootsControlUnitMgr
-    : public ControlUnitAPI
-    , public ScrollableUnit
+    : public WlRootsControlUnitAPI
 {
 public:
     WlRootsControlUnitMgr(std::filesystem::path wlr_socket_path);
@@ -47,6 +46,7 @@ public:
     virtual bool key_down(int key) override;
     virtual bool key_up(int key) override;
 
+    virtual bool relative_move(int dx, int dy) override;
     virtual bool scroll(int dx, int dy) override;
 
     virtual bool inactive() override;

--- a/source/include/LibraryHolder/ControlUnit.h
+++ b/source/include/LibraryHolder/ControlUnit.h
@@ -159,7 +159,7 @@ private:
 class WlRootsControlUnitLibraryHolder : public LibraryHolder<WlRootsControlUnitLibraryHolder>
 {
 public:
-    static std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> create_control_unit(const char* wlr_socket_path);
+    static std::shared_ptr<MAA_CTRL_UNIT_NS::WlRootsControlUnitAPI> create_control_unit(const char* wlr_socket_path);
 
 private:
     inline static const std::filesystem::path libname_ = MAA_NS::path("MaaWlRootsControlUnit");


### PR DESCRIPTION
## Summary by Sourcery

为 wlroots 控制单元添加相对指针移动支持，并收紧其类型化 API 表面。

新特性：
- 在 Wayland 客户端和 wlroots 控制单元管理器中引入相对指针移动处理。

增强改进：
- 定义专用的 `WlRootsControlUnitAPI` 接口和用于 wlroots 专用控制单元的句柄，并更新库持有者和 C API 以使用更具体的类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add relative pointer movement support to the wlroots control unit and tighten its typed API surface.

New Features:
- Introduce relative pointer movement handling in the Wayland client and wlroots control unit manager.

Enhancements:
- Define a dedicated WlRootsControlUnitAPI interface and handle for wlroots-specific control units, and update library holder and C API to use the more specific type.

</details>