### PR TITLE
fix: skip screencap when all next nodes use DirectHit

### DIFF
--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -161,11 +161,16 @@ NodeDetail PipelineTask::run_next(const std::vector<MAA_RES_NS::NodeAttr>& next,
         return true;
     };
 
+    const bool need_screencap = !std::ranges::all_of(next, [&](const MAA_RES_NS::NodeAttr& node) {
+        auto data_opt = context_->get_pipeline_data(node);
+        return !data_opt || !data_opt->enabled || data_opt->reco_type == MAA_RES_NS::Recognition::Type::DirectHit;
+    });
+
     while (!context_->need_to_stop()) {
         auto current_clock = std::chrono::steady_clock::now();
-        cv::Mat image = screencap();
+        cv::Mat image = need_screencap ? screencap() : cv::Mat {};
 
-        if (image.empty()) {
+        if (need_screencap && image.empty()) {
             LogWarn << "screencap failed, skip recognition" << VAR(pretask.name);
             if (!check_timeout_and_sleep(current_clock)) {
                 break;


### PR DESCRIPTION
## Summary

- When all enabled nodes in the `next` list use `DirectHit` recognition, skip the `screencap()` call entirely
- `DirectHit` does not require image data — `correct_roi` already handles empty images gracefully
- This allows non-visual pipeline tasks (e.g. `Custom` actions like Kill Self / Sleep / Webhook) to execute even when the controller is disconnected or unavailable

## Background

Downstream projects like MXU (MaaEnd) use `DirectHit` + `Custom Action` for non-visual tasks such as process management, sleep, and notifications. When a preceding task disconnects the controller (e.g. killing the game process), subsequent `DirectHit` tasks would get stuck in the screencap-retry loop until timeout, even though they never need a screenshot.

Related: MaaEnd/MaaEnd#2109

## Test plan

- [ ] Verify normal pipeline execution with screenshot-dependent nodes (TemplateMatch, OCR, etc.) is unaffected
- [ ] Verify `DirectHit` + `Custom` action nodes work without a connected controller
- [ ] Verify mixed `next` lists (some DirectHit, some not) still require screencap

Made with [Cursor](https://cursor.com)

## Sourcery 总结

错误修复：
- 允许仅包含已启用 DirectHit 下一节点的管道在没有连接的控制器或未成功捕获截图的情况下继续运行。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 允许启用的后续节点全部使用 DirectHit 识别的流水线继续运行，即使未连接控制器或截图捕获失败。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 允许启用的后续节点全部使用 DirectHit 识别的流水线，在没有连接控制器或截图捕获不成功的情况下继续运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow pipelines whose enabled next nodes all use DirectHit recognition to continue without a connected controller or successful screenshot capture.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>