### PR TITLE
fix(win32): 键盘注入时补全硬件扫描码(wScan)

### DIFF
--- a/source/MaaWin32ControlUnit/Input/BackgroundManagedKeyInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/BackgroundManagedKeyInput.cpp
@@ -202,6 +202,7 @@ void BackgroundManagedKeyInput::send_key_event(int keycode, bool key_up)
     INPUT input { };
     input.type = INPUT_KEYBOARD;
     input.ki.wVk = static_cast<WORD>(keycode);
+    input.ki.wScan = static_cast<WORD>(MapVirtualKeyW(static_cast<UINT>(keycode), MAPVK_VK_TO_VSC));
     input.ki.dwFlags = key_up ? KEYEVENTF_KEYUP : 0;
     SendInput(1, &input, sizeof(INPUT));
 }

--- a/source/MaaWin32ControlUnit/Input/LegacyEventInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/LegacyEventInput.cpp
@@ -161,7 +161,7 @@ bool LegacyEventInput::key_down(int key)
 
     // check_and_block_input();
 
-    keybd_event(static_cast<BYTE>(key), 0, 0, 0);
+    keybd_event(static_cast<BYTE>(key), static_cast<BYTE>(MapVirtualKeyW(static_cast<UINT>(key), MAPVK_VK_TO_VSC)), 0, 0);
 
     return true;
 }
@@ -175,7 +175,7 @@ bool LegacyEventInput::key_up(int key)
 
     // OnScopeLeave([this]() { unblock_input(); });
 
-    keybd_event(static_cast<BYTE>(key), 0, KEYEVENTF_KEYUP, 0);
+    keybd_event(static_cast<BYTE>(key), static_cast<BYTE>(MapVirtualKeyW(static_cast<UINT>(key), MAPVK_VK_TO_VSC)), KEYEVENTF_KEYUP, 0);
 
     return true;
 }

--- a/source/MaaWin32ControlUnit/Input/SeizeInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/SeizeInput.cpp
@@ -237,6 +237,7 @@ bool SeizeInput::key_down(int key)
 
     inputs[0].type = INPUT_KEYBOARD;
     inputs[0].ki.wVk = static_cast<WORD>(key);
+    inputs[0].ki.wScan = static_cast<WORD>(MapVirtualKeyW(static_cast<UINT>(key), MAPVK_VK_TO_VSC));
 
     SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));
 
@@ -256,6 +257,7 @@ bool SeizeInput::key_up(int key)
 
     inputs[0].type = INPUT_KEYBOARD;
     inputs[0].ki.wVk = static_cast<WORD>(key);
+    inputs[0].ki.wScan = static_cast<WORD>(MapVirtualKeyW(static_cast<UINT>(key), MAPVK_VK_TO_VSC));
     inputs[0].ki.dwFlags = KEYEVENTF_KEYUP;
 
     SendInput(ARRAYSIZE(inputs), inputs, sizeof(INPUT));


### PR DESCRIPTION
SeizeInput、BackgroundManagedKeyInput、LegacyEventInput 的按键注入 之前只设置 wVk（虚拟键码），未设置 wScan（硬件扫描码），导致使用
Raw Input 读取键盘事件的游戏无法识别注入的按键。

通过 MapVirtualKeyW(MAPVK_VK_TO_VSC) 显式填充 wScan，与
MessageInput 的行为保持一致。

## Summary by Sourcery

Bug Fixes:
- 在 `SeizeInput`、`BackgroundManagedKeyInput` 和 `LegacyEventInput` 的键盘注入中使用 `MapVirtualKeyW` 填充 `wScan`，以确保与基于 Raw Input 的应用程序兼容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Populate wScan in SeizeInput, BackgroundManagedKeyInput, and LegacyEventInput keyboard injections using MapVirtualKeyW to ensure compatibility with Raw Input-based applications.

</details>