### PR TITLE
docs: 添加 MaaHub 链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ _✨ 基于图像识别的自动化黑盒测试框架 ✨_
 
 > [!TIP]
 > 访问我们的 [官网](https://maafw.com/) 以获得更优秀的文档阅读体验。  
-> 找不到相关文档？试试问 [AI](https://deepwiki.com/MaaXYZ/MaaFramework) ！
+> 找不到相关文档？试试问 [AI](https://deepwiki.com/MaaXYZ/MaaFramework) ！  
+> 在 [MaaHub](https://hub.maafw.com) 发现更多由社区提供的技能、流水线、自定义模块与经验。
 
 - [快速开始](docs/zh_cn/1.1-快速开始.md) & [术语解释](docs/zh_cn/1.2-术语解释.md)
 - [代码集成](docs/zh_cn/2.1-集成文档.md) & [API](docs/zh_cn/2.2-集成接口一览.md)

--- a/README_en.md
+++ b/README_en.md
@@ -51,7 +51,8 @@ It offers low-code simplicity while maintaining high extensibility. The framewor
 
 > [!TIP]
 > Visit our [website](https://maafw.com/) for a better documentation experience.  
-> Can't find the relevant documents? Try asking [AI](https://deepwiki.com/MaaXYZ/MaaFramework) ！
+> Can't find the relevant documents? Try asking [AI](https://deepwiki.com/MaaXYZ/MaaFramework) !  
+> Discover more community-contributed skills, pipelines, customs, and experiences on [MaaHub](https://hub.maafw.com).
 
 - [Quick Start](docs/en_us/1.1-QuickStarted.md) & [Terms](docs/en_us/1.2-ExplanationOfTerms.md)
 - [Integration](docs/en_us/2.1-Integration.md) & [API](docs/en_us/2.2-IntegratedInterfaceOverview.md)

--- a/docs/en_us/1.1-QuickStarted.md
+++ b/docs/en_us/1.1-QuickStarted.md
@@ -5,7 +5,8 @@
 MaaFramework provides three integration solutions to meet different development scenarios:
 
 > [!TIP]
-> Afraid of not being able to understand? It doesn't matter, there are many mature [projects](https://github.com/MaaXYZ/MaaFramework?tab=readme-ov-file#%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F) in the community to refer to.
+> Afraid of not being able to understand? It doesn't matter, there are many mature [projects](https://github.com/MaaXYZ/MaaFramework?tab=readme-ov-file#%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F) in the community to refer to.  
+> You can also discover more community-contributed skills, pipelines, customs, and experiences on [MaaHub](https://hub.maafw.com).
 
 ### Approach 1: Pure JSON Low-Code Programming
 

--- a/docs/zh_cn/1.1-快速开始.md
+++ b/docs/zh_cn/1.1-快速开始.md
@@ -5,7 +5,8 @@
 MaaFramework 提供三种集成方案，满足不同开发场景需求：
 
 > [!TIP]
-> 害怕看不懂？没关系，社区内有很多成熟的 [项目](https://github.com/MaaXYZ/MaaFramework?tab=readme-ov-file#%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F) 可供参考。
+> 害怕看不懂？没关系，社区内有很多成熟的 [项目](https://github.com/MaaXYZ/MaaFramework?tab=readme-ov-file#%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F) 可供参考。  
+> 还可以去 [MaaHub](https://hub.maafw.com) 发现更多由社区提供的技能、流水线、自定义模块与经验。
 
 ### 方案一：纯 JSON 低代码编程
 


### PR DESCRIPTION
## Summary by Sourcery

在中文和英文的文档入口中，将 MaaHub 作为额外的社区资源进行链接。

Documentation:
- 在主中文 README 的提示部分中添加 MaaHub 链接，作为关于技能、流水线、自定义模块和经验的社区资源。
- 在主英文 README 的提示部分中添加 MaaHub 链接，以突出社区贡献的技能、流水线、自定义项和经验。
- 在英文快速上手指南中提及 MaaHub，将其作为额外的社区参考资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Link MaaHub as an additional community resource in both Chinese and English documentation entry points.

Documentation:
- Add MaaHub link to the main Chinese README tip section as a community resource for skills, pipelines, custom modules, and experiences.
- Add MaaHub link to the main English README tip section highlighting community-contributed skills, pipelines, customs, and experiences.
- Mention MaaHub as an additional community reference resource in the English Quick Start guide.

</details>