### PR TITLE
fix:当有多显示器且游戏窗口与鼠标不在同一窗口后先暂停maa

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -341,6 +341,7 @@ void MessageInput::restore_pos()
 
     if (config_.with_window_pos) {
         restore_window_pos();
+        reset_windowpos_guard_state();
     }
 }
 
@@ -443,6 +444,8 @@ void MessageInput::abort_windowpos_operation(const char* reason)
 {
     LogWarn << "WithWindowPos guard: abort operation" << VAR(reason);
 
+    // 不要在这里直接发送 mouse up：该函数可能由 tracking thread 调用。
+    // best-effort release 交给后续 touch_move/touch_up 的异常路径，避免跨线程清理 gesture 状态。
     window_pos_invalid_movement_ = true;
 
     stop_window_tracking();
@@ -450,8 +453,6 @@ void MessageInput::abort_windowpos_operation(const char* reason)
     pending_mouse_x_ = 0;
     pending_mouse_y_ = 0;
     has_pending_mouse_ = false;
-
-    gesture_target_ = nullptr;
 }
 
 void MessageInput::reset_windowpos_guard_state()
@@ -459,10 +460,51 @@ void MessageInput::reset_windowpos_guard_state()
     window_pos_invalid_movement_ = false;
 }
 
+bool MessageInput::best_effort_release_mouse(const char* reason)
+{
+    const bool should_release = mouse_down_sent_.exchange(false);
+    const int contact = mouse_down_contact_.load();
+    const int x = last_mouse_x_.load();
+    const int y = last_mouse_y_.load();
+
+    OnScopeLeave([this]() {
+        gesture_target_ = nullptr;
+        mouse_down_contact_ = 0;
+        last_mouse_x_ = 0;
+        last_mouse_y_ = 0;
+    });
+
+    if (!should_release) {
+        LogInfo << "WithWindowPos guard: no active mouse down, skip best-effort mouse up" << VAR(reason);
+        return true;
+    }
+
+    HWND target = nullptr;
+    bool reuse_gesture = gesture_target_ && IsWindow(gesture_target_);
+    if (reuse_gesture) {
+        target = gesture_target_;
+        bool use_post = (config_.mode == Mode::PostMessage);
+        ::MaaNS::CtrlUnitNs::send_activate_message(target, use_post);
+    }
+    else {
+        target = send_activate();
+    }
+
+    MouseMessageInfo msg_info;
+    if (!contact_to_mouse_up_message(contact, msg_info)) {
+        LogWarn << "WithWindowPos guard: best-effort mouse up skipped, invalid contact" << VAR(reason) << VAR(contact);
+        return false;
+    }
+
+    LogWarn << "WithWindowPos guard: send best-effort mouse up" << VAR(reason) << VAR(contact) << VAR(x) << VAR(y);
+    LPARAM lParam = make_mouse_lparam(target, x, y);
+    return send_or_post_w(target, msg_info.message, msg_info.w_param, lParam);
+}
+
 bool MessageInput::prepare_mouse_position(int x, int y)
 {
     if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
-        LogWarn << "WithWindowPos guard: reject input after invalid movement" << VAR(x) << VAR(y);
+        LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(x) << VAR(y);
         return false;
     }
 
@@ -834,8 +876,12 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
-    if (config_.with_window_pos) {
-        reset_windowpos_guard_state();
+    if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+        LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(contact) << VAR(x) << VAR(y);
+        std::ignore = best_effort_release_mouse("touch_down after WithWindowPos abort");
+        restore_pos();
+        unblock_input();
+        return false;
     }
 
     MouseMessageInfo move_info;
@@ -860,6 +906,10 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
     save_pos();
 
     if (!prepare_mouse_position(x, y)) {
+        if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+            LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(contact) << VAR(x) << VAR(y);
+            std::ignore = best_effort_release_mouse("touch_down prepare after WithWindowPos abort");
+        }
         gesture_target_ = nullptr;
         restore_pos();
         unblock_input();
@@ -884,6 +934,11 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
+    mouse_down_contact_ = contact;
+    last_mouse_x_ = x;
+    last_mouse_y_ = y;
+    mouse_down_sent_ = true;
+
     last_pos_ = { x, y };
     last_pos_set_ = true;
 
@@ -901,6 +956,14 @@ bool MessageInput::touch_move(int contact, int x, int y, int pressure)
         return false;
     }
 
