### PR TITLE
fix: use _wfopen for non-ASCII log paths on Windows

### DIFF
--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -645,12 +645,12 @@ class Tasker:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        encoded_path = str(path).encode()
+        encoded_path_bytes = str(path).encode("utf-8")
         return bool(
             Library.framework().MaaGlobalSetOption(
                 MaaOption(MaaGlobalOptionEnum.LogDir),
-                encoded_path,
-                len(encoded_path),
+                encoded_path_bytes,
+                len(encoded_path_bytes),
             )
         )
 

--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -1,6 +1,7 @@
 import ctypes
 import dataclasses
 import json
+from os import fspath
 from pathlib import Path
 from typing import Dict, Optional, Union
 
@@ -645,7 +646,7 @@ class Tasker:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        encoded_path_bytes = str(path).encode("utf-8")
+        encoded_path_bytes = fspath(path).encode("utf-8")
         return bool(
             Library.framework().MaaGlobalSetOption(
                 MaaOption(MaaGlobalOptionEnum.LogDir),

--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -645,12 +645,12 @@ class Tasker:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        strpath = str(path)
+        encoded_path = str(path).encode()
         return bool(
             Library.framework().MaaGlobalSetOption(
                 MaaOption(MaaGlobalOptionEnum.LogDir),
-                strpath.encode(),
-                len(strpath),
+                encoded_path,
+                len(encoded_path),
             )
         )
 

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -472,7 +472,8 @@ def test_tasker_api(resource: Resource, controller: DbgController):
     # 测试全局选项 (静态方法)
     Tasker.set_save_draw(True)
     Tasker.set_stdout_level(LoggingLevelEnum.All)
-    Tasker.set_log_dir("debug")
+    log_dir = install_dir / "bin" / "debug" / "新建文件夹"
+    assert Tasker.set_log_dir(log_dir)
     Tasker.set_debug_mode(True)
     Tasker.set_save_on_error(True)
     Tasker.set_draw_quality(85)


### PR DESCRIPTION
## 问题

在 Windows 上，当 `set_log_dir` 的路径包含非 ASCII 字符（如中文 `新建文件夹`）时，Python 绑定测试会崩溃，抛出 `OSError: 0xe06d7363`。

## 原因

`Logger::open()` 中使用 `fopen` 打开日志文件时，通过 `path.string()` 将内部 `std::wstring` 转换为窄字符串。在 Windows 上，这个转换使用的是系统活动代码页（ACP），而非 UTF-8。

在中文 Windows（ACP=936/GBK）上，UTF-8 导出的宽字符串再通过 GBK 转回窄字符串会产生乱码，导致 `fopen` 失败并抛出 C++ 异常。

日志也印证了这一点：`log_dir_=C:/MaaFramework/install/bin/debug/?????`

## 修复

将 `fopen` 改为 `_wfopen`，直接使用宽字符串路径，绕过有损的 `.string()` 转换：

```cpp
// Before:
std::string str_log_path = log_path_.string();
FILE* file_ptr = fopen(str_log_path.c_str(), append ? "a" : "w");

// After:
FILE* file_ptr = _wfopen(log_path_.c_str(), append ? L"a" : L"w");
```

## 相关

- 依赖子模块 PR: https://github.com/MaaXYZ/MaaUtils/pull/16

## Summary by Sourcery

确保 Python 绑定正确传递 UTF-8 编码的日志目录路径，并扩展测试以覆盖包含非 ASCII 字符的 Windows 路径。

Bug Fixes:
- 修复 Python 中的 `Tasker.set_log_dir`，使其向底层框架发送 UTF-8 编码的路径，避免在使用含非 ASCII 字符的目录时发生崩溃。

Tests:
- 新增一个 Python 绑定测试，将日志目录设置为包含非 ASCII 字符的路径，以验证处理是否正确。

Chores:
- 更新 MaaUtils 子模块引用，以获取 Windows 宽路径日志记录相关的修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Python bindings correctly pass UTF-8 encoded log directory paths and extend tests to cover non-ASCII Windows paths.

Bug Fixes:
- Fix Python Tasker.set_log_dir to send UTF-8 encoded paths to the underlying framework, avoiding crashes with non-ASCII directories.

Tests:
- Add a Python binding test that sets the log directory to a path containing non-ASCII characters to validate correct handling.

Chores:
- Update MaaUtils submodule reference to pick up Windows wide-path logging fixes.

</details>