### PR TITLE
perf: avoid masked matchTemplate when no mask is needed

### DIFF
--- a/source/MaaFramework/Vision/TemplateMatcher.cpp
+++ b/source/MaaFramework/Vision/TemplateMatcher.cpp
@@ -64,7 +64,21 @@ TemplateMatcher::ResultsVec TemplateMatcher::template_match(const cv::Mat& templ
     }
 
     cv::Mat matched;
-    cv::matchTemplate(image, templ, matched, method, create_mask(templ, param_.green_mask));
+    cv::Mat mask;
+    if (param_.green_mask) {
+        mask = create_mask(templ, true);
+
+        if (!mask.empty() && cv::countNonZero(mask) == mask.rows * mask.cols) {
+            mask.release();
+        }
+    }
+
+    if (mask.empty()) {
+        cv::matchTemplate(image, templ, matched, method);
+    }
+    else {
+        cv::matchTemplate(image, templ, matched, method, mask);
+    }
 
     if (invert_score) {
         matched = 1.0f - matched;


### PR DESCRIPTION
## 由 Sourcery 提供的总结

通过在掩码实际不会起作用时跳过带 mask 的 `matchTemplate` 调用来优化模板匹配，并基于现有测试数据集为 TemplateMatcher 引入专门的性能与正确性测试可执行程序。

新特性：
- 添加可选的性能测试目标和 `TemplateMatcherPerformance` 可执行文件，用于对模板匹配行为以及 OpenCV 使用情况进行基准测试。
- 添加 `TemplateMatcherCorrectness` 可执行文件，用于将 TemplateMatcher 的结果与原生 OpenCV `matchTemplate` 的预期结果进行对比验证。

增强：
- 当启用了绿色掩码但实际生成的是一个“完全激活”的掩码时，不再构造并传递 mask 给 `cv::matchTemplate`，而是回退到无 mask 的重载版本。

构建：
- 引入 `BUILD_PERFORMANCE_TESTING` 选项，将 templatematcher 测试和共享的 `TestingDataSet` 子目录接入构建系统，并在启用流水线测试时强制启用 `WITH_DBG_CONTROLLER`。

测试：
- 为以 TemplateMatcher 为重点的测试可执行文件添加可复用的 CMake 配置和共享源码。
- 添加基于数据集的性能与正确性探针，在真实负载和各种掩码配置下对 TemplateMatcher 进行验证与压测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize template matching by skipping masked matchTemplate calls when the mask would be effectively unused, and introduce dedicated performance and correctness test binaries for TemplateMatcher using the existing test dataset.

New Features:
- Add optional performance testing target and TemplateMatcherPerformance executable to benchmark template matching behavior and OpenCV usage.
- Add TemplateMatcherCorrectness executable to validate TemplateMatcher results against raw OpenCV matchTemplate expectations.

Enhancements:
- Avoid constructing and passing a mask to cv::matchTemplate when green masking is enabled but produces a fully active mask, falling back to the unmasked overload instead.

Build:
- Introduce BUILD_PERFORMANCE_TESTING option, wire templatematcher tests and shared TestingDataSet subdirectory into the build, and enforce WITH_DBG_CONTROLLER when pipeline testing is enabled.

Tests:
- Add reusable CMake configuration and shared sources for TemplateMatcher-focused test executables.
- Add dataset-based performance and correctness probes to exercise TemplateMatcher under realistic workloads and mask configurations.

</details>