+    if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+        LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(contact) << VAR(x) << VAR(y);
+        std::ignore = best_effort_release_mouse("touch_move after WithWindowPos abort");
+        restore_pos();
+        unblock_input();
+        return false;
+    }
+
     MouseMessageInfo msg_info;
     if (!contact_to_mouse_move_message(contact, msg_info)) {
         LogError << VAR(config_.mode) << VAR(config_.with_cursor_pos) << VAR(config_.with_window_pos) << "contact out of range"
@@ -909,6 +972,10 @@ bool MessageInput::touch_move(int contact, int x, int y, int pressure)
     }
 
     if (!prepare_mouse_position(x, y)) {
+        if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+            LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(contact) << VAR(x) << VAR(y);
+            std::ignore = best_effort_release_mouse("touch_move prepare after WithWindowPos abort");
+        }
         gesture_target_ = nullptr;
         restore_pos();
         unblock_input();
@@ -923,6 +990,11 @@ bool MessageInput::touch_move(int contact, int x, int y, int pressure)
         restore_pos();
         unblock_input();
         return false;
+    }
+
+    if (mouse_down_sent_.load()) {
+        last_mouse_x_ = x;
+        last_mouse_y_ = y;
     }
 
     last_pos_ = { x, y };
@@ -941,9 +1013,8 @@ bool MessageInput::touch_up(int contact)
     }
 
     if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
-        LogWarn << "WithWindowPos guard: reject touch_up after invalid movement" << VAR(contact);
-
-        gesture_target_ = nullptr;
+        LogWarn << "WithWindowPos guard: touch up after abort" << VAR(contact);
+        std::ignore = best_effort_release_mouse("touch up after WithWindowPos abort");
         restore_pos();
         unblock_input();
         return false;
@@ -952,6 +1023,12 @@ bool MessageInput::touch_up(int contact)
     bool reuse_gesture = gesture_target_ && IsWindow(gesture_target_);
     HWND target = reuse_gesture ? gesture_target_ : send_activate();
     gesture_target_ = nullptr;
+    OnScopeLeave([this]() {
+        mouse_down_sent_ = false;
+        mouse_down_contact_ = 0;
+        last_mouse_x_ = 0;
+        last_mouse_y_ = 0;
+    });
 
     OnScopeLeave([this]() { unblock_input(); });
 
@@ -1054,8 +1131,12 @@ bool MessageInput::scroll(int dx, int dy)
         return false;
     }
 
-    if (config_.with_window_pos) {
-        reset_windowpos_guard_state();
+    if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+        LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(dx) << VAR(dy);
+        std::ignore = best_effort_release_mouse("scroll after WithWindowPos abort");
+        restore_pos();
+        unblock_input();
+        return false;
     }
 
     HWND target = send_activate();
@@ -1068,6 +1149,10 @@ bool MessageInput::scroll(int dx, int dy)
     save_pos();
 
     if (!prepare_mouse_position(target_pos.first, target_pos.second)) {
+        if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+            LogWarn << "WithWindowPos guard: previous invalid movement, reject input" << VAR(dx) << VAR(dy);
+            std::ignore = best_effort_release_mouse("scroll prepare after WithWindowPos abort");
+        }
         restore_pos();
         return false;
     }

--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -376,29 +376,118 @@ bool MessageInput::move_window_to_align_cursor(int x, int y)
     int new_left = cursor_pos.x - x - border_x;
     int new_top = cursor_pos.y - y - border_y;
 
+    if (!is_window_move_allowed(new_left, new_top, current_rect, "align cursor")) {
+        abort_windowpos_operation("align cursor");
+        return false;
+    }
+
     if (!SetWindowPos(hwnd_, nullptr, new_left, new_top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_ASYNCWINDOWPOS)) {
         LogError << "SetWindowPos failed" << VAR(hwnd_) << VAR(new_left) << VAR(new_top) << VAR(GetLastError());
+        abort_windowpos_operation("align cursor SetWindowPos failed");
         return false;
     }
 
     return true;
 }
 
