### PR TITLE
docs: update macOS controller notes for Stage Manager and PostToPid

### DIFF
--- a/docs/en_us/2.4-ControlMethods.md
+++ b/docs/en_us/2.4-ControlMethods.md
@@ -189,9 +189,9 @@ No default value. Client can choose one as the default.
 
 > [!NOTE]
 >
-> - **Screencap**: ScreenCaptureKit supports background capture, including fullscreen windows on other Spaces, without requiring the target window to be in the foreground.
+> - **Screencap**: ScreenCaptureKit supports background capture, including fullscreen windows on other Spaces, without requiring the target window to be in the foreground. Does not support Stage Manager, screenshots only capture the tilted thumbnail window, suspected system bug.
 > - **Keyboard input**: In PostToPid mode, keyboard input supports background operation without activating the target window.
-> - **Mouse input**: Due to macOS system limitations, mouse events activate the target window regardless of whether GlobalEvent or PostToPid is used. For mouse operations, GlobalEvent is recommended (it automatically activates the window and restores the cursor position after the operation). If only keyboard operations are needed, PostToPid enables true background control.
+> - **Mouse input**: PostToPid supports background and fullscreen input and clicking. However, some games (e.g., 异环) check for window focus on the first click and steal focus if absent, causing the window to repeatedly jump to the foreground and making it impossible to stop. It is recommended that the frontend prompt users to run in windowed mode or provide a hotkey to stop execution.
 
 ## PlayCover (macOS)
 

--- a/docs/en_us/2.4-ControlMethods.md
+++ b/docs/en_us/2.4-ControlMethods.md
@@ -187,6 +187,12 @@ No default value. Client can choose one as the default.
 | GlobalEvent | `1` | High | Accessibility | No | Injects into the global HID event stream via `CGEventPost(kCGHIDEventTap)`, dispatched by the OS to the front window (automatically activates the target window) |
 | PostToPid | `2` | Medium | Accessibility | Yes | Sends directly to the target process via `CGEventPostToPid`, no need for the target window to be in the foreground |
 
