### PR TITLE
fix: register And/Or sub-recognition results in runtime cache

### DIFF
--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -394,6 +394,13 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
             res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
         }
 
+        if (res.box.has_value() && !res.name.empty()) {
+            auto& cache = tasker_->runtime_cache();
+            auto sub_node_id = TaskBase::generate_node_id();
+            cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id });
+            cache.set_latest_node(res.name, sub_node_id);
+        }
+
         all_hit &= res.box.has_value();
         sub_results.emplace_back(std::move(res));
 
@@ -477,6 +484,14 @@ RecoResult Recognizer::or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrPara
         }
 
         has_hit = res.box.has_value();
+
+        if (has_hit && !res.name.empty()) {
+            auto& cache = tasker_->runtime_cache();
+            auto sub_node_id = TaskBase::generate_node_id();
+            cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id });
+            cache.set_latest_node(res.name, sub_node_id);
+        }
+
         sub_results.emplace_back(std::move(res));
 
         if (has_hit) {

--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -394,12 +394,7 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
             res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
         }
 
-        if (res.box.has_value() && !res.name.empty()) {
-            auto& cache = tasker_->runtime_cache();
-            auto sub_node_id = TaskBase::generate_node_id();
-            cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id });
-            cache.set_latest_node(res.name, sub_node_id);
-        }
+        register_sub_result_in_cache(res);
 
         all_hit &= res.box.has_value();
         sub_results.emplace_back(std::move(res));
@@ -484,14 +479,7 @@ RecoResult Recognizer::or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrPara
         }
 
         has_hit = res.box.has_value();
-
-        if (has_hit && !res.name.empty()) {
-            auto& cache = tasker_->runtime_cache();
-            auto sub_node_id = TaskBase::generate_node_id();
-            cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id });
-            cache.set_latest_node(res.name, sub_node_id);
-        }
-
+        register_sub_result_in_cache(res);
         sub_results.emplace_back(std::move(res));
 
         if (has_hit) {
@@ -624,6 +612,20 @@ void Recognizer::save_draws(const std::string& node_name, const RecoResult& resu
 {
     std::string name = std::format("{}_{}", node_name, result.reco_id);
     MAA_VISION_NS::VisionBase::save_draws(name, result.draws);
+}
+
+void Recognizer::register_sub_result_in_cache(const RecoResult& res)
+{
+    if (!res.box.has_value() || res.name.empty()) {
+        return;
+    }
+
+    auto& cache = tasker_->runtime_cache();
+    auto sub_node_id = TaskBase::generate_node_id();
+    cache.set_node_detail(
+        sub_node_id,
+        NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id, .completed = true });
+    cache.set_latest_node(res.name, sub_node_id);
 }
 
 bool Recognizer::debug_mode() const

--- a/source/MaaFramework/Task/Component/Recognizer.h
+++ b/source/MaaFramework/Task/Component/Recognizer.h
@@ -47,6 +47,7 @@ private:
     std::vector<cv::Rect> get_rois(const MAA_VISION_NS::Target& roi, bool use_best = false);
     std::vector<cv::Rect> get_rois_from_pretask(const std::string& name, bool use_best);
     void save_draws(const std::string& node_name, const RecoResult& result) const;
+    void register_sub_result_in_cache(const RecoResult& res);
 
 private:
     bool debug_mode() const;

--- a/source/MaaFramework/Task/TaskBase.h
+++ b/source/MaaFramework/Task/TaskBase.h
@@ -46,7 +46,7 @@ protected:
         std::shared_ptr<MAA_VISION_NS::OCRCache> ocr_cache = nullptr);
     ActionResult run_action(const RecoResult& reco, const PipelineData& data);
     cv::Mat screencap();
-    MaaNodeId generate_node_id();
+    static MaaNodeId generate_node_id();
     void set_node_detail(MaaNodeId node_id, NodeDetail detail);
     void set_task_detail(TaskDetail detail);
 

--- a/source/MaaFramework/Task/TaskBase.h
+++ b/source/MaaFramework/Task/TaskBase.h
@@ -34,6 +34,7 @@ public:
     Tasker* tasker() const;
     MaaTaskId task_id() const;
     const std::string& entry() const;
