### PR TITLE
fix(Python): pass UTF-8 byte length for log dir option

### DIFF
--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -645,12 +645,12 @@ class Tasker:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        encoded_path = str(path).encode()
+        encoded_path_bytes = str(path).encode("utf-8")
         return bool(
             Library.framework().MaaGlobalSetOption(
                 MaaOption(MaaGlobalOptionEnum.LogDir),
-                encoded_path,
-                len(encoded_path),
+                encoded_path_bytes,
+                len(encoded_path_bytes),
             )
         )
 

--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -645,12 +645,12 @@ class Tasker:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        strpath = str(path)
+        encoded_path = str(path).encode()
         return bool(
             Library.framework().MaaGlobalSetOption(
                 MaaOption(MaaGlobalOptionEnum.LogDir),
-                strpath.encode(),
-                len(strpath),
+                encoded_path,
+                len(encoded_path),
             )
         )
 

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -472,7 +472,8 @@ def test_tasker_api(resource: Resource, controller: DbgController):
     # 测试全局选项 (静态方法)
     Tasker.set_save_draw(True)
     Tasker.set_stdout_level(LoggingLevelEnum.All)
-    Tasker.set_log_dir("debug")
+    log_dir = install_dir / "bin" / "debug" / "新建文件夹"
+    assert Tasker.set_log_dir(log_dir)
     Tasker.set_debug_mode(True)
     Tasker.set_save_on_error(True)
     Tasker.set_draw_quality(85)


### PR DESCRIPTION
Tasker.set_log_dir encoded the path as UTF-8 but passed the character count to MaaGlobalSetOption. Non-ASCII paths were truncated before native path conversion on Windows, which could surface as an uncaught C++ filesystem exception.

Use the encoded byte length and cover set_log_dir with a non-ASCII path in the binding test.

## Summary by Sourcery

修复 Python Tasker 日志目录配置，以正确处理 UTF-8 路径，并在测试中为包含非 ASCII 字符的日志目录路径补充覆盖。

Bug 修复：
- 通过使用 UTF-8 字节长度而不是字符数来修正传递给 `MaaGlobalSetOption` 的日志目录选项长度，避免非 ASCII 路径被截断。

测试：
- 扩展 Python 绑定测试，以验证 `Tasker.set_log_dir` 在 Windows 风格路径中使用包含非 ASCII 字符的日志目录路径时能够正常工作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Python Tasker log directory configuration to correctly handle UTF-8 paths and add coverage for non-ASCII log directory paths in tests.

Bug Fixes:
- Correct the length passed to MaaGlobalSetOption for the log directory option by using the UTF-8 byte length instead of the character count to avoid truncation of non-ASCII paths.

Tests:
- Extend Python binding tests to verify Tasker.set_log_dir works with a non-ASCII log directory path on Windows-like paths.

</details>