### PR TITLE
fix(ci): 升级 Node.js 至 v22 以兼容 pnpm 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Prepare node_modules
               run: |
@@ -184,7 +184,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             # https://github.com/MaaXYZ/MaaFramework/actions/runs/5643408179/job/15285186255
             - uses: actions/checkout@v4
@@ -303,7 +303,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Prepare node_modules
               run: |
@@ -515,7 +515,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Build wrapper
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4
@@ -179,7 +179,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4
@@ -298,7 +298,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4
@@ -510,7 +510,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4
@@ -204,7 +204,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4
@@ -335,7 +335,7 @@ jobs:
 
             - uses: pnpm/action-setup@v4
               with:
-                  version: latest
+                  version: 10
 
             - name: Use Node
               uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Prepare Node Binding
               shell: bash
@@ -209,7 +209,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Prepare Node Binding
               shell: bash
@@ -340,7 +340,7 @@ jobs:
             - name: Use Node
               uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
 
             - name: Prepare Node Binding
               shell: bash

--- a/source/binding/NodeJS/package.json
+++ b/source/binding/NodeJS/package.json
@@ -1,4 +1,7 @@
 {
+    "pnpm": {
+        "onlyBuiltDependencies": ["esbuild"]
+    },
     "binary": {
         "napi_versions": [
             8


### PR DESCRIPTION
pnpm 11 依赖 node:sqlite 内置模块，要求 Node.js >= v22.13。

## Summary by Sourcery

将 CI 工作流更新为在构建和测试任务中使用 Node.js 22。

CI：
- 在 GitHub Actions 构建工作流中，将 Node.js 版本从 20 升级到 22。
- 在 GitHub Actions 测试工作流中，将 Node.js 版本从 20 升级到 22。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to use Node.js 22 for build and test jobs.

CI:
- Bump Node.js version from 20 to 22 in GitHub Actions build workflow.
- Bump Node.js version from 20 to 22 in GitHub Actions test workflow.

</details>