-LPARAM MessageInput::prepare_mouse_position(int x, int y)
+bool MessageInput::is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason)
 {
+    RECT base_rect = window_pos_saved_ ? saved_window_rect_ : current_rect;
+
+    HMONITOR origin_monitor = MonitorFromRect(&base_rect, MONITOR_DEFAULTTONULL);
+    if (!origin_monitor) {
+        LogWarn << "WithWindowPos guard: origin monitor not found" << VAR(reason) << VAR(base_rect.left) << VAR(base_rect.top)
+                << VAR(base_rect.right) << VAR(base_rect.bottom);
+        return false;
+    }
+
+    HMONITOR current_monitor = MonitorFromRect(&current_rect, MONITOR_DEFAULTTONULL);
+    if (!current_monitor || current_monitor != origin_monitor) {
+        LogWarn << "WithWindowPos guard: current window is not on origin monitor" << VAR(reason) << VAR(current_rect.left)
+                << VAR(current_rect.top) << VAR(current_rect.right) << VAR(current_rect.bottom);
+        return false;
+    }
+
+    MONITORINFO origin_info { sizeof(MONITORINFO) };
+    if (!GetMonitorInfoW(origin_monitor, &origin_info)) {
+        LogWarn << "WithWindowPos guard: GetMonitorInfoW failed" << VAR(reason) << VAR(GetLastError());
+        return false;
+    }
+
+    RECT predicted_rect = current_rect;
+    OffsetRect(&predicted_rect, new_left - current_rect.left, new_top - current_rect.top);
+
+    HMONITOR predicted_monitor = MonitorFromRect(&predicted_rect, MONITOR_DEFAULTTONULL);
+    if (!predicted_monitor || predicted_monitor != origin_monitor) {
+        LogWarn << "WithWindowPos guard: predicted window rect moved to another monitor" << VAR(reason) << VAR(new_left) << VAR(new_top)
+                << VAR(predicted_rect.left) << VAR(predicted_rect.top) << VAR(predicted_rect.right) << VAR(predicted_rect.bottom);
+        return false;
+    }
+
+    const RECT& monitor_rect = origin_info.rcMonitor;
+
+    const bool fully_inside = predicted_rect.left >= monitor_rect.left && predicted_rect.top >= monitor_rect.top
+                              && predicted_rect.right <= monitor_rect.right && predicted_rect.bottom <= monitor_rect.bottom;
+
+    if (!fully_inside) {
+        LogWarn << "WithWindowPos guard: predicted window rect would leave origin monitor" << VAR(reason) << VAR(new_left) << VAR(new_top)
+                << VAR(predicted_rect.left) << VAR(predicted_rect.top) << VAR(predicted_rect.right) << VAR(predicted_rect.bottom)
+                << VAR(monitor_rect.left) << VAR(monitor_rect.top) << VAR(monitor_rect.right) << VAR(monitor_rect.bottom);
+        return false;
+    }
+
+    return true;
+}
+
+void MessageInput::abort_windowpos_operation(const char* reason)
+{
+    LogWarn << "WithWindowPos guard: abort operation" << VAR(reason);
+
+    window_pos_invalid_movement_ = true;
+
+    stop_window_tracking();
+
+    pending_mouse_x_ = 0;
+    pending_mouse_y_ = 0;
+    has_pending_mouse_ = false;
+
+    gesture_target_ = nullptr;
+}
+
+void MessageInput::reset_windowpos_guard_state()
+{
+    window_pos_invalid_movement_ = false;
+}
+
+bool MessageInput::prepare_mouse_position(int x, int y)
+{
+    if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+        LogWarn << "WithWindowPos guard: reject input after invalid movement" << VAR(x) << VAR(y);
+        return false;
+    }
+
     if (config_.with_cursor_pos) {
         // WithCursorPos 模式：移动真实光标到目标位置
         POINT screen_pos = client_to_screen(x, y);
         if (!SetCursorPos(screen_pos.x, screen_pos.y)) {
             LogError << "SetCursorPos failed" << VAR(screen_pos.x) << VAR(screen_pos.y) << VAR(GetLastError());
+            return false;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        return true;
     }
-    else if (config_.with_window_pos) {
+
+    if (config_.with_window_pos) {
         start_window_tracking(x, y);
-        move_window_to_align_cursor(x, y);
+
+        if (!move_window_to_align_cursor(x, y)) {
+            return false;
+        }
+
+        return true;
     }
-    return MAKELPARAM(x, y);
+
+    return true;
 }
 
 // WH_MOUSE_LL 钩子回调：累加硬件鼠标位移 delta 并拦截，由追踪线程按固定帧率批量释放
@@ -525,24 +614,35 @@ void MessageInput::process_pending_mouse_frame()
     int new_left = mx - tx - border_x;
     int new_top = my - ty - border_y;
 
+    if (!is_window_move_allowed(new_left, new_top, rect, "tracking frame")) {
+        abort_windowpos_operation("tracking frame");
+        return;
+    }
+
     // 1. 挂起目标进程，避免它在窗口和光标尚未重新对齐时观测到中间态
     suspend_target_process();
+    OnScopeLeave([this]() { resume_target_process(); });
 
     // 2. 移动窗口（SWP_ASYNCWINDOWPOS 避免阻塞 + SWP_NOSENDCHANGING 跳过同步通知）
-    SetWindowPos(
-        hwnd_,
-        nullptr,
-        new_left,
-        new_top,
-        0,
-        0,
-        SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS);
+    if (!SetWindowPos(
+            hwnd_,
+            nullptr,
+            new_left,
+            new_top,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
+        LogError << "SetWindowPos failed in tracking frame" << VAR(hwnd_) << VAR(new_left) << VAR(new_top) << VAR(GetLastError());
+        abort_windowpos_operation("tracking SetWindowPos failed");
+        return;
+    }
 
     // 3. 释放光标到累积后的真实目标位置
-    SetCursorPos(mx, my);
-
-    // 4. 恢复目标进程（它醒来时看到的窗口和光标已完美对齐）
-    resume_target_process();
+    if (!SetCursorPos(mx, my)) {
+        LogError << "SetCursorPos failed in tracking frame" << VAR(mx) << VAR(my) << VAR(GetLastError());
+        abort_windowpos_operation("tracking SetCursorPos failed");
+        return;
+    }
 }
 
 void MessageInput::tracking_thread_func()
@@ -691,7 +791,7 @@ std::pair<int, int> MessageInput::get_target_pos() const
     }
 
     // 未设置时返回窗口客户区中心
