### PR TITLE
feat:将window_pos_saved_标记清除延迟到inactive()

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -216,7 +216,6 @@ void MessageInput::restore_window_pos()
     if (!SetWindowPos(hwnd_, nullptr, left, top, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE)) {
         LogError << "SetWindowPos failed during restore" << VAR(hwnd_) << VAR(GetLastError());
     }
-    window_pos_saved_ = false;
 }
 
 void MessageInput::start_window_tracking(int x, int y)
@@ -828,6 +827,7 @@ void MessageInput::inactive()
     }
 
     restore_pos();
+    window_pos_saved_ = false;
     unblock_input();
 }
 


### PR DESCRIPTION
### 改动  
restore_window_pos()不再清除标记，改为在 inactive() 中清除，使 WithWindowPos模式下首次保存的窗口位置在整个任务期间不被覆盖，便于恢复窗口位置

### 关联MAA PR
[feat:SendMsg在WindowPos输入下保留窗口原始位置，任务结束时恢复](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/16528)

## Summary by Sourcery

Enhancements:
- 在 WithWindowPos 模式下，通过在 `inactive()` 时清除已保存位置标志，而不是在位置恢复期间清除，从而保留首次保存的窗口位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Preserve the first saved window position in WithWindowPos mode by clearing the saved-position flag on inactive() instead of during position restoration.

</details>