### PR TITLE
refactor(wlroots): remove unused last_pos_ / has_clicked_ state

### DIFF
--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
@@ -159,6 +159,7 @@ bool WlRootsControlUnitMgr::touch_up(int contact)
         return false;
     }
 
+    // Ended phase only sends button release; WaylandClient ignores x/y. (0,0) is a placeholder.
     return client_->pointer(WaylandClient::EventPhase::Ended, 0, 0, contact);
 }
 

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
@@ -2,7 +2,6 @@
 
 #include <filesystem>
 #include <system_error>
-#include <utility>
 
 #include <opencv2/imgproc.hpp>
 
@@ -138,14 +137,7 @@ bool WlRootsControlUnitMgr::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
-    if (!client_->pointer(WaylandClient::EventPhase::Began, x, y, contact)) {
-        return false;
-    }
-
-    last_pos_ = { x, y };
-    has_clicked_ = true;
-
-    return true;
+    return client_->pointer(WaylandClient::EventPhase::Began, x, y, contact);
 }
 
 bool WlRootsControlUnitMgr::touch_move(int contact, int x, int y, int pressure)
@@ -157,14 +149,7 @@ bool WlRootsControlUnitMgr::touch_move(int contact, int x, int y, int pressure)
         return false;
     }
 
-    if (!client_->pointer(WaylandClient::EventPhase::Moved, x, y, contact)) {
-        return false;
-    }
-
-    last_pos_ = { x, y };
-    has_clicked_ = true;
-
-    return true;
+    return client_->pointer(WaylandClient::EventPhase::Moved, x, y, contact);
 }
 
 bool WlRootsControlUnitMgr::touch_up(int contact)
@@ -174,21 +159,7 @@ bool WlRootsControlUnitMgr::touch_up(int contact)
         return false;
     }
 
-    std::pair<int, int> up = { 0, 0 };
-    if (has_clicked_) {
-        up = last_pos_;
-    }
-    else {
-        auto [width, height] = client_->screen_size();
-        up = { width / 2, height / 2 };
-    }
-
-    if (!client_->pointer(WaylandClient::EventPhase::Ended, up.first, up.second, contact)) {
-        return false;
-    }
-
-    has_clicked_ = false;
-    return true;
+    return client_->pointer(WaylandClient::EventPhase::Ended, 0, 0, contact);
 }
 
 bool WlRootsControlUnitMgr::click_key(int key)

--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.h
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "MaaControlUnit/ControlUnitAPI.h"
 #include "MaaFramework/MaaDef.h"
@@ -55,8 +54,6 @@ public:
 private:
     std::unique_ptr<WaylandClient> client_;
     std::filesystem::path wlr_socket_path_;
-    std::pair<int, int> last_pos_ = { 0, 0 };
-    bool has_clicked_ = false;
 };
 
 MAA_CTRL_UNIT_NS_END


### PR DESCRIPTION
The Ended phase in WaylandClient::pointer only sends a button release and ignores coordinates. The framework guarantees position is already set via touch_down/touch_move before touch_up, so tracking last_pos_ served no purpose.

Made-with: Cursor

## Summary by Sourcery

通过移除未使用的指针位置跟踪，并将触摸事件直接委托给 Wayland 客户端，简化 Wayland 触摸处理。

增强内容：
- 从 `WlRootsControlUnitMgr` 的触摸处理逻辑中移除未使用的 `last_pos_` 和 `has_clicked_` 状态。
- 精简 `touch_down`、`touch_move` 和 `touch_up`，使其在不增加额外状态或坐标逻辑的前提下，直接将指针事件转发给 Wayland 客户端。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify Wayland touch handling by removing unused pointer position tracking and delegating touch events directly to the Wayland client.

Enhancements:
- Remove unused last_pos_ and has_clicked_ state from WlRootsControlUnitMgr touch handling.
- Streamline touch_down, touch_move, and touch_up to directly forward pointer events to the Wayland client without additional state or coordinate logic.

</details>