### PR TITLE
feat: 支持腾讯应用宝

### DIFF
--- a/docs/en_us/2.4-ControlMethods.md
+++ b/docs/en_us/2.4-ControlMethods.md
@@ -24,7 +24,7 @@ By default, all methods except EmulatorExtras are attempted.
 | AdbShell | `1` | Slow | High | |
 | MinitouchAndAdbKey | `2` | Fast | Medium | Key input still uses AdbShell |
 | Maatouch | `4` | Fast | Medium | |
-| EmulatorExtras | `8` | Fast | Low | Only supports emulators: MuMu 12 |
+| EmulatorExtras | `8` | Fast | Low | Only supports emulators: MuMu 12, Tencent App Store (应用宝) |
 
 ### Adb Screencap
 
@@ -44,7 +44,7 @@ By default, all methods except `RawByNetcat`, `MinicapDirect`, and `MinicapStrea
 | RawByNetcat | `8` | Fast | Low | Lossless | |
 | MinicapDirect | `16` | Fast | Low | Lossy | |
 | MinicapStream | `32` | Very Fast | Low | Lossy | |
-| EmulatorExtras | `64` | Very Fast | Low | Lossless | Only supports emulators: MuMu 12, LDPlayer 9, and AVD |
+| EmulatorExtras | `64` | Very Fast | Low | Lossless | Only supports emulators: MuMu 12, LDPlayer 9, AVD, and Tencent App Store (应用宝) |
 
 ## Android Native
 

--- a/docs/zh_cn/2.4-控制方式说明.md
+++ b/docs/zh_cn/2.4-控制方式说明.md
@@ -24,7 +24,7 @@
 | AdbShell | `1` | 慢 | 高 | |
 | MinitouchAndAdbKey | `2` | 快 | 中 | 按键仍使用 AdbShell |
 | Maatouch | `4` | 快 | 中 | |
-| EmulatorExtras | `8` | 快 | 低 | 仅支持模拟器：MuMu 12 |
+| EmulatorExtras | `8` | 快 | 低 | 仅支持模拟器：MuMu 12、腾讯应用宝 |
 
 ### Adb Screencap
 
@@ -44,7 +44,7 @@
 | RawByNetcat | `8` | 快 | 低 | 无损 | |
 | MinicapDirect | `16` | 快 | 低 | 有损 | |
 | MinicapStream | `32` | 极快 | 低 | 有损 | |
-| EmulatorExtras | `64` | 极快 | 低 | 无损 | 仅支持模拟器：MuMu 12、雷电 9、AVD |
+| EmulatorExtras | `64` | 极快 | 低 | 无损 | 仅支持模拟器：MuMu 12、雷电 9、AVD、腾讯应用宝 |
 
 ## Android Native
 

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
@@ -2,6 +2,7 @@
 
 #include "AndrowsExtras.h"
 
+#include <charconv>
 #include <cmath>
 #include <format>
 #include <sstream>
@@ -116,6 +117,11 @@ bool AndrowsExtras::request_display_info()
         return MtouchHelper::request_display_info();
     }
 
+    auto trim = [](std::string_view s) {
+        while (!s.empty() && s.front() == ' ') s.remove_prefix(1);
+        while (!s.empty() && s.back() == ' ') s.remove_suffix(1);
+        return s;
+    };
     // Parse width and height from output (take the last "WxH" pattern to prefer Override size)
     int w = 0;
     int h = 0;
@@ -127,26 +133,16 @@ bool AndrowsExtras::request_display_info()
             continue;
         }
         std::string value_part = line.substr(pos + 1);
-        int tw = 0, th = 0;
         auto xpos = value_part.find('x');
         if (xpos == std::string::npos) {
             continue;
         }
-        try {
-            // trim spaces before parsing
-            std::string ws = value_part.substr(0, xpos);
-            std::string hs = value_part.substr(xpos + 1);
-            // remove leading/trailing spaces
-            auto trim = [](std::string& s) {
-                while (!s.empty() && s.front() == ' ') s.erase(s.begin());
-                while (!s.empty() && s.back() == ' ') s.pop_back();
-            };
-            trim(ws);
-            trim(hs);
-            tw = std::stoi(ws);
-            th = std::stoi(hs);
-        }
-        catch (...) {
+        auto ws = trim(std::string_view(value_part.data(), xpos));
+        auto hs = trim(std::string_view(value_part.data() + xpos + 1, value_part.size() - xpos - 1));
+        int tw = 0, th = 0;
+        auto [p1, ec1] = std::from_chars(ws.data(), ws.data() + ws.size(), tw);
+        auto [p2, ec2] = std::from_chars(hs.data(), hs.data() + hs.size(), th);
+        if (ec1 != std::errc() || ec2 != std::errc()) {
             continue;
         }
         if (tw > 0 && th > 0) {

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
@@ -2,26 +2,25 @@
 
 #include "AndrowsExtras.h"
 
-#include <array>
 #include <cmath>
 #include <format>
-#include <ranges>
 #include <sstream>
 
 #include "MaaUtils/Logger.h"
 #include "MaaUtils/NoWarningCV.hpp"
-#include "MaaUtils/Platform.h"
 
 MAA_CTRL_UNIT_NS_BEGIN
 
 AndrowsExtras::AndrowsExtras(std::filesystem::path agent_path)
-    : agent_path_(std::move(agent_path))
 {
+    agent_path_ = std::move(agent_path);
     // Only register invoke_app_ / adb_shell_input_ into children_ when we actually
     // need the input pathway (agent_path_ non-empty). For screencap-only instances
     // these sub-objects stay idle and should not participate in parse/init/replacement
     // propagation.
     if (!agent_path_.empty()) {
+        invoke_app_ = std::make_shared<InvokeApp>();
+        adb_shell_input_ = std::make_shared<AdbShellInput>();
         children_.emplace_back(invoke_app_);
         children_.emplace_back(adb_shell_input_);
     }
@@ -57,16 +56,7 @@ bool AndrowsExtras::parse(const json::value& config)
               && parse_command("ScreencapEncode", config, kScreencapEncodeArgv, screencap_encode_argv_);
 
     if (ok && !agent_path_.empty()) {
-        static const json::array kDefaultArch = {
-            "x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi",
-        };
-        json::array jarch = config.get("prebuilt", "minitouch", "arch", kDefaultArch);
-        if (!jarch.all<std::string>()) {
-            return false;
-        }
-        arch_list_ = jarch.as<std::vector<std::string>>();
-
-        ok = invoke_app_->parse(config) && MtouchHelper::parse(config) && adb_shell_input_->parse(config);
+        ok = parse_minitouch_config(config);
     }
 
     return ok;
@@ -176,51 +166,6 @@ bool AndrowsExtras::request_display_info()
 
     LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_);
     return true;
-}
-
-MaaControllerFeature AndrowsExtras::get_features() const
-{
-    MaaControllerFeature feat = MaaControllerFeature_UseMouseDownAndUpInsteadOfClick;
-    if (adb_shell_input_) {
-        feat |= adb_shell_input_->get_features() & MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
-    }
-    return feat;
-}
-
-bool AndrowsExtras::click_key(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-    return adb_shell_input_->click_key(key);
-}
-
-bool AndrowsExtras::input_text(const std::string& text)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-    return adb_shell_input_->input_text(text);
-}
-
-bool AndrowsExtras::key_down(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-    return adb_shell_input_->key_down(key);
-}
-
-bool AndrowsExtras::key_up(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-    return adb_shell_input_->key_up(key);
 }
 
 void AndrowsExtras::on_app_started(const std::string& intent)
@@ -341,28 +286,7 @@ bool AndrowsExtras::query_event_id()
 
 bool AndrowsExtras::init_minitouch()
 {
-    if (!invoke_app_->init()) {
-        return false;
-    }
-
-    auto archs = invoke_app_->abilist();
-    if (!archs) {
-        return false;
-    }
-
-    auto arch_iter = std::ranges::find_first_of(*archs, arch_list_);
-    if (arch_iter == archs->end()) {
-        LogError << "Androws: no matching arch for minitouch" << VAR(*archs) << VAR(arch_list_);
-        return false;
-    }
-    const std::string& target_arch = *arch_iter;
-
-    const auto bin_path = agent_path_ / path(target_arch) / path("minitouch");
-    if (!invoke_app_->push(bin_path)) {
-        return false;
-    }
-
-    if (!invoke_app_->chmod()) {
+    if (!push_minitouch()) {
         return false;
     }
 
@@ -390,12 +314,6 @@ bool AndrowsExtras::reinvoke_minitouch()
     }
 
     return read_info();
-}
-
-void AndrowsExtras::remove_binary()
-{
-    LogTrace;
-    invoke_app_->remove();
 }
 
 std::optional<std::string> AndrowsExtras::adb_shell(const std::string& cmd)

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
@@ -1,0 +1,428 @@
+#ifndef __ANDROID__
+
+#include "AndrowsExtras.h"
+
+#include <array>
+#include <cmath>
+#include <format>
+#include <ranges>
+#include <sstream>
+
+#include "MaaUtils/Logger.h"
+#include "MaaUtils/NoWarningCV.hpp"
+#include "MaaUtils/Platform.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+AndrowsExtras::AndrowsExtras(std::filesystem::path agent_path)
+    : agent_path_(std::move(agent_path))
+{
+    // Only register invoke_app_ / adb_shell_input_ into children_ when we actually
+    // need the input pathway (agent_path_ non-empty). For screencap-only instances
+    // these sub-objects stay idle and should not participate in parse/init/replacement
+    // propagation.
+    if (!agent_path_.empty()) {
+        children_.emplace_back(invoke_app_);
+        children_.emplace_back(adb_shell_input_);
+    }
+}
+
+AndrowsExtras::~AndrowsExtras()
+{
+    remove_binary();
+}
+
+bool AndrowsExtras::parse(const json::value& config)
+{
+    bool enable = config.get("extras", "androws", "enable", false);
+    if (!enable) {
+        LogInfo << "extras.androws.enable is false, ignore";
+        return false;
+    }
+
+    app_package_ = config.get("extras", "androws", "app_package", std::string {});
+    LogInfo << VAR(app_package_);
+
+    // ADB shell command generator: {ADB} -s {ADB_SERIAL} shell {ANDROWS_SHELL_CMD}
+    static const json::array kAdbShellArgv = {
+        "{ADB}", "-s", "{ADB_SERIAL}", "shell", "{ANDROWS_SHELL_CMD}",
+    };
+
+    // Screencap using logical display ID directly
+    static const json::array kScreencapEncodeArgv = {
+        "{ADB}", "-s", "{ADB_SERIAL}", "exec-out", "screencap -d {ANDROWS_DISPLAY_ID} -p",
+    };
+
+    bool ok = parse_command("AndrowsShell", config, kAdbShellArgv, adb_shell_argv_)
+              && parse_command("ScreencapEncode", config, kScreencapEncodeArgv, screencap_encode_argv_);
+
+    if (ok && !agent_path_.empty()) {
+        static const json::array kDefaultArch = {
+            "x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi",
+        };
+        json::array jarch = config.get("prebuilt", "minitouch", "arch", kDefaultArch);
+        if (!jarch.all<std::string>()) {
+            return false;
+        }
+        arch_list_ = jarch.as<std::vector<std::string>>();
+
+        ok = invoke_app_->parse(config) && MtouchHelper::parse(config) && adb_shell_input_->parse(config);
+    }
+
+    return ok;
+}
+
+bool AndrowsExtras::init()
+{
+    if (!query_display_id()) {
+        return false;
+    }
+
+    // If no agent_path is provided, this instance is screencap-only; skip minitouch setup.
+    if (agent_path_.empty()) {
+        return true;
+    }
+
+    if (!query_event_id()) {
+        return false;
+    }
+    return init_minitouch();
+}
+
+std::optional<cv::Mat> AndrowsExtras::screencap()
+{
+    if (display_id_.empty() && !query_display_id()) {
+        LogError << "Androws: display ID not available";
+        return std::nullopt;
+    }
+
+    auto argv_opt = screencap_encode_argv_.gen(argv_replace_);
+    if (!argv_opt) {
+        LogError << "Androws: failed to generate screencap encode argv";
+        return std::nullopt;
+    }
+
+    auto output_opt = startup_and_read_pipe(*argv_opt);
+    if (!output_opt) {
+        LogWarn << "Androws: screencap encode failed";
+        return std::nullopt;
+    }
+
+    return screencap_helper_.process_data(*output_opt, ScreencapHelper::decode_png);
+}
+
+bool AndrowsExtras::request_display_info()
+{
+    if (display_id_.empty() && !query_display_id()) {
+        LogError << "Androws: display_id_ is empty, cannot query display size";
+        return false;
+    }
+
+    // Query virtual display resolution: wm size -d {display_id}
+    // Output format: "Physical size: 1280x720" (may also have "Override size: ...")
+    auto output = adb_shell(std::format("wm size -d {}", display_id_));
+    if (!output || output->empty()) {
+        LogWarn << "Androws: wm size -d failed, falling back to default display info";
+        return MtouchHelper::request_display_info();
+    }
+
+    // Parse width and height from output (take the last "WxH" pattern to prefer Override size)
+    int w = 0;
+    int h = 0;
+    std::istringstream iss(*output);
+    std::string line;
+    while (std::getline(iss, line)) {
+        auto pos = line.find(':');
+        if (pos == std::string::npos) {
+            continue;
+        }
+        std::string value_part = line.substr(pos + 1);
+        int tw = 0, th = 0;
+        auto xpos = value_part.find('x');
+        if (xpos == std::string::npos) {
+            continue;
+        }
+        try {
+            // trim spaces before parsing
+            std::string ws = value_part.substr(0, xpos);
+            std::string hs = value_part.substr(xpos + 1);
+            // remove leading/trailing spaces
+            auto trim = [](std::string& s) {
+                while (!s.empty() && s.front() == ' ') s.erase(s.begin());
+                while (!s.empty() && s.back() == ' ') s.pop_back();
+            };
+            trim(ws);
+            trim(hs);
+            tw = std::stoi(ws);
+            th = std::stoi(hs);
+        }
+        catch (...) {
+            continue;
+        }
+        if (tw > 0 && th > 0) {
+            w = tw;
+            h = th;
+        }
+    }
+
+    if (w <= 0 || h <= 0) {
+        LogWarn << "Androws: failed to parse wm size output" << VAR(*output);
+        return MtouchHelper::request_display_info();
+    }
+
+    display_width_ = w;
+    display_height_ = h;
+    orientation_ = 0; // Androws virtual display has no rotation
+
+    LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_);
+    return true;
+}
+
+MaaControllerFeature AndrowsExtras::get_features() const
+{
+    MaaControllerFeature feat = MaaControllerFeature_UseMouseDownAndUpInsteadOfClick;
+    if (adb_shell_input_) {
+        feat |= adb_shell_input_->get_features() & MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
+    }
+    return feat;
+}
+
+bool AndrowsExtras::click_key(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->click_key(key);
+}
+
+bool AndrowsExtras::input_text(const std::string& text)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->input_text(text);
+}
+
+bool AndrowsExtras::key_down(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->key_down(key);
+}
+
+bool AndrowsExtras::key_up(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->key_up(key);
+}
+
+void AndrowsExtras::on_app_started(const std::string& intent)
+{
+    std::string package = intent;
+    auto slash = intent.find('/');
+    if (slash != std::string::npos) {
+        package = intent.substr(0, slash);
+    }
+
+    if (!app_package_.empty() && package != app_package_) {
+        LogInfo << "app_package changed" << VAR(app_package_) << VAR(package);
+    }
+
+    app_package_ = package;
+    clear_display_id_cache();
+    query_display_id();
+
+    if (!agent_path_.empty()) {
+        query_event_id();
+        // App switch: display/event may have changed but the minitouch binary is
+        // already pushed; only re-invoke it to refresh the connection.
+        reinvoke_minitouch();
+    }
+}
+
+void AndrowsExtras::on_app_stopped(const std::string& intent)
+{
+    std::ignore = intent;
+    clear_display_id_cache();
+}
+
+void AndrowsExtras::on_image_resolution_changed(const std::pair<int, int>& pre, const std::pair<int, int>& cur)
+{
+    std::ignore = pre;
+    std::ignore = cur;
+
+    // Resolution change may imply a display switch; invalidate cached display_id
+    // and re-query it (needed for both screencap and input paths).
+    clear_display_id_cache();
+    query_display_id();
+
+    // Input-side: also re-query event_id and reinvoke minitouch to refresh touch info.
+    if (!agent_path_.empty()) {
+        query_event_id();
+        reinvoke_minitouch();
+    }
+}
+
+bool AndrowsExtras::query_display_id()
+{
+    if (!display_id_.empty()) {
+        return true;
+    }
+
+    std::optional<std::string> display_output;
+
+    if (!app_package_.empty()) {
+        display_output = adb_shell(
+            "dumpsys activity activities | grep -A2 " + app_package_
+            + " | grep mDisplayId | grep -o 'mDisplayId=[0-9]*' | head -1 | grep -o '[0-9]*'");
+    }
+
+    if (!display_output || display_output->empty()) {
+        LogWarn << "Androws: failed to get display ID by package, falling back to second display";
+        display_output = adb_shell("dumpsys display | grep -o 'mDisplayId=[0-9]*' | head -2 | tail -1 | grep -o '[0-9]*'");
+    }
+
+    if (!display_output || display_output->empty()) {
+        LogError << "Androws: failed to get display ID";
+        return false;
+    }
+
+    display_id_ = *display_output;
+    LogInfo << "Androws" << VAR(display_id_);
+
+    argv_replace_["{ANDROWS_DISPLAY_ID}"] = display_id_;
+    return true;
+}
+
+void AndrowsExtras::clear_display_id_cache()
+{
+    display_id_.clear();
+    event_id_.clear();
+    argv_replace_.erase("{ANDROWS_DISPLAY_ID}");
+}
+
+bool AndrowsExtras::query_event_id()
+{
+    if (!event_id_.empty()) {
+        return true;
+    }
+
+    if (display_id_.empty()) {
+        LogError << "Androws: display_id_ is empty, cannot query event_id";
+        return false;
+    }
+
+    // Find the EventHub device ID associated with the virtual display,
+    // then resolve its /dev/input/eventN path.
+    // Reference: MaaAssistantArknights config.json eventId command
+    const std::string cmd = std::format(
+        "EH_ID=$(dumpsys input | grep -E 'EventHub Devices:|Viewport.*displayId={0},' "
+        "| grep -B1 'displayId={0},' | grep EventHub | head -1 | sed 's/.*\\[ *//;s/ *\\].*//'); "
+        "dumpsys input | grep \"    ${{EH_ID}}: \" -A2 | grep Path | head -1 | sed 's/.*event//'",
+        display_id_);
+
+    auto output = adb_shell(cmd);
+    if (!output || output->empty()) {
+        LogError << "Androws: failed to query event_id for display_id:" << display_id_;
+        return false;
+    }
+
+    event_id_ = *output;
+    LogInfo << "Androws" << VAR(event_id_);
+    return true;
+}
+
+bool AndrowsExtras::init_minitouch()
+{
+    if (!invoke_app_->init()) {
+        return false;
+    }
+
+    auto archs = invoke_app_->abilist();
+    if (!archs) {
+        return false;
+    }
+
+    auto arch_iter = std::ranges::find_first_of(*archs, arch_list_);
+    if (arch_iter == archs->end()) {
+        LogError << "Androws: no matching arch for minitouch" << VAR(*archs) << VAR(arch_list_);
+        return false;
+    }
+    const std::string& target_arch = *arch_iter;
+
+    const auto bin_path = agent_path_ / path(target_arch) / path("minitouch");
+    if (!invoke_app_->push(bin_path)) {
+        return false;
+    }
+
+    if (!invoke_app_->chmod()) {
+        return false;
+    }
+
+    const std::string extra = std::format("-i -d /dev/input/event{}", event_id_);
+    pipe_ios_ = invoke_app_->invoke_bin(extra);
+    if (!pipe_ios_) {
+        return false;
+    }
+
+    return read_info();
+}
+
+bool AndrowsExtras::reinvoke_minitouch()
+{
+    if (event_id_.empty()) {
+        LogWarn << "Androws: event_id_ is empty, skip reinvoke";
+        return false;
+    }
+
+    const std::string extra = std::format("-i -d /dev/input/event{}", event_id_);
+    pipe_ios_ = invoke_app_->invoke_bin(extra);
+    if (!pipe_ios_) {
+        LogError << "Androws: failed to reinvoke minitouch";
+        return false;
+    }
+
+    return read_info();
+}
+
+void AndrowsExtras::remove_binary()
+{
+    LogTrace;
+    invoke_app_->remove();
+}
+
+std::optional<std::string> AndrowsExtras::adb_shell(const std::string& cmd)
+{
+    argv_replace_["{ANDROWS_SHELL_CMD}"] = cmd;
+
+    auto argv_opt = adb_shell_argv_.gen(argv_replace_);
+    argv_replace_.erase("{ANDROWS_SHELL_CMD}");
+
+    if (!argv_opt) {
+        LogError << "Androws: failed to generate adb shell argv for cmd:" << cmd;
+        return std::nullopt;
+    }
+
+    auto output_opt = startup_and_read_pipe(*argv_opt);
+    if (!output_opt) {
+        return std::nullopt;
+    }
+
+    std::string& output = *output_opt;
+    while (!output.empty() && (output.back() == '\n' || output.back() == '\r' || output.back() == ' ')) {
+        output.pop_back();
+    }
+
+    return output;
+}
+
+MAA_CTRL_UNIT_NS_END
+
+#endif

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.h
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#ifndef __ANDROID__
+
+#include "Base/UnitBase.h"
+#include "Input/AdbShellInput.h"
+#include "Input/MtouchHelper.h"
+#include "Invoke/InvokeApp.h"
+#include "MaaUtils/NoWarningCVMat.hpp"
+
+#include <filesystem>
+#include <optional>
+#include <string>
+
+#include "Common/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+// AndrowsExtras handles Androws (Tencent) emulator's virtual display.
+// It dynamically queries the logical display ID via ADB shell at runtime,
+// using the app package name to find the correct display.
+// For touch input, it uses minitouch with a specific input device node
+// that corresponds to the virtual display.
+class AndrowsExtras
+    : public ScreencapBase
+    , public MtouchHelper
+{
+public:
+    // agent_path: path to the minitouch agent directory.
+    // Pass empty path (default) when only screencap functionality is needed.
+    explicit AndrowsExtras(std::filesystem::path agent_path = {});
+
+    virtual ~AndrowsExtras() override;
+
+public: // from UnitBase
+    virtual bool parse(const json::value& config) override;
+
+public: // from ScreencapBase
+    virtual bool init() override;
+    virtual std::optional<cv::Mat> screencap() override;
+
+public: // from InputBase (via MtouchHelper)
+    virtual MaaControllerFeature get_features() const override;
+
+    virtual bool click_key(int key) override;
+    virtual bool input_text(const std::string& text) override;
+
+    virtual bool key_down(int key) override;
+    virtual bool key_up(int key) override;
+
+public: // from ControlUnitSink
+    virtual void on_app_started(const std::string& intent) override;
+    virtual void on_app_stopped(const std::string& intent) override;
+    virtual void on_image_resolution_changed(const std::pair<int, int>& pre, const std::pair<int, int>& cur) override;
+
+protected: // from MtouchHelper
+    virtual bool request_display_info() override;
+    virtual std::pair<int, int> screen_to_touch(int x, int y) override { return _screen_to_touch(x, y); }
+    virtual std::pair<int, int> screen_to_touch(double x, double y) override { return _screen_to_touch(x, y); }
+
+private:
+    template <typename T1, typename T2>
+    inline std::pair<int, int> _screen_to_touch(T1 x, T2 y)
+    {
+        auto make_pair = [](double x, double y) {
+            return std::make_pair(static_cast<int>(round(x)), static_cast<int>(round(y)));
+        };
+        switch (orientation_) {
+        case 0:
+            return make_pair(x * xscale_, y * yscale_);
+        case 1:
+            return make_pair(touch_height_ - y * yscale_, x * xscale_);
+        case 2:
+            return make_pair(touch_width_ - x * xscale_, touch_height_ - y * yscale_);
+        case 3:
+            return make_pair(y * yscale_, touch_width_ - x * xscale_);
+        default:
+            return make_pair(x * xscale_, y * yscale_);
+        }
+    }
+
+    // Query logical display_id via ADB shell, cache result.
+    // Returns true if display ID was successfully resolved.
+    bool query_display_id();
+    void clear_display_id_cache();
+
+    // Query the input event device ID for the virtual display.
+    bool query_event_id();
+
+    // Push, chmod and invoke minitouch with the resolved event device.
+    bool init_minitouch();
+    // Reinvoke the already-pushed minitouch without re-pushing the binary.
+    // Used when app/display/resolution changes but the binary has not changed.
+    bool reinvoke_minitouch();
+    void remove_binary();
+
+    // Execute an ADB shell command and return the trimmed output.
+    std::optional<std::string> adb_shell(const std::string& cmd);
+
+    std::filesystem::path agent_path_;
+    std::vector<std::string> arch_list_;
+
+    std::string app_package_;
+
+    // Cached display IDs (empty = not yet queried or query failed)
+    std::string display_id_;
+    std::string event_id_;
+
+    // ADB command generators for screencap
+    ProcessArgvGenerator screencap_encode_argv_;
+
+    // ADB shell command generator (used to query display/event IDs)
+    ProcessArgvGenerator adb_shell_argv_;
+
+    std::shared_ptr<InvokeApp> invoke_app_ = std::make_shared<InvokeApp>();
+    std::shared_ptr<AdbShellInput> adb_shell_input_ = std::make_shared<AdbShellInput>();
+};
+
+MAA_CTRL_UNIT_NS_END
+
+#endif

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.h
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.h
@@ -3,12 +3,9 @@
 #ifndef __ANDROID__
 
 #include "Base/UnitBase.h"
-#include "Input/AdbShellInput.h"
 #include "Input/MtouchHelper.h"
-#include "Invoke/InvokeApp.h"
 #include "MaaUtils/NoWarningCVMat.hpp"
 
-#include <filesystem>
 #include <optional>
 #include <string>
 
@@ -39,15 +36,6 @@ public: // from ScreencapBase
     virtual bool init() override;
     virtual std::optional<cv::Mat> screencap() override;
 
-public: // from InputBase (via MtouchHelper)
-    virtual MaaControllerFeature get_features() const override;
-
-    virtual bool click_key(int key) override;
-    virtual bool input_text(const std::string& text) override;
-
-    virtual bool key_down(int key) override;
-    virtual bool key_up(int key) override;
-
 public: // from ControlUnitSink
     virtual void on_app_started(const std::string& intent) override;
     virtual void on_app_stopped(const std::string& intent) override;
@@ -55,30 +43,8 @@ public: // from ControlUnitSink
 
 protected: // from MtouchHelper
     virtual bool request_display_info() override;
-    virtual std::pair<int, int> screen_to_touch(int x, int y) override { return _screen_to_touch(x, y); }
-    virtual std::pair<int, int> screen_to_touch(double x, double y) override { return _screen_to_touch(x, y); }
 
 private:
-    template <typename T1, typename T2>
-    inline std::pair<int, int> _screen_to_touch(T1 x, T2 y)
-    {
-        auto make_pair = [](double x, double y) {
-            return std::make_pair(static_cast<int>(round(x)), static_cast<int>(round(y)));
-        };
-        switch (orientation_) {
-        case 0:
-            return make_pair(x * xscale_, y * yscale_);
-        case 1:
-            return make_pair(touch_height_ - y * yscale_, x * xscale_);
-        case 2:
-            return make_pair(touch_width_ - x * xscale_, touch_height_ - y * yscale_);
-        case 3:
-            return make_pair(y * yscale_, touch_width_ - x * xscale_);
-        default:
-            return make_pair(x * xscale_, y * yscale_);
-        }
-    }
-
     // Query logical display_id via ADB shell, cache result.
     // Returns true if display ID was successfully resolved.
     bool query_display_id();
@@ -92,13 +58,9 @@ private:
     // Reinvoke the already-pushed minitouch without re-pushing the binary.
     // Used when app/display/resolution changes but the binary has not changed.
     bool reinvoke_minitouch();
-    void remove_binary();
 
     // Execute an ADB shell command and return the trimmed output.
     std::optional<std::string> adb_shell(const std::string& cmd);
-
-    std::filesystem::path agent_path_;
-    std::vector<std::string> arch_list_;
 
     std::string app_package_;
 
@@ -111,9 +73,6 @@ private:
 
     // ADB shell command generator (used to query display/event IDs)
     ProcessArgvGenerator adb_shell_argv_;
-
-    std::shared_ptr<InvokeApp> invoke_app_ = std::make_shared<InvokeApp>();
-    std::shared_ptr<AdbShellInput> adb_shell_input_ = std::make_shared<AdbShellInput>();
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/Input/MaatouchInput.cpp
+++ b/source/MaaAdbControlUnit/Input/MaatouchInput.cpp
@@ -1,12 +1,9 @@
 #include "MaatouchInput.h"
 
-#include <array>
 #include <cmath>
 #include <format>
-#include <ranges>
 
 #include "MaaUtils/Logger.h"
-#include "MaaUtils/Platform.h"
 
 MAA_CTRL_UNIT_NS_BEGIN
 
@@ -140,13 +137,6 @@ bool MaatouchInput::invoke_and_read_info()
     }
 
     return read_info();
-}
-
-void MaatouchInput::remove_binary()
-{
-    LogTrace;
-
-    invoke_app_->remove();
 }
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/Input/MaatouchInput.h
+++ b/source/MaaAdbControlUnit/Input/MaatouchInput.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <filesystem>
-
-#include "Base/UnitBase.h"
-#include "Invoke/InvokeApp.h"
 #include "MtouchHelper.h"
 
 #include "Common/Conf.h"
@@ -14,8 +10,9 @@ class MaatouchInput : public MtouchHelper
 {
 public:
     explicit MaatouchInput(std::filesystem::path agent_path)
-        : agent_path_(std::move(agent_path))
     {
+        agent_path_ = std::move(agent_path);
+        invoke_app_ = std::make_shared<InvokeApp>();
         children_.emplace_back(invoke_app_);
     }
 
@@ -39,23 +36,20 @@ public: // from ControlUnitSink
     virtual void on_image_resolution_changed(const std::pair<int, int>& pre, const std::pair<int, int>& cur) override;
 
 protected: // from MtouchHelper
-    virtual std::pair<int, int> screen_to_touch(int x, int y) override { return _screen_to_touch(x, y); }
+    virtual std::pair<int, int> screen_to_touch(int x, int y) override { return screen_to_touch_no_orient(x, y); }
 
-    virtual std::pair<int, int> screen_to_touch(double x, double y) override { return _screen_to_touch(x, y); }
+    virtual std::pair<int, int> screen_to_touch(double x, double y) override { return screen_to_touch_no_orient(x, y); }
 
 private:
     template <typename T1, typename T2>
-    inline std::pair<int, int> _screen_to_touch(T1 x, T2 y)
+    inline std::pair<int, int> screen_to_touch_no_orient(T1 x, T2 y)
     {
         return std::make_pair(static_cast<int>(round(x * xscale_)), static_cast<int>(round(y * yscale_)));
     }
 
     bool invoke_and_read_info();
-    void remove_binary();
 
-    std::filesystem::path agent_path_;
     std::string package_name_;
-    std::shared_ptr<InvokeApp> invoke_app_ = std::make_shared<InvokeApp>();
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/Input/MinitouchInput.cpp
+++ b/source/MaaAdbControlUnit/Input/MinitouchInput.cpp
@@ -1,12 +1,6 @@
 #include "MinitouchInput.h"
 
-#include <array>
-#include <cmath>
-#include <format>
-#include <ranges>
-
 #include "MaaUtils/Logger.h"
-#include "MaaUtils/Platform.h"
 
 MAA_CTRL_UNIT_NS_BEGIN
 
@@ -17,99 +11,18 @@ MinitouchInput::~MinitouchInput()
 
 bool MinitouchInput::parse(const json::value& config)
 {
-    static const json::array kDefaultArch = {
-        "x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi",
-    };
-    json::array jarch = config.get("prebuilt", "minitouch", "arch", kDefaultArch);
-
-    if (!jarch.all<std::string>()) {
-        return false;
-    }
-
-    arch_list_ = jarch.as<std::vector<std::string>>();
-
-    return invoke_app_->parse(config) && MtouchHelper::parse(config) && adb_shell_input_->parse(config);
+    return parse_minitouch_config(config);
 }
 
 bool MinitouchInput::init()
 {
     LogFunc;
 
-    if (!invoke_app_->init()) {
-        return false;
-    }
-
-    auto archs = invoke_app_->abilist();
-
-    if (!archs) {
-        return false;
-    }
-
-    auto arch_iter = std::ranges::find_first_of(*archs, arch_list_);
-    if (arch_iter == archs->end()) {
-        return false;
-    }
-    const std::string& target_arch = *arch_iter;
-
-    const auto bin_path = agent_path_ / path(target_arch) / path("minitouch");
-    if (!invoke_app_->push(bin_path)) {
-        return false;
-    }
-
-    if (!invoke_app_->chmod()) {
+    if (!push_minitouch()) {
         return false;
     }
 
     return invoke_and_read_info();
-}
-
-MaaControllerFeature MinitouchInput::get_features() const
-{
-    MaaControllerFeature feat = MaaControllerFeature_UseMouseDownAndUpInsteadOfClick;
-    if (adb_shell_input_) {
-        feat |= adb_shell_input_->get_features() & MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
-    }
-    return feat;
-}
-
-bool MinitouchInput::click_key(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-
-    return adb_shell_input_->click_key(key);
-}
-
-bool MinitouchInput::input_text(const std::string& text)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-
-    return adb_shell_input_->input_text(text);
-}
-
-bool MinitouchInput::key_down(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-
-    return adb_shell_input_->key_down(key);
-}
-
-bool MinitouchInput::key_up(int key)
-{
-    if (!adb_shell_input_) {
-        LogError << "adb_shell_input_ is nullptr";
-        return false;
-    }
-
-    return adb_shell_input_->key_up(key);
 }
 
 void MinitouchInput::on_image_resolution_changed(const std::pair<int, int>& pre, const std::pair<int, int>& cur)
@@ -130,13 +43,6 @@ bool MinitouchInput::invoke_and_read_info()
     }
 
     return read_info();
-}
-
-void MinitouchInput::remove_binary()
-{
-    LogTrace;
-
-    invoke_app_->remove();
 }
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/Input/MinitouchInput.h
+++ b/source/MaaAdbControlUnit/Input/MinitouchInput.h
@@ -2,11 +2,6 @@
 
 #include "MtouchHelper.h"
 
-#include <filesystem>
-
-#include "AdbShellInput.h"
-#include "Invoke/InvokeApp.h"
-
 #include "Common/Conf.h"
 
 MAA_CTRL_UNIT_NS_BEGIN
@@ -15,8 +10,10 @@ class MinitouchInput : public MtouchHelper
 {
 public:
     explicit MinitouchInput(std::filesystem::path agent_path)
-        : agent_path_(std::move(agent_path))
     {
+        agent_path_ = std::move(agent_path);
+        invoke_app_ = std::make_shared<InvokeApp>();
+        adb_shell_input_ = std::make_shared<AdbShellInput>();
         children_.emplace_back(invoke_app_);
         children_.emplace_back(adb_shell_input_);
     }
@@ -29,50 +26,11 @@ public: // from UnitBase
 public: // from InputBase
     virtual bool init() override;
 
-    virtual MaaControllerFeature get_features() const override;
-
-    virtual bool click_key(int key) override;
-    virtual bool input_text(const std::string& text) override;
-
-    virtual bool key_down(int key) override;
-    virtual bool key_up(int key) override;
-
 public: // from ControlUnitSink
     virtual void on_image_resolution_changed(const std::pair<int, int>& pre, const std::pair<int, int>& cur) override;
 
-protected: // from MtouchHelper
-    virtual std::pair<int, int> screen_to_touch(int x, int y) override { return _screen_to_touch(x, y); }
-
-    virtual std::pair<int, int> screen_to_touch(double x, double y) override { return _screen_to_touch(x, y); }
-
 private:
-    template <typename T1, typename T2>
-    inline std::pair<int, int> _screen_to_touch(T1 x, T2 y)
-    {
-        auto make_pair = [](double x, double y) {
-            return std::make_pair(static_cast<int>(round(x)), static_cast<int>(round(y)));
-        };
-        switch (orientation_) {
-        case 0:
-            return make_pair(x * xscale_, y * yscale_);
-        case 1:
-            return make_pair(touch_height_ - y * yscale_, x * xscale_);
-        case 2:
-            return make_pair(touch_width_ - x * xscale_, touch_height_ - y * yscale_);
-        case 3:
-            return make_pair(y * yscale_, touch_width_ - x * xscale_);
-        default:
-            return make_pair(x * xscale_, y * yscale_);
-        }
-    }
-
     bool invoke_and_read_info();
-    void remove_binary();
-
-    std::filesystem::path agent_path_;
-    std::vector<std::string> arch_list_;
-    std::shared_ptr<InvokeApp> invoke_app_ = std::make_shared<InvokeApp>();
-    std::shared_ptr<AdbShellInput> adb_shell_input_ = std::make_shared<AdbShellInput>();
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/Input/MtouchHelper.cpp
+++ b/source/MaaAdbControlUnit/Input/MtouchHelper.cpp
@@ -72,6 +72,11 @@ bool MtouchHelper::key_up(int key)
 
 bool MtouchHelper::parse_minitouch_config(const json::value& config)
 {
+    if (!invoke_app_ || !adb_shell_input_) {
+        LogError << "invoke_app_ or adb_shell_input_ is nullptr";
+        return false;
+    }
+
     static const json::array kDefaultArch = {
         "x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi",
     };
@@ -83,7 +88,7 @@ bool MtouchHelper::parse_minitouch_config(const json::value& config)
 
     arch_list_ = jarch.as<std::vector<std::string>>();
 
-    return invoke_app_->parse(config) && parse(config) && adb_shell_input_->parse(config);
+    return invoke_app_->parse(config) && MtouchHelper::parse(config) && adb_shell_input_->parse(config);
 }
 
 bool MtouchHelper::push_minitouch()

--- a/source/MaaAdbControlUnit/Input/MtouchHelper.cpp
+++ b/source/MaaAdbControlUnit/Input/MtouchHelper.cpp
@@ -6,12 +6,122 @@
 #include <ranges>
 
 #include "MaaUtils/Logger.h"
+#include "MaaUtils/Platform.h"
 
 MAA_CTRL_UNIT_NS_BEGIN
 
 std::string MtouchHelper::type_name() const
 {
     return typeid(this).name();
+}
+
+std::pair<int, int> MtouchHelper::screen_to_touch(int x, int y)
+{
+    return screen_to_touch_impl(x, y);
+}
+
+std::pair<int, int> MtouchHelper::screen_to_touch(double x, double y)
+{
+    return screen_to_touch_impl(x, y);
+}
+
+MaaControllerFeature MtouchHelper::get_features() const
+{
+    MaaControllerFeature feat = MaaControllerFeature_UseMouseDownAndUpInsteadOfClick;
+    if (adb_shell_input_) {
+        feat |= adb_shell_input_->get_features() & MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
+    }
+    return feat;
+}
+
+bool MtouchHelper::click_key(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->click_key(key);
+}
+
+bool MtouchHelper::input_text(const std::string& text)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->input_text(text);
+}
+
+bool MtouchHelper::key_down(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->key_down(key);
+}
+
+bool MtouchHelper::key_up(int key)
+{
+    if (!adb_shell_input_) {
+        LogError << "adb_shell_input_ is nullptr";
+        return false;
+    }
+    return adb_shell_input_->key_up(key);
+}
+
+bool MtouchHelper::parse_minitouch_config(const json::value& config)
+{
+    static const json::array kDefaultArch = {
+        "x86_64", "x86", "arm64-v8a", "armeabi-v7a", "armeabi",
+    };
+    json::array jarch = config.get("prebuilt", "minitouch", "arch", kDefaultArch);
+
+    if (!jarch.all<std::string>()) {
+        return false;
+    }
+
+    arch_list_ = jarch.as<std::vector<std::string>>();
+
+    return invoke_app_->parse(config) && parse(config) && adb_shell_input_->parse(config);
+}
+
+bool MtouchHelper::push_minitouch()
+{
+    if (!invoke_app_->init()) {
+        return false;
+    }
+
+    auto archs = invoke_app_->abilist();
+    if (!archs) {
+        return false;
+    }
+
+    auto arch_iter = std::ranges::find_first_of(*archs, arch_list_);
+    if (arch_iter == archs->end()) {
+        LogError << "no matching arch for minitouch" << VAR(*archs) << VAR(arch_list_);
+        return false;
+    }
+    const std::string& target_arch = *arch_iter;
+
+    const auto bin_path = agent_path_ / path(target_arch) / path("minitouch");
+    if (!invoke_app_->push(bin_path)) {
+        return false;
+    }
+
+    if (!invoke_app_->chmod()) {
+        return false;
+    }
+
+    return true;
+}
+
+void MtouchHelper::remove_binary()
+{
+    LogTrace;
+    if (invoke_app_) {
+        invoke_app_->remove();
+    }
 }
 
 bool MtouchHelper::read_info()

--- a/source/MaaAdbControlUnit/Input/MtouchHelper.h
+++ b/source/MaaAdbControlUnit/Input/MtouchHelper.h
@@ -2,6 +2,9 @@
 
 #include "Base/UnitBase.h"
 
+#include <filesystem>
+
+#include "AdbShellInput.h"
 #include "General/DeviceInfo.h"
 #include "Invoke/InvokeApp.h"
 #include "MaaUtils/IOStream/ChildPipeIOStream.h"
@@ -18,7 +21,7 @@ public:
     virtual ~MtouchHelper() override = default;
 
 public: // from InputBase
-    virtual MaaControllerFeature get_features() const override = 0;
+    virtual MaaControllerFeature get_features() const override;
 
     virtual bool click(int x, int y) override;
     virtual bool swipe(int x1, int y1, int x2, int y2, int duration) override;
@@ -29,19 +32,24 @@ public: // from InputBase
 
     virtual bool parse(const json::value& config) override;
 
-    virtual bool click_key(int key) override = 0;
-    virtual bool input_text(const std::string& text) override = 0;
+    virtual bool click_key(int key) override;
+    virtual bool input_text(const std::string& text) override;
 
-    virtual bool key_down(int key) override = 0;
-    virtual bool key_up(int key) override = 0;
+    virtual bool key_down(int key) override;
+    virtual bool key_up(int key) override;
 
 protected:
     bool read_info();
 
-    virtual std::pair<int, int> screen_to_touch(int x, int y) = 0;
-    virtual std::pair<int, int> screen_to_touch(double x, double y) = 0;
+    virtual std::pair<int, int> screen_to_touch(int x, int y);
+    virtual std::pair<int, int> screen_to_touch(double x, double y);
 
     virtual std::string type_name() const;
+
+    // minitouch common operations
+    bool parse_minitouch_config(const json::value& config);
+    bool push_minitouch();
+    void remove_binary();
 
     // https://github.com/openstf/minitouch#writable-to-the-socket
     static constexpr std::string_view kDownFormat = "d {} {} {} {}\nc\n";
@@ -59,10 +67,35 @@ protected:
     int press_ = 0;
     int orientation_ = 0;
 
+    std::filesystem::path agent_path_;
+    std::vector<std::string> arch_list_;
+    std::shared_ptr<InvokeApp> invoke_app_ = nullptr;
+    std::shared_ptr<AdbShellInput> adb_shell_input_ = nullptr;
+
 protected:
     virtual bool request_display_info();
 
 private:
+    template <typename T1, typename T2>
+    inline std::pair<int, int> screen_to_touch_impl(T1 x, T2 y)
+    {
+        auto make_pair = [](double x, double y) {
+            return std::make_pair(static_cast<int>(round(x)), static_cast<int>(round(y)));
+        };
+        switch (orientation_) {
+        case 0:
+            return make_pair(x * xscale_, y * yscale_);
+        case 1:
+            return make_pair(touch_height_ - y * yscale_, x * xscale_);
+        case 2:
+            return make_pair(touch_width_ - x * xscale_, touch_height_ - y * yscale_);
+        case 3:
+            return make_pair(y * yscale_, touch_width_ - x * xscale_);
+        default:
+            return make_pair(x * xscale_, y * yscale_);
+        }
+    }
+
     std::shared_ptr<DeviceInfo> device_info_ = std::make_shared<DeviceInfo>();
 };
 

--- a/source/MaaAdbControlUnit/Input/MtouchHelper.h
+++ b/source/MaaAdbControlUnit/Input/MtouchHelper.h
@@ -59,8 +59,10 @@ protected:
     int press_ = 0;
     int orientation_ = 0;
 
+protected:
+    virtual bool request_display_info();
+
 private:
-    bool request_display_info();
     std::shared_ptr<DeviceInfo> device_info_ = std::make_shared<DeviceInfo>();
 };
 

--- a/source/MaaAdbControlUnit/Manager/InputAgent.cpp
+++ b/source/MaaAdbControlUnit/Manager/InputAgent.cpp
@@ -4,6 +4,7 @@
 #include <ranges>
 #include <unordered_set>
 
+#include "EmulatorExtras/AndrowsExtras.h"
 #include "EmulatorExtras/MuMuPlayerExtras.h"
 #include "Input/AdbShellInput.h"
 #include "Input/MaatouchInput.h"
@@ -18,6 +19,7 @@ InputAgent::InputAgent(MaaAdbInputMethod methods, const std::filesystem::path& a
     if (methods & MaaAdbInputMethod_EmulatorExtras) {
 #ifdef _WIN32
         method_vector.emplace_back(InputAgent::Method::MuMuPlayerExtras);
+        method_vector.emplace_back(InputAgent::Method::AndrowsExtras);
 #else
         LogWarn << "EmulatorExtras is not supported on this platform";
 #endif
@@ -63,6 +65,15 @@ InputAgent::InputAgent(MaaAdbInputMethod methods, const std::filesystem::path& a
         case Method::MuMuPlayerExtras:
             unit = std::make_shared<MuMuPlayerExtras>();
             break;
+
+        case Method::AndrowsExtras: {
+            auto minitouch_path = agent_path / "minitouch";
+            if (!std::filesystem::exists(minitouch_path)) {
+                LogWarn << "minitouch path not exists" << VAR(minitouch_path);
+                break;
+            }
+            unit = std::make_shared<AndrowsExtras>(minitouch_path);
+        } break;
 #endif
 
         default:

--- a/source/MaaAdbControlUnit/Manager/InputAgent.h
+++ b/source/MaaAdbControlUnit/Manager/InputAgent.h
@@ -16,6 +16,7 @@ public:
         MinitouchAndAdbKey,
         Maatouch,
         MuMuPlayerExtras,
+        AndrowsExtras,
     };
 
 public:

--- a/source/MaaAdbControlUnit/Manager/ScreencapAgent.cpp
+++ b/source/MaaAdbControlUnit/Manager/ScreencapAgent.cpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 
 #include "EmulatorExtras/AVDExtras.h"
+#include "EmulatorExtras/AndrowsExtras.h"
 #include "EmulatorExtras/LDPlayerExtras.h"
 #include "EmulatorExtras/MuMuPlayerExtras.h"
 #include "MaaUtils/Logger.h"
@@ -43,6 +44,7 @@ ScreencapAgent::ScreencapAgent(MaaAdbScreencapMethod methods, const std::filesys
 #ifdef _WIN32
         method_set.emplace(ScreencapAgent::Method::MuMuPlayerExtras);
         method_set.emplace(ScreencapAgent::Method::LDPlayerExtras);
+        method_set.emplace(ScreencapAgent::Method::AndrowsExtras);
 #endif
 #ifndef __ANDROID__
         method_set.emplace(ScreencapAgent::Method::AVDExtras);
@@ -91,6 +93,9 @@ ScreencapAgent::ScreencapAgent(MaaAdbScreencapMethod methods, const std::filesys
             break;
         case Method::LDPlayerExtras:
             unit = std::make_shared<LDPlayerExtras>();
+            break;
+        case Method::AndrowsExtras:
+            unit = std::make_shared<AndrowsExtras>();
             break;
 #endif
 #ifndef __ANDROID__

--- a/source/MaaAdbControlUnit/Manager/ScreencapAgent.h
+++ b/source/MaaAdbControlUnit/Manager/ScreencapAgent.h
@@ -23,6 +23,7 @@ public:
         MuMuPlayerExtras,
         LDPlayerExtras,
         AVDExtras,
+        AndrowsExtras,
     };
 
 public:

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -140,6 +140,36 @@ bool request_waydroid_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI
     return true;
 }
 
+bool request_androws_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> control_unit, AdbDevice& device)
+{
+    if (!control_unit) {
+        return false;
+    }
+
+    // Detect via Tencent-specific property; non-empty means this is an Androws device
+    std::string output;
+    bool ret = control_unit->shell("getprop sys.tencent.imei", output);
+    if (!ret) {
+        return false;
+    }
+    // Trim whitespace/newlines
+    while (!output.empty() && (output.back() == '\n' || output.back() == '\r' || output.back() == ' ')) {
+        output.pop_back();
+    }
+    if (output.empty()) {
+        return false;
+    }
+
+    // Just mark the device; AndrowsExtras will dynamically resolve the correct
+    // display ID at runtime using the app package name.
+    device.config["extras"]["androws"]["enable"] = true;
+    device.screencap_methods = MaaAdbScreencapMethod_EmulatorExtras;
+    device.input_methods = MaaAdbInputMethod_EmulatorExtras;
+
+    LogInfo << "Androws detected" << VAR(device);
+    return true;
+}
+
 bool request_avd_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> control_unit, AdbDevice& device)
 {
     if (!control_unit) {
@@ -197,6 +227,8 @@ std::optional<AdbDevice>
     device.config = { };
 
     if (request_waydroid_config(control_unit, device)) {
+    }
+    else if (request_androws_config(control_unit, device)) {
     }
     else if (request_avd_config(control_unit, device)) {
     }

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -284,6 +284,20 @@ std::vector<AdbDeviceFinder::Emulator> AdbDeviceFinder::find_emulators() const
         result.emplace_back(std::move(emulator));
     }
 
+    // Platform-specific fallback discovery (e.g. registry lookup for elevated-process emulators like Androws).
+    // Merged here so downstream logic in find() treats them uniformly. Deduplicated by adb_path against
+    // process-enumerated entries to avoid connecting to the same adb server twice.
+    for (auto& extra : find_extra_emulators()) {
+        if (extra.adb_path.empty() || !std::filesystem::exists(extra.adb_path)) {
+            LogWarn << "extra emulator has invalid adb_path" << VAR(extra);
+            continue;
+        }
+        if (!seen_adb_paths.insert(extra.adb_path).second) {
+            continue;
+        }
+        result.emplace_back(std::move(extra));
+    }
+
     LogInfo << VAR(result);
 
     return result;

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.h
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.h
@@ -54,6 +54,12 @@ protected:
 
     virtual std::vector<AdbDevice> find_by_emulator_tool(const Emulator&) const { return { }; }
 
+    // Extra emulator discovery hook for platform-specific fallbacks that cannot rely on process enumeration,
+    // e.g. emulators running as elevated processes whose exe path is unreachable via OpenProcess.
+    // Subclasses may override to return additional Emulator entries. Results are de-duplicated by adb_path
+    // against process-enumerated emulators in find_emulators().
+    virtual std::vector<Emulator> find_extra_emulators() const { return { }; }
+
 protected:
     std::vector<std::string> find_serials_by_adb_command(const std::filesystem::path& adb_path) const;
     std::optional<AdbDevice> try_device(const std::filesystem::path& adb_path, const std::string& serial, const Emulator& emulator) const;

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -54,6 +54,8 @@ const AdbDeviceFinder::EmulatorConstDataMap& AdbDeviceWin32Finder::get_emulator_
           { .keyword = "qemu-system",
             .adb_candidate_paths = { "..\\..\\..\\platform-tools\\adb.exe"_path },
             .adb_common_serials = { "emulator-5554", "127.0.0.1:5555" } } },
+
+        { "Androws", { .keyword = "Androws", .adb_candidate_paths = { "adb.exe"_path } } },
     };
 
     return kConstData;

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -5,6 +5,7 @@
 
 #include "MaaUtils/IOStream/ChildPipeIOStream.h"
 #include "MaaUtils/Logger.h"
+#include "MaaUtils/SafeWindows.hpp"
 #include "MaaUtils/StringMisc.hpp"
 
 MAA_TOOLKIT_NS_BEGIN
@@ -259,6 +260,104 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_ld_devices(const Emulator& emu
     }
 
     return result;
+}
+
+std::vector<AdbDeviceFinder::Emulator> AdbDeviceWin32Finder::find_extra_emulators() const
+{
+    LogFunc;
+
+    std::vector<Emulator> result;
+
+    if (auto androws_adb = find_androws_adb_path_from_registry()) {
+        Emulator emulator {
+            .name = "Androws",
+            .process_path = { },
+            .adb_path = *androws_adb,
+        };
+        LogInfo << "Androws found via registry" << VAR(emulator);
+        result.emplace_back(std::move(emulator));
+    }
+
+    return result;
+}
+
+namespace
+{
+// Read a REG_SZ value from an opened registry key into a std::wstring. Returns nullopt on any failure.
+std::optional<std::wstring> read_reg_sz(HKEY key, const wchar_t* value_name)
+{
+    DWORD type = 0;
+    DWORD size = 0;
+    LONG ret = RegQueryValueExW(key, value_name, nullptr, &type, nullptr, &size);
+    if (ret != ERROR_SUCCESS || type != REG_SZ || size == 0) {
+        return std::nullopt;
+    }
+
+    // size is in bytes, may or may not include the trailing null.
+    std::vector<BYTE> data(size);
+    ret = RegQueryValueExW(key, value_name, nullptr, &type, data.data(), &size);
+    if (ret != ERROR_SUCCESS || type != REG_SZ || size == 0) {
+        return std::nullopt;
+    }
+
+    // Length in wchar_t; drop trailing nulls if present.
+    size_t len = size / sizeof(wchar_t);
+    auto* wbuf = reinterpret_cast<const wchar_t*>(data.data());
+    while (len > 0 && wbuf[len - 1] == L'\0') {
+        --len;
+    }
+    if (len == 0) {
+        return std::nullopt;
+    }
+    return std::wstring(wbuf, len);
+}
+}
+
+std::optional<std::filesystem::path> AdbDeviceWin32Finder::find_androws_adb_path_from_registry()
+{
+    HKEY install_key = nullptr;
+    OnScopeLeave([&]() {
+        if (install_key) {
+            RegCloseKey(install_key);
+        }
+    });
+
+    // Silent miss: treat "not installed" as normal; do not log at warn/error.
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Tencent\\Androws", 0, KEY_READ, &install_key) != ERROR_SUCCESS) {
+        return std::nullopt;
+    }
+
+    auto install_path = read_reg_sz(install_key, L"InstallPath");
+    if (!install_path) {
+        LogWarn << "Androws registry key exists but InstallPath is missing or invalid";
+        return std::nullopt;
+    }
+
+    HKEY app_key = nullptr;
+    OnScopeLeave([&]() {
+        if (app_key) {
+            RegCloseKey(app_key);
+        }
+    });
+
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Tencent\\Androws\\Androws", 0, KEY_READ, &app_key) != ERROR_SUCCESS) {
+        LogWarn << "Androws InstallPath present but sub key 'Androws' missing";
+        return std::nullopt;
+    }
+
+    auto version = read_reg_sz(app_key, L"Version");
+    if (!version) {
+        LogWarn << "Androws sub key exists but Version is missing or invalid";
+        return std::nullopt;
+    }
+
+    std::filesystem::path adb_path = std::filesystem::path(*install_path) / L"Application" / *version / L"adb.exe";
+    if (!std::filesystem::exists(adb_path)) {
+        LogWarn << "Androws resolved adb.exe does not exist" << VAR(adb_path);
+        return std::nullopt;
+    }
+
+    return std::filesystem::canonical(adb_path);
 }
 
 MAA_TOOLKIT_NS_END

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.h
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.h
@@ -23,12 +23,20 @@ public:
 protected:
     virtual const EmulatorConstDataMap& get_emulator_const_data() const override;
     virtual std::vector<AdbDevice> find_by_emulator_tool(const Emulator& emulator) const override;
+    virtual std::vector<Emulator> find_extra_emulators() const override;
 
 private:
     AdbDeviceWin32Finder() = default;
 
     std::vector<AdbDevice> find_mumu_devices(const Emulator& emulator) const;
     std::vector<AdbDevice> find_ld_devices(const Emulator& emulator) const;
+
+    // Androws (Tencent Androws) runs as an elevated process, so its adb.exe path cannot be
+    // obtained via process enumeration + OpenProcess. Fall back to Windows Registry:
+    //   HKLM\SOFTWARE\Tencent\Androws                   -> InstallPath
+    //   HKLM\SOFTWARE\Tencent\Androws\Androws          -> Version
+    // Resolved path: {InstallPath}\Application\{Version}\adb.exe
+    static std::optional<std::filesystem::path> find_androws_adb_path_from_registry();
 };
 
 MAA_TOOLKIT_NS_END

--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -223,7 +223,7 @@ class MaaAdbScreencapMethodEnum(IntEnum):
     | RawByNetcat           | Fast       | Low           | Lossless |                                   |
     | MinicapDirect         | Fast       | Low           | Lossy    |                                   |
     | MinicapStream         | Very Fast  | Low           | Lossy    |                                   |
-    | EmulatorExtras        | Very Fast  | Low           | Lossless | Emulators only: MuMu 12, LDPlayer 9 |
+    | EmulatorExtras        | Very Fast  | Low           | Lossless | Emulators only: MuMu 12, LDPlayer 9, Androws |
     """
 
     Null = 0


### PR DESCRIPTION
## Summary by Sourcery

为 Androws（腾讯应用商店模拟器）新增截图和输入支持，将共享的 minitouch 逻辑集中管理，并通过 ADB 设备检测和各类 Agent 接入。

新功能：
- 引入 AndrowsExtras 组件，为 Androws（腾讯应用商店）虚拟显示器提供截图和基于 minitouch 的输入能力。
- 通过 ADB 属性和 Windows 进程元数据检测 Androws 设备，并为其自动启用 EmulatorExtras 的截图和输入方式。

增强改进：
- 将共享的 minitouch 配置、部署以及按键/键盘输入处理逻辑，从 MinitouchInput 重构到 MtouchHelper 中，以便 AndrowsExtras 和 MaatouchInput 等其他输入方式复用。
- 扩展 InputAgent 和 ScreencapAgent，在可用时通过新的 AndrowsExtras 实现路由 EmulatorExtras 的流量。

文档：
- 更新英文和中文的 control-methods 文档，将腾讯应用商店/Androws 列为 EmulatorExtras 下已支持的输入和截图方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Androws (Tencent App Store) emulator support for screencap and input, centralizing shared minitouch logic and wiring it through ADB device detection and agents.

New Features:
- Introduce AndrowsExtras component to provide screencap and minitouch-based input on Androws (Tencent App Store) virtual displays.
- Detect Androws devices via ADB properties and Windows process metadata, automatically enabling EmulatorExtras screencap and input methods for them.

Enhancements:
- Refactor shared minitouch configuration, deployment, and key/keyboard input handling from MinitouchInput into MtouchHelper for reuse by other inputs such as AndrowsExtras and MaatouchInput.
- Extend InputAgent and ScreencapAgent to route EmulatorExtras traffic through the new AndrowsExtras implementation when available.

Documentation:
- Update English and Chinese control-methods documentation to list Tencent App Store/Androws as supported under EmulatorExtras for both input and screencap.

</details>