-    RECT rect = { };
+    RECT rect = {};
     if (hwnd_ && GetClientRect(hwnd_, &rect)) {
         return { (rect.right - rect.left) / 2, (rect.bottom - rect.top) / 2 };
     }
@@ -734,6 +834,10 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
         return false;
     }
 
+    if (config_.with_window_pos) {
+        reset_windowpos_guard_state();
+    }
+
     MouseMessageInfo move_info;
     if (!contact_to_mouse_move_message(contact, move_info)) {
         LogError << VAR(config_.mode) << VAR(config_.with_cursor_pos) << VAR(config_.with_window_pos) << "contact out of range"
@@ -755,13 +859,19 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
 
     save_pos();
 
-    prepare_mouse_position(x, y);
+    if (!prepare_mouse_position(x, y)) {
+        gesture_target_ = nullptr;
+        restore_pos();
+        unblock_input();
+        return false;
+    }
 
     LPARAM lParam = make_mouse_lparam(target, x, y);
 
     if (!send_or_post_w(target, move_info.message, move_info.w_param, lParam)) {
         gesture_target_ = nullptr;
-        finish_pos();
+        restore_pos();
+        unblock_input();
         return false;
     }
 
@@ -769,7 +879,8 @@ bool MessageInput::touch_down(int contact, int x, int y, int pressure)
 
     if (!send_or_post_w(target, down_info.message, down_info.w_param, lParam)) {
         gesture_target_ = nullptr;
-        finish_pos();
+        restore_pos();
+        unblock_input();
         return false;
     }
 
@@ -797,13 +908,20 @@ bool MessageInput::touch_move(int contact, int x, int y, int pressure)
         return false;
     }
 
-    prepare_mouse_position(x, y);
+    if (!prepare_mouse_position(x, y)) {
+        gesture_target_ = nullptr;
+        restore_pos();
+        unblock_input();
+        return false;
+    }
 
     HWND target = (gesture_target_ && IsWindow(gesture_target_)) ? gesture_target_ : get_active_hwnd();
     LPARAM lParam = make_mouse_lparam(target, x, y);
 
     if (!send_or_post_w(target, msg_info.message, msg_info.w_param, lParam)) {
         gesture_target_ = nullptr;
+        restore_pos();
+        unblock_input();
         return false;
     }
 
