### PR TITLE
fix(Win32-Input): 支持系统鼠标左右键互换设置

### DIFF
--- a/source/MaaWin32ControlUnit/Input/InputUtils.h
+++ b/source/MaaWin32ControlUnit/Input/InputUtils.h
@@ -64,7 +64,7 @@ inline bool IsMouseButtonSwapped()
 inline int GetMappedContact(int original_contact)
 {
     if (IsMouseButtonSwapped()) {
-        // 左右键交换后，左键为1，右键为0，异或取反即可
+        // 左右键交换后，左键为1，右键为0，异或取反输出即可
         return original_contact ^ 1;
     }
     return original_contact;

--- a/source/MaaWin32ControlUnit/Input/InputUtils.h
+++ b/source/MaaWin32ControlUnit/Input/InputUtils.h
@@ -53,6 +53,23 @@ inline void ensure_foreground_and_topmost(HWND hwnd)
     }
 }
 
+// 检查鼠标左右按键是否被交换
+inline bool IsMouseButtonSwapped()
+{
+    int is_swapped = GetSystemMetrics(SM_SWAPBUTTON);
+    return is_swapped != 0;
+}
+
+// 获取兼容鼠标左右按键交换后的鼠标按键映射
+inline int GetMappedContact(int original_contact)
+{
+    if (IsMouseButtonSwapped()) {
+        // 左右键交换后，左键为1，右键为0，异或取反即可
+        return original_contact ^ 1;
+    }
+    return original_contact;
+}
+
 // Contact 到 WM_* 消息的转换结果
 struct MouseMessageInfo
 {
@@ -63,7 +80,8 @@ struct MouseMessageInfo
 // 将 contact ID 转换为鼠标按下消息
 inline bool contact_to_mouse_down_message(int contact, MouseMessageInfo& info)
 {
-    switch (contact) {
+    int mapped_contact = GetMappedContact(contact);
+    switch (mapped_contact) {
     case 0:
         info.message = WM_LBUTTONDOWN;
         info.w_param = MK_LBUTTON;
@@ -92,7 +110,8 @@ inline bool contact_to_mouse_down_message(int contact, MouseMessageInfo& info)
 // 将 contact ID 转换为鼠标移动消息
 inline bool contact_to_mouse_move_message(int contact, MouseMessageInfo& info)
 {
-    switch (contact) {
+    int mapped_contact = GetMappedContact(contact);
+    switch (mapped_contact) {
     case 0:
         info.message = WM_MOUSEMOVE;
         info.w_param = MK_LBUTTON;
@@ -121,7 +140,8 @@ inline bool contact_to_mouse_move_message(int contact, MouseMessageInfo& info)
 // 将 contact ID 转换为鼠标抬起消息
 inline bool contact_to_mouse_up_message(int contact, MouseMessageInfo& info)
 {
-    switch (contact) {
+    int mapped_contact = GetMappedContact(contact);
+    switch (mapped_contact) {
     case 0:
         info.message = WM_LBUTTONUP;
         info.w_param = 0;
@@ -157,7 +177,8 @@ struct MouseEventFlags
 // 将 contact ID 转换为 MOUSEEVENTF 按下标志（用于 SendInput/mouse_event）
 inline bool contact_to_mouse_down_flags(int contact, MouseEventFlags& flags_info)
 {
-    switch (contact) {
+    int mapped_contact = GetMappedContact(contact);
+    switch (mapped_contact) {
     case 0:
         flags_info.flags = MOUSEEVENTF_LEFTDOWN;
         flags_info.button_data = 0;
@@ -186,7 +207,8 @@ inline bool contact_to_mouse_down_flags(int contact, MouseEventFlags& flags_info
 // 将 contact ID 转换为 MOUSEEVENTF 抬起标志（用于 SendInput/mouse_event）
 inline bool contact_to_mouse_up_flags(int contact, MouseEventFlags& flags_info)
 {
-    switch (contact) {
+    int mapped_contact = GetMappedContact(contact);
+    switch (mapped_contact) {
     case 0:
         flags_info.flags = MOUSEEVENTF_LEFTUP;
         flags_info.button_data = 0;


### PR DESCRIPTION
## 问题描述
MaaFramework v5.10.4 Win32 输入层将 `contact=0/1` 直接硬编码为左/右键消息或 `SendInput` 标志，未读取系统 `SM_SWAPBUTTON` 设置。

Windows 开启「左右键互换」后：
- Win32-Front（SeizeInput）点击失效
- Win32-Window-Background（MessageInput with_window_pos）点击失效

## 修复方案
在 `InputUtils.h` 中统一做逻辑主键/副键 remap：

- 添加 `IsMouseButtonSwapped()` 读取 `GetSystemMetrics(SM_SWAPBUTTON)`
- 添加 `GetMappedContact()` 使用异或 `^1` 实现 0↔1 互换
- 修改所有 `contact_to_xxx` 函数，使用映射后的按键
- MessageInput 和 SeizeInput 自动获得左右键互换支持

## 修改的文件
- `source/MaaWin32ControlUnit/Input/InputUtils.h`

## 关联 Issue
Fixes #1323

## Summary by Sourcery

Bug Fixes:
- 在将鼠标接触映射到 Win32 消息和 `SendInput` 标志时，遵从系统的 `SM_SWAPBUTTON` 设置，以便在 Win32 前台和后台模式下，交换了主/副按钮的鼠标能够正确触发点击。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Respect the system SM_SWAPBUTTON setting when mapping mouse contacts to Win32 messages and SendInput flags so swapped primary/secondary buttons click correctly in Win32 front and background modes.

</details>