### PR TITLE
fix: batch OCR crash when inline sub_name conflicts with pipeline node

### DIFF
--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -358,21 +358,9 @@ std::optional<PipelineTask::BatchOCRPlan> PipelineTask::prepare_batch_ocr(const 
         collect_ocr_from_reco(ctx, data.name, data.reco_type, data.reco_param);
     }
 
-    if (ctx.plan.node_names.size() < 2) {
-        LogDebug << "batch OCR not needed, eligible OCR nodes < 2" << VAR(ctx.plan.node_names.size());
+    if (ctx.plan.entries.size() < 2) {
+        LogDebug << "batch OCR not needed, eligible OCR nodes < 2" << VAR(ctx.plan.entries.size());
         return std::nullopt;
-    }
-
-    for (const auto& name : ctx.plan.node_names) {
-        auto node_opt = context_->get_pipeline_data(name);
-        if (!node_opt) {
-            continue;
-        }
-        ctx.plan.entries.emplace_back(
-            BatchOCREntry {
-                .name = name,
-                .param = std::get<MAA_VISION_NS::OCRerParam>(node_opt->reco_param),
-            });
     }
 
     LogInfo << "prepared batch OCR plan" << VAR(ctx.plan.node_names) << VAR(ctx.plan.model);
@@ -410,6 +398,7 @@ void PipelineTask::try_add_ocr_node(OCRCollectContext& ctx, const std::string& n
     }
 
     ctx.plan.node_names.emplace(name);
+    ctx.plan.entries.emplace_back(BatchOCREntry { .name = name, .param = param });
 }
 
 void PipelineTask::collect_ocr_from_reco(

--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -397,8 +397,9 @@ void PipelineTask::try_add_ocr_node(OCRCollectContext& ctx, const std::string& n
         return;
     }
 
-    ctx.plan.node_names.emplace(name);
-    ctx.plan.entries.emplace_back(BatchOCREntry { .name = name, .param = param });
+    if (ctx.plan.node_names.emplace(name).second) {
+        ctx.plan.entries.emplace_back(BatchOCREntry { .name = name, .param = param });
+    }
 }
 
 void PipelineTask::collect_ocr_from_reco(


### PR DESCRIPTION
## Summary

- Fixes crash (`std::bad_variant_access` → `std::terminate`) when an `And`/`Or` sub-recognition's `sub_name` matches an existing pipeline node of a different type

## Root Cause

`prepare_batch_ocr` used a two-phase approach:
1. **Collect phase**: `try_add_ocr_node` stored OCR node **names** in `node_names` (using `sub_name` for inline subs)
2. **Build phase**: Loop over `node_names`, call `get_pipeline_data(name)`, and `std::get<OCRerParam>(node_opt->reco_param)`

For inline sub-recognitions inside `And`/`Or`, the `sub_name` is user-defined and doesn't necessarily correspond to an actual pipeline node. When `sub_name` happened to match a real pipeline node with a different recognition type (e.g. `ColorMatch`), `std::get<OCRerParam>` threw `std::bad_variant_access`, causing silent process termination.

## Fix

Build `BatchOCREntry` directly in `try_add_ocr_node` using the already-available `OCRerParam`, eliminating the second lookup via `get_pipeline_data`. This ensures the param always comes from the actual OCR recognition, not from a potentially mismatched pipeline node.

Closes #1268

## Summary by Sourcery

防止在行内 OCR 子识别名称与非 OCR 流水线节点名称冲突时导致批量 OCR 流水线崩溃，并在节点收集阶段直接构建批量 OCR 计划。

Bug 修复：
- 修复由于行内 OCR 子识别名称与已有非 OCR 流水线节点名称发生冲突而导致的批量 OCR 崩溃问题。

增强：
- 在收集阶段构建批量 OCR 条目，并使用收集到的条目列表来决定是否需要批量 OCR 计划，从而避免重复的流水线查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent batch OCR pipeline from crashing when inline OCR sub-recognition names collide with non-OCR pipeline nodes and build the batch OCR plan directly during node collection.

Bug Fixes:
- Fix batch OCR crash caused by inline OCR sub-recognition names colliding with existing non-OCR pipeline node names.

Enhancements:
- Construct batch OCR entries at collection time and use the collected entries list to decide whether a batch OCR plan is needed, avoiding redundant pipeline lookups.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

防止在行内 OCR 子识别名称与非 OCR 流水线节点名称冲突时导致批量 OCR 流水线崩溃，并在节点收集阶段直接构建批量 OCR 计划。

Bug 修复：
- 修复由于行内 OCR 子识别名称与已有非 OCR 流水线节点名称发生冲突而导致的批量 OCR 崩溃问题。

增强：
- 在收集阶段构建批量 OCR 条目，并使用收集到的条目列表来决定是否需要批量 OCR 计划，从而避免重复的流水线查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent batch OCR pipeline from crashing when inline OCR sub-recognition names collide with non-OCR pipeline nodes and build the batch OCR plan directly during node collection.

Bug Fixes:
- Fix batch OCR crash caused by inline OCR sub-recognition names colliding with existing non-OCR pipeline node names.

Enhancements:
- Construct batch OCR entries at collection time and use the collected entries list to decide whether a batch OCR plan is needed, avoiding redundant pipeline lookups.

</details>

</details>