@@ -819,6 +937,15 @@ bool MessageInput::touch_up(int contact)
 
     if (!hwnd_) {
         LogError << VAR(config_.mode) << VAR(config_.with_cursor_pos) << VAR(config_.with_window_pos) << "hwnd_ is nullptr";
+        return false;
+    }
+
+    if (config_.with_window_pos && window_pos_invalid_movement_.load()) {
+        LogWarn << "WithWindowPos guard: reject touch_up after invalid movement" << VAR(contact);
+
+        gesture_target_ = nullptr;
+        restore_pos();
+        unblock_input();
         return false;
     }
 
@@ -843,7 +970,7 @@ bool MessageInput::touch_up(int contact)
     LPARAM lParam = make_mouse_lparam(target, target_pos.first, target_pos.second);
 
     if (!send_or_post_w(target, msg_info.message, msg_info.w_param, lParam)) {
-        finish_pos();
+        restore_pos();
         return false;
     }
 
@@ -927,6 +1054,10 @@ bool MessageInput::scroll(int dx, int dy)
         return false;
     }
 
+    if (config_.with_window_pos) {
+        reset_windowpos_guard_state();
+    }
+
     HWND target = send_activate();
 
     check_and_block_input();
@@ -936,7 +1067,10 @@ bool MessageInput::scroll(int dx, int dy)
 
     save_pos();
 
-    prepare_mouse_position(target_pos.first, target_pos.second);
+    if (!prepare_mouse_position(target_pos.first, target_pos.second)) {
+        restore_pos();
+        return false;
+    }
     POINT screen_pos = client_to_screen(target_pos.first, target_pos.second);
     LPARAM lParam = MAKELPARAM(screen_pos.x, screen_pos.y);
     bool success = true;
@@ -975,7 +1109,7 @@ bool MessageInput::relative_move(int dx, int dy)
     // 标记：这次 SendInput 产生的 WM_INPUT 不要被 RawInput handler 对冲
     counter_pending_++;
 
-    INPUT input = { };
+    INPUT input = {};
     input.type = INPUT_MOUSE;
     input.mi.dx = dx;
     input.mi.dy = dy;
@@ -1264,7 +1398,7 @@ void MessageInput::process_mouse_lock_follow_frame()
 
 bool MessageInput::create_rawinput_window()
 {
-    WNDCLASSEXW wc = { };
+    WNDCLASSEXW wc = {};
     wc.cbSize = sizeof(wc);
     wc.lpfnWndProc = RawInputWndProc;
     wc.hInstance = GetModuleHandleW(NULL);
@@ -1280,7 +1414,7 @@ bool MessageInput::create_rawinput_window()
     }
 
     // 注册接收鼠标 RawInput（RIDEV_INPUTSINK 确保后台也能收到）
-    RAWINPUTDEVICE rid = { };
+    RAWINPUTDEVICE rid = {};
     rid.usUsagePage = 0x01; // HID_USAGE_PAGE_GENERIC
     rid.usUsage = 0x02;     // HID_USAGE_GENERIC_MOUSE
     rid.dwFlags = RIDEV_INPUTSINK;
@@ -1302,7 +1436,7 @@ void MessageInput::destroy_rawinput_window()
         return;
     }
 
-    RAWINPUTDEVICE rid = { };
+    RAWINPUTDEVICE rid = {};
     rid.usUsagePage = 0x01;
     rid.usUsage = 0x02;
     rid.dwFlags = RIDEV_REMOVE;
@@ -1321,7 +1455,7 @@ void MessageInput::send_counter_move(int raw_dx, int raw_dy)
 
     counter_pending_++;
 
-    INPUT counter = { };
+    INPUT counter = {};
     counter.type = INPUT_MOUSE;
     counter.mi.dx = -raw_dx;
     counter.mi.dy = -raw_dy;
@@ -1344,7 +1478,7 @@ bool MessageInput::handle_rawinput_message(LPARAM lParam)
         return false;
     }
 
-    RAWINPUT raw = { };
+    RAWINPUT raw = {};
     UINT copied = size;
     if (GetRawInputData(reinterpret_cast<HRAWINPUT>(lParam), RID_INPUT, &raw, &copied, sizeof(RAWINPUTHEADER)) != size) {
         return false;

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -78,6 +78,7 @@ private:
     bool is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason);
     void abort_windowpos_operation(const char* reason);
     void reset_windowpos_guard_state();