+    static MaaNodeId generate_node_id();
 
 protected:
     MAA_RES_NS::ResourceMgr* resource();
@@ -46,7 +47,6 @@ protected:
         std::shared_ptr<MAA_VISION_NS::OCRCache> ocr_cache = nullptr);
     ActionResult run_action(const RecoResult& reco, const PipelineData& data);
     cv::Mat screencap();
-    static MaaNodeId generate_node_id();
     void set_node_detail(MaaNodeId node_id, NodeDetail detail);
     void set_task_detail(TaskDetail detail);
 


### PR DESCRIPTION
## Summary

- Fixes Custom recognizers inside `And`/`Or` being unable to access sibling node recognition results via `roi` string references (PreTask/Anchor)

## Root Cause

`And`/`Or` sub-recognition results were only stored in two places:

1. **`sub_best_box_` / `sub_filtered_boxes_`** — shared among `Recognizer` copies within the same `And`/`Or`, but NOT accessible from a new `RecognitionTask`
2. **`reco_details_`** (by reco_id) — stored via `set_reco_detail` in `Recognizer::recognize()`, but not retrievable by **node name**

When a Custom recognizer called `context.run_reco()`, it created a new `RecognitionTask` → new `Recognizer` with empty `sub_best_box_`. The new recognizer's `get_rois_from_pretask("sibling_node")` then tried `runtime_cache().get_latest_node("sibling_node")`, which also failed because **no node detail or latest-node entry was ever registered** for `And`/`Or` sub-recognitions.

## Fix

After each successful sub-recognition in `and_()` / `or_()`, register a `NodeDetail` and `latest_node` entry in the runtime cache. This allows any subsequent `run_reco` call to find sibling results through the standard `get_latest_node(name)` → `get_node_detail(node_id)` → `get_reco_result(reco_id)` lookup chain.

Also made `TaskBase::generate_node_id()` `static` so `Recognizer` can use the shared node ID counter.

Closes #1267

## Summary by Sourcery

在运行时缓存中注册 And/Or 子节点的识别结果，以便同级识别器可以通过标准的节点查找方式访问这些结果。

Bug Fixes:
- 确保位于 And/Or 内部的自定义识别器可以通过运行时缓存中的 ROI 字符串引用，访问同级节点的识别结果。

Enhancements:
- 将成功的 And/Or 子识别结果记录为节点详细信息，并在运行时缓存中添加对应的 latest-node 条目。
- 将 `TaskBase::generate_node_id()` 暴露为静态方法，以便识别器可以为子识别结果创建节点 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Register recognition results of And/Or sub-nodes in the runtime cache so sibling recognizers can access them via standard node lookups.

Bug Fixes:
- Ensure Custom recognizers inside And/Or can access sibling node recognition results via runtime cache ROI string references.

Enhancements:
- Record successful And/Or sub-recognition results as node details with latest-node entries in the runtime cache.
- Expose TaskBase::generate_node_id() as a static method so recognizers can create node IDs for sub-recognition results.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在运行时缓存中注册 And/Or 子节点的识别结果，以便同级识别器可以通过标准的节点查找方式访问这些结果。

Bug Fixes:
- 确保位于 And/Or 内部的自定义识别器可以通过运行时缓存中的 ROI 字符串引用，访问同级节点的识别结果。

Enhancements:
- 将成功的 And/Or 子识别结果记录为节点详细信息，并在运行时缓存中添加对应的 latest-node 条目。
- 将 `TaskBase::generate_node_id()` 暴露为静态方法，以便识别器可以为子识别结果创建节点 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Register recognition results of And/Or sub-nodes in the runtime cache so sibling recognizers can access them via standard node lookups.

Bug Fixes:
- Ensure Custom recognizers inside And/Or can access sibling node recognition results via runtime cache ROI string references.

Enhancements:
- Record successful And/Or sub-recognition results as node details with latest-node entries in the runtime cache.
- Expose TaskBase::generate_node_id() as a static method so recognizers can create node IDs for sub-recognition results.

</details>

</details>