+> [!NOTE]
+>
+> - **Screencap**: ScreenCaptureKit supports background capture, including fullscreen windows on other Spaces, without requiring the target window to be in the foreground.
+> - **Keyboard input**: In PostToPid mode, keyboard input supports background operation without activating the target window.
+> - **Mouse input**: Due to macOS system limitations, mouse events activate the target window regardless of whether GlobalEvent or PostToPid is used. For mouse operations, GlobalEvent is recommended (it automatically activates the window and restores the cursor position after the operation). If only keyboard operations are needed, PostToPid enables true background control.
+
 ## PlayCover (macOS)
 
 The PlayCover controller is used to control iOS applications running via [fork PlayCover](https://github.com/hguandl/PlayCover/releases) on macOS.

--- a/docs/zh_cn/2.4-控制方式说明.md
+++ b/docs/zh_cn/2.4-控制方式说明.md
@@ -189,9 +189,9 @@ tccutil reset Accessibility
 
 > [!NOTE]
 >
-> - **截图**：ScreenCaptureKit 支持后台截图，包括其他 Space 中的全屏窗口，无需目标窗口处于前台。
+> - **截图**：ScreenCaptureKit 支持后台截图，包括其他 Space 中的全屏窗口，无需目标窗口处于前台。不支持台前调度（Stage Manager），截图仅能获取倾斜的缩略小窗，疑似系统 Bug。
 > - **键盘输入**：PostToPid 模式下键盘输入支持后台操作，无需激活目标窗口。
-> - **鼠标输入**：受 macOS 系统限制，鼠标事件无论使用 GlobalEvent 还是 PostToPid 均会激活目标窗口。如需鼠标操作，建议使用 GlobalEvent（自动激活窗口并在操作后恢复光标位置）。若仅需键盘操作，PostToPid 可实现真正的后台控制。
+> - **鼠标输入**：PostToPid 支持后台和全屏输入与点击。但部分游戏（如异环）会在首次点击时检测窗口焦点，若无焦点则抢夺焦点，导致窗口不断跳转前台而无法停止。建议前端提示用户以窗口化模式运行，或提供快捷键停止运行。
 
 ## PlayCover (macOS)
 

--- a/docs/zh_cn/2.4-控制方式说明.md
+++ b/docs/zh_cn/2.4-控制方式说明.md
@@ -187,6 +187,12 @@ tccutil reset Accessibility
 | GlobalEvent | `1` | 高 | 辅助功能权限 | 否 | 通过 `CGEventPost(kCGHIDEventTap)` 向全局 HID 事件流注入，由系统分发至前台窗口（会自动激活目标窗口） |
 | PostToPid | `2` | 中 | 辅助功能权限 | 是 | 通过 `CGEventPostToPid` 直接发送至目标进程，无需目标窗口处于前台 |
 
+> [!NOTE]
+>
+> - **截图**：ScreenCaptureKit 支持后台截图，包括其他 Space 中的全屏窗口，无需目标窗口处于前台。
+> - **键盘输入**：PostToPid 模式下键盘输入支持后台操作，无需激活目标窗口。
+> - **鼠标输入**：受 macOS 系统限制，鼠标事件无论使用 GlobalEvent 还是 PostToPid 均会激活目标窗口。如需鼠标操作，建议使用 GlobalEvent（自动激活窗口并在操作后恢复光标位置）。若仅需键盘操作，PostToPid 可实现真正的后台控制。
+
 ## PlayCover (macOS)
 
 PlayCover 控制器用于在 macOS 上控制通过 [fork版PlayCover](https://github.com/hguandl/PlayCover/releases) 运行的 iOS 应用程序。

--- a/source/MaaToolkit/DesktopWindow/DesktopWindowMacOSFinder.mm
+++ b/source/MaaToolkit/DesktopWindow/DesktopWindowMacOSFinder.mm
@@ -30,13 +30,8 @@ std::vector<DesktopWindow> DesktopWindowMacOSFinder::find_all() const
                 return;
             }
 
-            // 枚举所有窗口
+            // 枚举所有窗口（包括其他 Space 的全屏窗口）
             for (SCWindow* window in content.windows) {
-                // 跳过不可见的窗口
-                if (!window.isOnScreen) {
-                    continue;
-                }
-
                 std::wstring class_name;
                 if (window.owningApplication) {
                     NSString* bundleId = window.owningApplication.bundleIdentifier ? window.owningApplication.bundleIdentifier : @"";


### PR DESCRIPTION
Closes #1311

## Changes

- **截图**：补充台前调度（Stage Manager）不支持说明，截图仅能获取倾斜的缩略小窗，疑似系统 Bug
- **鼠标输入**：更新 PostToPid 描述，支持后台和全屏输入与点击；补充部分游戏（如异环）抢焦点导致窗口不断跳转前台的注意事项，建议前端提示窗口化运行或提供快捷键停止

中英文文档同步更新。

## Summary by Sourcery

记录 macOS 在 Stage Manager（舞台管理）和 PostToPid 下的控制器行为，并扩展 macOS 窗口枚举逻辑，以包含其他 Spaces 中的全屏窗口。

增强功能：
- 在基于 Finder 的窗口枚举逻辑中，包含来自其他 Spaces 的 macOS 全屏窗口。

文档：
- 澄清 macOS 的 ScreenCaptureKit 后台捕获对 Stage Manager 的支持不正确，这很可能是由于系统缺陷导致的。
- 记录 PostToPid 在后台和全屏输入场景下的键盘和鼠标行为，包括某些游戏中会抢占焦点的注意事项，以及在英文和中文控制方式文档中的推荐 UI 指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document macOS controller behavior for Stage Manager and PostToPid, and expand macOS window enumeration to include fullscreen windows on other Spaces.

Enhancements:
- Include macOS fullscreen windows from other Spaces in the Finder-based window enumeration logic.

Documentation:
- Clarify that macOS ScreenCaptureKit background capture does not correctly support Stage Manager, likely due to a system bug.
- Document PostToPid keyboard and mouse behavior for background and fullscreen input, including focus-stealing caveats for certain games and recommended UI guidance in both English and Chinese control method docs.

</details>