+    bool best_effort_release_mouse(const char* reason);
 
     // helpers for cursor/window position
     POINT client_to_screen(int x, int y);
@@ -120,6 +121,10 @@ private:
     std::atomic_int pending_mouse_y_ = 0;
     std::atomic_bool has_pending_mouse_ = false;
     std::atomic_bool window_pos_invalid_movement_ = false;
+    std::atomic_bool mouse_down_sent_ = false;
+    std::atomic_int mouse_down_contact_ = 0;
+    std::atomic_int last_mouse_x_ = 0;
+    std::atomic_int last_mouse_y_ = 0;
 
     // 目标进程挂起/恢复
     void open_target_process();

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -71,10 +71,13 @@ private:
     LPARAM make_mouse_lparam(HWND target, int x, int y);
 
     // 在发鼠标消息前把系统状态调整到目标窗口愿意接受的位置。
-    LPARAM prepare_mouse_position(int x, int y);
+    bool prepare_mouse_position(int x, int y);
 
     // WithWindowPos 模式：移动窗口使客户区坐标 (x,y) 与当前鼠标位置重合
     bool move_window_to_align_cursor(int x, int y);
+    bool is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason);
+    void abort_windowpos_operation(const char* reason);
+    void reset_windowpos_guard_state();
 
     // helpers for cursor/window position
     POINT client_to_screen(int x, int y);
@@ -116,6 +119,7 @@ private:
     std::atomic_int pending_mouse_x_ = 0;
     std::atomic_int pending_mouse_y_ = 0;
     std::atomic_bool has_pending_mouse_ = false;
+    std::atomic_bool window_pos_invalid_movement_ = false;
 
     // 目标进程挂起/恢复
     void open_target_process();
@@ -167,8 +171,8 @@ private:
     std::atomic<bool> mouse_lock_follow_active_ = false;
     bool tracking_thread_started_for_lock_follow_ = false;
 
-    POINT lock_anchor_cursor_ = { };
-    RECT lock_anchor_window_ = { };
+    POINT lock_anchor_cursor_ = {};
+    RECT lock_anchor_window_ = {};
     int lock_offset_x_ = 0;
     int lock_offset_y_ = 0;
 };


### PR DESCRIPTION
关联 issue：MaaAssistantArknights/MaaAssistantArknights#16339

## Summary by Sourcery

在 WithWindowPos 模式下为窗口对齐相关的输入处理添加保护，以避免在多显示器环境中出现无效窗口移动，并在失败时安全地取消交互。

Bug 修复：
- 防止在与光标对齐或跟踪鼠标移动时，窗口移动操作将游戏窗口移动到其他显示器上，或部分移出屏幕之外。
- 在窗口或光标移动失败后，通过中止操作、恢复原始位置并解除输入阻塞，避免继续后续的输入序列。
- 在窗口移动前后安全地挂起并恢复目标进程，确保当移动失败时，目标进程不会观察到光标/窗口对齐状态的不一致。

增强改进：
- 引入一个可复用的保护器，在调用 SetWindowPos 之前验证预测的窗口位置是否仍在原始显示器上，如果被拒绝则记录详细诊断日志。
- 通过原子标志跟踪无效的 WithWindowPos 移动，在保护状态被重置之前，拒绝后续的输入（touch_down、touch_move、touch_up、scroll）。
- 对多种 Win32 结构统一使用零初始化并结合花括号初始化，以提高代码清晰度和安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard window-alignment input handling in WithWindowPos mode to avoid invalid window moves across monitors and cancel interactions safely on failure.

Bug Fixes:
- Prevent window movement operations from moving the game window to a different monitor or partially off-screen when aligning with the cursor or tracking mouse movement.
- Avoid continuing input sequences after failed window or cursor moves by aborting the operation, restoring original positions, and unblocking input.
- Suspend and resume the target process safely around window moves, ensuring it never observes inconsistent cursor/window alignment when movement fails.

Enhancements:
- Introduce a reusable guard that validates predicted window positions against the original monitor before applying SetWindowPos, logging detailed diagnostics when rejected.
- Track invalid WithWindowPos movements via an atomic flag and reject subsequent input (touch_down, touch_move, touch_up, scroll) until the guard state is reset.
- Consistently use zero-initialized structs with brace initialization for various Win32 structures to improve clarity and safety.

</details>