### PR TITLE
fix: validate dbg controller for pipeline testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,13 @@ if(NOT WITH_REPLAY_CONTROLLER)
     set(BUILD_PIPELINE_TESTING OFF)
 endif()
 
+# check options
+if(BUILD_PIPELINE_TESTING AND NOT WITH_DBG_CONTROLLER)
+    message(FATAL_ERROR
+            "BUILD_PIPELINE_TESTING requires WITH_DBG_CONTROLLER because PipelineTesting uses the debug controller. "
+            "Please configure with -DWITH_DBG_CONTROLLER=ON or -DBUILD_PIPELINE_TESTING=OFF.")
+endif()
+
 if(WITH_WIN32_CONTROLLER AND NOT WIN32)
     message(STATUS "Not on Windows, disable WITH_WIN32_CONTROLLER")
     set(WITH_WIN32_CONTROLLER OFF)


### PR DESCRIPTION
PipelineTesting calls MaaDbgControllerCreate, which requires MaaDbgControlUnit to be built. Fail during CMake configuration when BUILD_PIPELINE_TESTING is enabled without WITH_DBG_CONTROLLER, so the option mismatch is reported early with a clear message.

## Summary by Sourcery

错误修复：
- 当启用了 `BUILD_PIPELINE_TESTING` 但未启用 `WITH_DBG_CONTROLLER` 时，使 CMake 配置失败，以防止错误配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent misconfiguration by failing CMake configuration when BUILD_PIPELINE_TESTING is enabled without WITH_DBG_CONTROLLER.

</details>