### PR TITLE
fix(win32): WithWindowPos 模式下禁用窗口位置检查

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -63,6 +63,7 @@ MessageInput::MessageInput(HWND hwnd, Config config)
     , config_(config)
 {
     if (config_.with_window_pos) {
+        window_pos_guard_enabled_ = false;
         tracking_thread_ = std::thread(&MessageInput::tracking_thread_func, this);
     }
 }
@@ -393,6 +394,10 @@ bool MessageInput::move_window_to_align_cursor(int x, int y)
 
 bool MessageInput::is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason)
 {
+    if (!window_pos_guard_enabled_) {
+        return true;
+    }
+
     RECT base_rect = window_pos_saved_ ? saved_window_rect_ : current_rect;
 
     HMONITOR origin_monitor = MonitorFromRect(&base_rect, MONITOR_DEFAULTTONULL);

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -60,6 +60,10 @@ public: // from InputBase
 public: // mouse lock follow
     bool set_mouse_lock_follow(bool enabled);
 
+    // WithWindowPos 模式下默认禁用显示器保护，因为后台控制器需要自由移动窗口。
+    // 如需恢复保护，调用 set_window_pos_guard_enabled(true)。
+    void set_window_pos_guard_enabled(bool enabled) { window_pos_guard_enabled_ = enabled; }
+
 private:
     using TrackingClock = std::chrono::steady_clock;
     using TrackingDeadlineTicks = TrackingClock::duration::rep;
@@ -121,6 +125,7 @@ private:
     std::atomic_int pending_mouse_y_ = 0;
     std::atomic_bool has_pending_mouse_ = false;
     std::atomic_bool window_pos_invalid_movement_ = false;
+    std::atomic_bool window_pos_guard_enabled_ = true;
     std::atomic_bool mouse_down_sent_ = false;
     std::atomic_int mouse_down_contact_ = 0;
     std::atomic_int last_mouse_x_ = 0;


### PR DESCRIPTION
- fix https://github.com/MaaEnd/MaaEnd/issues/2583
- fix https://github.com/MaaEnd/MaaEnd/issues/2616

## Summary by Sourcery

在使用 WithWindowPos 模式时，默认禁用窗口位置保护机制，并允许通过新的配置方法重新启用。

Bug 修复：
- 通过跳过窗口位置检查（除非显式重新启用），防止在 WithWindowPos 模式下错误地阻止窗口移动。

增强功能：
- 添加运行时开关，用于在需要不受限制的窗口移动的场景中启用或禁用窗口位置保护机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable window position guard by default when using WithWindowPos mode and allow re-enabling it via a new configuration method.

Bug Fixes:
- Prevent incorrect blocking of window movements in WithWindowPos mode by bypassing window position checks unless explicitly re-enabled.

Enhancements:
- Add a runtime toggle to enable or disable the window position guard for scenarios requiring unrestricted window movement.

</details>