### PR TITLE
feat: 增加MaaContextRunRecognitionList并行识别

### DIFF
--- a/include/MaaFramework/Instance/MaaContext.h
+++ b/include/MaaFramework/Instance/MaaContext.h
@@ -27,20 +27,26 @@ extern "C"
     /**
      * @brief Recognize a list of entries against a single given frame, in parallel.
      *
-     * The framework runs the recognition of every entry concurrently against the same image,
-     * then returns the index of the highest-priority (lowest-index) entry that hit. Per-node
-     * recognition callbacks are NOT emitted. No subsequent action or next is executed.
+     * The framework runs the recognition of EVERY entry concurrently against the same image and
+     * waits for ALL of them to finish before returning. Per-node recognition callbacks are NOT
+     * emitted. No subsequent action or next is executed.
      *
-     * @param entries_json JSON array of entry (node) names, ordered by priority.
+     * @param entries_json JSON array of entry (node) names.
      * @param pipeline_override pipeline override json (use "{}" for none).
      * @param image Image to recognize. Must not be NULL or empty.
-     * @return The index into @p entries_json of the first hit, or -1 if none hit / on error.
+     * @param reco_ids Output array, caller-allocated, with at least as many elements as entries
+     *                 in @p entries_json. On success each element receives the MaaRecoId of the
+     *                 corresponding entry (aligned by index), or MaaInvalidId if that entry was
+     *                 skipped (node not found / disabled). Query each id for its recognition
+     *                 detail (hit / box / ...) via MaaTasker.
+     * @return true on success, false on error.
      */
-    MAA_FRAMEWORK_API int64_t MaaContextRunRecognitionList(
+    MAA_FRAMEWORK_API MaaBool MaaContextRunRecognitionList(
         MaaContext* context,
         const char* entries_json,
         const char* pipeline_override,
-        const MaaImageBuffer* image);
+        const MaaImageBuffer* image,
+        /* out */ MaaRecoId* reco_ids);
 
     MAA_FRAMEWORK_API MaaActId MaaContextRunAction(
         MaaContext* context,

--- a/include/MaaFramework/Instance/MaaContext.h
+++ b/include/MaaFramework/Instance/MaaContext.h
@@ -24,6 +24,24 @@ extern "C"
     MAA_FRAMEWORK_API MaaRecoId
         MaaContextRunRecognition(MaaContext* context, const char* entry, const char* pipeline_override, const MaaImageBuffer* image);
 
+    /**
+     * @brief Recognize a list of entries against a single given frame, in parallel.
+     *
+     * The framework runs the recognition of every entry concurrently against the same image,
+     * then returns the index of the highest-priority (lowest-index) entry that hit. Per-node
+     * recognition callbacks are NOT emitted. No subsequent action or next is executed.
+     *
+     * @param entries_json JSON array of entry (node) names, ordered by priority.
+     * @param pipeline_override pipeline override json (use "{}" for none).
+     * @param image Image to recognize. Must not be NULL or empty.
+     * @return The index into @p entries_json of the first hit, or -1 if none hit / on error.
+     */
+    MAA_FRAMEWORK_API int64_t MaaContextRunRecognitionList(
+        MaaContext* context,
+        const char* entries_json,
+        const char* pipeline_override,
+        const MaaImageBuffer* image);
+
     MAA_FRAMEWORK_API MaaActId MaaContextRunAction(
         MaaContext* context,
         const char* entry,

--- a/source/Common/MaaContext.cpp
+++ b/source/Common/MaaContext.cpp
@@ -75,6 +75,64 @@ MaaRecoId MaaContextRunRecognition(MaaContext* context, const char* entry, const
     return context->run_recognition(entry, ov_opt->as_object(), mat);
 }
 
+int64_t MaaContextRunRecognitionList(
+    MaaContext* context,
+    const char* entries_json,
+    const char* pipeline_override,
+    const MaaImageBuffer* image)
+{
+    LogFunc << VAR_VOIDP(context) << VAR(entries_json) << VAR(pipeline_override);
+
+    if (!context || !image) {
+        LogError << "handle is null";
+        return -1;
+    }
+
+    if (!entries_json) {
+        LogError << "entries_json is null";
+        return -1;
+    }
+
+    if (!pipeline_override) {
+        LogError << "pipeline_override is null";
+        return -1;
+    }
+
+    auto entries_opt = json::parse(entries_json);
+    if (!entries_opt || !entries_opt->is_array()) {
+        LogError << "failed to parse entries as array" << VAR(entries_json);
+        return -1;
+    }
+
+    std::vector<std::string> entries;
+    entries.reserve(entries_opt->as_array().size());
+    for (const auto& v : entries_opt->as_array()) {
+        if (!v.is_string()) {
+            LogError << "entries must be an array of strings" << VAR(entries_json);
+            return -1;
+        }
+        entries.emplace_back(v.as_string());
+    }
+
+    auto ov_opt = json::parse(pipeline_override);
+    if (!ov_opt) {
+        LogError << "failed to parse" << VAR(pipeline_override);
+        return -1;
+    }
+    if (!ov_opt->is_object()) {
+        LogError << "json is not object" << VAR(pipeline_override);
+        return -1;
+    }
+
+    const auto& mat = image->get();
+    if (mat.empty()) {
+        LogError << "empty image";
+        return -1;
+    }
+
+    return context->run_recognition_list(entries, ov_opt->as_object(), mat);
+}
+
 MaaActId
     MaaContextRunAction(MaaContext* context, const char* entry, const char* pipeline_override, const MaaRect* box, const char* reco_detail)
 {

--- a/source/Common/MaaContext.cpp
+++ b/source/Common/MaaContext.cpp
@@ -75,33 +75,39 @@ MaaRecoId MaaContextRunRecognition(MaaContext* context, const char* entry, const
     return context->run_recognition(entry, ov_opt->as_object(), mat);
 }
 
-int64_t MaaContextRunRecognitionList(
+MaaBool MaaContextRunRecognitionList(
     MaaContext* context,
     const char* entries_json,
     const char* pipeline_override,
-    const MaaImageBuffer* image)
+    const MaaImageBuffer* image,
+    MaaRecoId* reco_ids)
 {
     LogFunc << VAR_VOIDP(context) << VAR(entries_json) << VAR(pipeline_override);
 
     if (!context || !image) {
         LogError << "handle is null";
-        return -1;
+        return false;
     }
 
     if (!entries_json) {
         LogError << "entries_json is null";
-        return -1;
+        return false;
     }
 
     if (!pipeline_override) {
         LogError << "pipeline_override is null";
-        return -1;
+        return false;
+    }
+
+    if (!reco_ids) {
+        LogError << "reco_ids is null";
+        return false;
     }
 
     auto entries_opt = json::parse(entries_json);
     if (!entries_opt || !entries_opt->is_array()) {
         LogError << "failed to parse entries as array" << VAR(entries_json);
-        return -1;
+        return false;
     }
 
     std::vector<std::string> entries;
@@ -109,7 +115,7 @@ int64_t MaaContextRunRecognitionList(
     for (const auto& v : entries_opt->as_array()) {
         if (!v.is_string()) {
             LogError << "entries must be an array of strings" << VAR(entries_json);
-            return -1;
+            return false;
         }
         entries.emplace_back(v.as_string());
     }
@@ -117,20 +123,27 @@ int64_t MaaContextRunRecognitionList(
     auto ov_opt = json::parse(pipeline_override);
     if (!ov_opt) {
         LogError << "failed to parse" << VAR(pipeline_override);
-        return -1;
+        return false;
     }
     if (!ov_opt->is_object()) {
         LogError << "json is not object" << VAR(pipeline_override);
-        return -1;
+        return false;
     }
 
     const auto& mat = image->get();
     if (mat.empty()) {
         LogError << "empty image";
-        return -1;
+        return false;
     }
 
-    return context->run_recognition_list(entries, ov_opt->as_object(), mat);
+    auto ids = context->run_recognition_list(entries, ov_opt->as_object(), mat);
+
+    // 输出数组由调用方按 entries 数量预分配；按下标对齐写入，缺失部分填 MaaInvalidId。
+    for (size_t i = 0; i < entries.size(); ++i) {
+        reco_ids[i] = i < ids.size() ? ids[i] : MaaInvalidId;
+    }
+
+    return true;
 }
 
 MaaActId

--- a/source/MaaAgentClient/Client/AgentClient.cpp
+++ b/source/MaaAgentClient/Client/AgentClient.cpp
@@ -261,6 +261,9 @@ bool AgentClient::handle_inserted_request(const json::value& j)
     else if (handle_context_run_recognition(j)) {
         return true;
     }
+    else if (handle_context_run_recognition_list(j)) {
+        return true;
+    }
     else if (handle_context_run_action(j)) {
         return true;
     }
@@ -557,6 +560,33 @@ bool AgentClient::handle_context_run_recognition(const json::value& j)
 
     ContextRunRecognitionReverseResponse resp {
         .reco_id = reco_id,
+    };
+    send(resp);
+
+    return true;
+}
+
+bool AgentClient::handle_context_run_recognition_list(const json::value& j)
+{
+    if (!j.is<ContextRunRecognitionListReverseRequest>()) {
+        return false;
+    }
+
+    const ContextRunRecognitionListReverseRequest& req = j.as<ContextRunRecognitionListReverseRequest>();
+    LogFunc << VAR(req) << VAR(ipc_addr_);
+
+    MaaContext* context = query_context(req.context_id);
+
+    int64_t hit_index = -1;
+    if (context) {
+        hit_index = context->run_recognition_list(req.entries, req.pipeline_override, get_image_cache(req.image));
+    }
+    else {
+        LogError << "context not found" << VAR(req.context_id);
+    }
+
+    ContextRunRecognitionListReverseResponse resp {
+        .hit_index = hit_index,
     };
     send(resp);
 

--- a/source/MaaAgentClient/Client/AgentClient.cpp
+++ b/source/MaaAgentClient/Client/AgentClient.cpp
@@ -577,16 +577,16 @@ bool AgentClient::handle_context_run_recognition_list(const json::value& j)
 
     MaaContext* context = query_context(req.context_id);
 
-    int64_t hit_index = -1;
+    std::vector<MaaRecoId> reco_ids;
     if (context) {
-        hit_index = context->run_recognition_list(req.entries, req.pipeline_override, get_image_cache(req.image));
+        reco_ids = context->run_recognition_list(req.entries, req.pipeline_override, get_image_cache(req.image));
     }
     else {
         LogError << "context not found" << VAR(req.context_id);
     }
 
     ContextRunRecognitionListReverseResponse resp {
-        .hit_index = hit_index,
+        .reco_ids = std::move(reco_ids),
     };
     send(resp);
 

--- a/source/MaaAgentClient/Client/AgentClient.h
+++ b/source/MaaAgentClient/Client/AgentClient.h
@@ -41,6 +41,7 @@ private: // Transceiver
 private:
     bool handle_context_run_task(const json::value& j);
     bool handle_context_run_recognition(const json::value& j);
+    bool handle_context_run_recognition_list(const json::value& j);
     bool handle_context_run_action(const json::value& j);
     bool handle_context_run_recognition_direct(const json::value& j);
     bool handle_context_run_action_direct(const json::value& j);

--- a/source/MaaAgentServer/RemoteInstance/RemoteContext.cpp
+++ b/source/MaaAgentServer/RemoteInstance/RemoteContext.cpp
@@ -43,6 +43,22 @@ MaaRecoId RemoteContext::run_recognition(const std::string& entry, const json::v
     return resp_opt->reco_id;
 }
 
+int64_t RemoteContext::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image)
+{
+    ContextRunRecognitionListReverseRequest req {
+        .context_id = context_id_,
+        .entries = entries,
+        .pipeline_override = pipeline_override,
+        .image = server_.send_image(image),
+    };
+
+    auto resp_opt = server_.send_and_recv<ContextRunRecognitionListReverseResponse>(req);
+    if (!resp_opt) {
+        return -1;
+    }
+    return resp_opt->hit_index;
+}
+
 MaaActId RemoteContext::run_action(
     const std::string& entry,
     const json::value& pipeline_override,

--- a/source/MaaAgentServer/RemoteInstance/RemoteContext.cpp
+++ b/source/MaaAgentServer/RemoteInstance/RemoteContext.cpp
@@ -43,7 +43,8 @@ MaaRecoId RemoteContext::run_recognition(const std::string& entry, const json::v
     return resp_opt->reco_id;
 }
 
-int64_t RemoteContext::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image)
+std::vector<MaaRecoId>
+    RemoteContext::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image)
 {
     ContextRunRecognitionListReverseRequest req {
         .context_id = context_id_,
@@ -54,9 +55,9 @@ int64_t RemoteContext::run_recognition_list(const std::vector<std::string>& entr
 
     auto resp_opt = server_.send_and_recv<ContextRunRecognitionListReverseResponse>(req);
     if (!resp_opt) {
-        return -1;
+        return std::vector<MaaRecoId>(entries.size(), MaaInvalidId);
     }
-    return resp_opt->hit_index;
+    return resp_opt->reco_ids;
 }
 
 MaaActId RemoteContext::run_action(

--- a/source/MaaAgentServer/RemoteInstance/RemoteContext.h
+++ b/source/MaaAgentServer/RemoteInstance/RemoteContext.h
@@ -19,6 +19,8 @@ public:
 
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) override;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) override;
+    virtual int64_t
+        run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) override;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail)
             override;

--- a/source/MaaAgentServer/RemoteInstance/RemoteContext.h
+++ b/source/MaaAgentServer/RemoteInstance/RemoteContext.h
@@ -19,7 +19,7 @@ public:
 
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) override;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) override;
-    virtual int64_t
+    virtual std::vector<MaaRecoId>
         run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) override;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail)

--- a/source/MaaFramework/Resource/OCRResMgr.cpp
+++ b/source/MaaFramework/Resource/OCRResMgr.cpp
@@ -95,6 +95,7 @@ void OCRResMgr::clear()
     LogFunc;
 
     roots_.clear();
+    std::lock_guard lock(models_mutex_);
     deters_.clear();
     recers_.clear();
     ocrers_.clear();
@@ -102,6 +103,8 @@ void OCRResMgr::clear()
 
 std::shared_ptr<fastdeploy::vision::ocr::DBDetector> OCRResMgr::deter(const std::string& name)
 {
+    std::lock_guard lock(models_mutex_);
+
     if (auto iter = deters_.find(name); iter != deters_.end()) {
         return iter->second;
     }
@@ -116,6 +119,8 @@ std::shared_ptr<fastdeploy::vision::ocr::DBDetector> OCRResMgr::deter(const std:
 
 std::shared_ptr<fastdeploy::vision::ocr::Recognizer> OCRResMgr::recer(const std::string& name)
 {
+    std::lock_guard lock(models_mutex_);
+
     if (auto iter = recers_.find(name); iter != recers_.end()) {
         return iter->second;
     }
@@ -130,6 +135,8 @@ std::shared_ptr<fastdeploy::vision::ocr::Recognizer> OCRResMgr::recer(const std:
 
 std::shared_ptr<fastdeploy::pipeline::PPOCRv4> OCRResMgr::ocrer(const std::string& name)
 {
+    std::lock_guard lock(models_mutex_);
+
     if (auto iter = ocrers_.find(name); iter != ocrers_.end()) {
         return iter->second;
     }

--- a/source/MaaFramework/Resource/OCRResMgr.h
+++ b/source/MaaFramework/Resource/OCRResMgr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <mutex>
 
 #include "Common/Conf.h"
 
@@ -51,6 +52,8 @@ private:
     fastdeploy::RuntimeOption det_option_;
     fastdeploy::RuntimeOption rec_option_;
 
+    // 保护下列模型缓存的懒加载写入，使其可被并行识别安全访问。
+    std::mutex models_mutex_;
     std::unordered_map<std::string, std::shared_ptr<fastdeploy::vision::ocr::DBDetector>> deters_;
     std::unordered_map<std::string, std::shared_ptr<fastdeploy::vision::ocr::Recognizer>> recers_;
     std::unordered_map<std::string, std::shared_ptr<fastdeploy::pipeline::PPOCRv4>> ocrers_;

--- a/source/MaaFramework/Resource/ONNXResMgr.cpp
+++ b/source/MaaFramework/Resource/ONNXResMgr.cpp
@@ -133,6 +133,8 @@ void ONNXResMgr::clear()
 {
     LogFunc;
 
+    std::lock_guard lock(models_mutex_);
+
     classifier_roots_.clear();
     detector_roots_.clear();
     classifiers_.clear();
@@ -141,6 +143,8 @@ void ONNXResMgr::clear()
 
 std::shared_ptr<Ort::Session> ONNXResMgr::classifier(const std::string& name)
 {
+    std::lock_guard lock(models_mutex_);
+
     if (auto iter = classifiers_.find(name); iter != classifiers_.end()) {
         return iter->second;
     }
@@ -155,6 +159,8 @@ std::shared_ptr<Ort::Session> ONNXResMgr::classifier(const std::string& name)
 
 std::shared_ptr<Ort::Session> ONNXResMgr::detector(const std::string& name)
 {
+    std::lock_guard lock(models_mutex_);
+
     if (auto iter = detectors_.find(name); iter != detectors_.end()) {
         return iter->second;
     }

--- a/source/MaaFramework/Resource/ONNXResMgr.h
+++ b/source/MaaFramework/Resource/ONNXResMgr.h
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <mutex>
 #include <optional>
 
 #include <onnxruntime/onnxruntime_cxx_api.h>
@@ -41,6 +42,8 @@ private:
     Ort::SessionOptions options_;
     Ort::MemoryInfo memory_info_;
 
+    // 保护 classifiers_/detectors_ 的懒加载，使其可被并行识别安全调用。
+    std::mutex models_mutex_;
     std::unordered_map<std::string, std::shared_ptr<Ort::Session>> classifiers_;
     std::unordered_map<std::string, std::shared_ptr<Ort::Session>> detectors_;
 };

--- a/source/MaaFramework/Resource/TemplateResMgr.cpp
+++ b/source/MaaFramework/Resource/TemplateResMgr.cpp
@@ -29,6 +29,7 @@ bool TemplateResMgr::load_file(const std::filesystem::path& path)
     }
 
     auto name = path_to_utf8_string(path.filename());
+    std::lock_guard lock(image_cache_mutex_);
     image_cache_[name] = { std::move(image) };
     return true;
 }
@@ -38,11 +39,15 @@ void TemplateResMgr::clear()
     LogFunc;
 
     roots_.clear();
+    std::lock_guard lock(image_cache_mutex_);
     image_cache_.clear();
 }
 
 std::vector<cv::Mat> TemplateResMgr::get_image(const std::string& name)
 {
+    // 持锁覆盖整个查找+懒加载+写入，使其可被并行识别安全调用。
+    std::lock_guard lock(image_cache_mutex_);
+
     if (auto iter = image_cache_.find(name); iter != image_cache_.end()) {
         return iter->second;
     }
@@ -57,6 +62,7 @@ std::vector<cv::Mat> TemplateResMgr::get_image(const std::string& name)
 
 void TemplateResMgr::set_image(const std::string& name, const cv::Mat& image)
 {
+    std::lock_guard lock(image_cache_mutex_);
     image_cache_[name] = { image };
 }
 

--- a/source/MaaFramework/Resource/TemplateResMgr.h
+++ b/source/MaaFramework/Resource/TemplateResMgr.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <mutex>
 #include <unordered_map>
 
 #include "Common/Conf.h"
@@ -26,6 +27,8 @@ private:
 
     std::vector<std::filesystem::path> roots_ = { "" }; // for filepath without prefix
 
+    // 保护 image_cache_ 的懒加载写入，使其可被并行识别安全访问。
+    std::mutex image_cache_mutex_;
     std::unordered_map<std::string, std::vector<cv::Mat>> image_cache_;
 };
 

--- a/source/MaaFramework/Task/Context.cpp
+++ b/source/MaaFramework/Task/Context.cpp
@@ -1,8 +1,6 @@
 #include "Context.h"
 
-#include <atomic>
 #include <future>
-#include <limits>
 #include <thread>
 
 #include <meojson/json.hpp>
@@ -113,30 +111,34 @@ MaaRecoId Context::run_recognition(const std::string& entry, const json::value& 
     return subtask.run_impl();
 }
 
-int64_t Context::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image_in)
+std::vector<MaaRecoId>
+    Context::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image_in)
 {
     LogFunc << VAR(getptr()) << VAR(entries) << VAR(pipeline_override);
 
+    // 与 entries 等长、按下标对齐；被跳过的 entry 保持 MaaInvalidId。
+    std::vector<MaaRecoId> reco_ids(entries.size(), MaaInvalidId);
+
     if (entries.empty()) {
-        return -1;
+        return reco_ids;
     }
     if (!tasker_) {
         LogError << "tasker is null";
-        return -1;
+        return reco_ids;
     }
 
     // 用一个 clone 承载可选的 override，识别期间只读，供多线程共享。
     auto work_ctx = make_clone();
     if (!pipeline_override.empty() && !work_ctx->override_pipeline(pipeline_override)) {
         LogError << "failed to override_pipeline" << VAR(pipeline_override);
-        return -1;
+        return reco_ids;
     }
 
     // 与 run_recognition 一致：画面由调用方传入，所有 entry 共用同一画面，本函数不负责抓取。
     const cv::Mat& image = image_in;
     if (image.empty()) {
         LogError << "empty image";
-        return -1;
+        return reco_ids;
     }
 
     const size_t count = entries.size();
@@ -167,50 +169,30 @@ int64_t Context::run_recognition_list(const std::vector<std::string>& entries, c
         }
     }
 
-    // best 记录已命中的最小 entry 下标，保留 next 列表"下标即优先级"的语义。
-    std::atomic<int64_t> best { std::numeric_limits<int64_t>::max() };
-
     // 直接走 Recognizer，绕过 RecognitionTask 的逐节点回调（避免并发回调竞态与日志洪泛）。
-    // 与 TaskBase::run_recognition 一致：node 级 inverse 需在此翻转命中结果。
-    auto recognize_hit = [&](size_t i) -> bool {
+    // 对每个 entry 完整执行识别并记录其 reco_id（无论是否命中），识别详情已写入 runtime_cache，
+    // 调用方可凭 reco_id 自行查询命中结果。reco_ids 已按下标预分配，各线程写入互不相交的元素，无竞态。
+    auto recognize_one = [&](size_t i) {
         Recognizer recognizer(tasker_, *work_ctx, image);
         RecoResult res = recognizer.recognize(datas[i].reco_type, datas[i].reco_param, datas[i].name);
-        bool hit = res.box.has_value();
-        if (datas[i].inverse) {
-            hit = !hit;
-        }
-        return hit;
+        reco_ids[i] = res.reco_id;
     };
 
-    // 并行阶段：只跑非 Custom 节点。parallel_indices 升序，故 worker 跨步遍历到的下标也升序，
-    // 一旦当前下标已高于已命中的 best，后续都不可能成为更高优先级命中，直接 break 提前退出。
+    // 并行阶段：非 Custom 节点全部跑完，不提前退出。
     const size_t parallel_count = parallel_indices.size();
     const unsigned hardware_threads = std::max(1U, std::thread::hardware_concurrency());
     const size_t worker_count = std::min(parallel_count, static_cast<size_t>(hardware_threads));
 
     auto worker = [&](size_t start) {
         for (size_t k = start; k < parallel_count; k += worker_count) {
-            const size_t i = parallel_indices[k];
-            if (static_cast<int64_t>(i) > best.load(std::memory_order_relaxed)) {
-                break;
-            }
-            if (!recognize_hit(i)) {
-                continue;
-            }
-            int64_t prev = best.load(std::memory_order_relaxed);
-            while (static_cast<int64_t>(i) < prev
-                   && !best.compare_exchange_weak(prev, static_cast<int64_t>(i), std::memory_order_relaxed)) {
-            }
-            break;
+            recognize_one(parallel_indices[k]);
         }
     };
 
-    if (worker_count <= 1) {
-        if (worker_count == 1) {
-            worker(0);
-        }
+    if (worker_count == 1) {
+        worker(0);
     }
-    else {
+    else if (worker_count > 1) {
         std::vector<std::future<void>> futures;
         futures.reserve(worker_count - 1);
         for (size_t w = 1; w < worker_count; ++w) {
@@ -222,22 +204,13 @@ int64_t Context::run_recognition_list(const std::vector<std::string>& entries, c
         }
     }
 
-    // 串行阶段：Custom 节点按下标升序逐个跑，只在其优先级高于已命中 best 时才识别；
-    // 命中即为剩余范围内的最高优先级，直接收敛。
+    // 串行阶段：Custom 节点逐个完整执行（反向 IPC 不可并发）。
     for (size_t i : custom_indices) {
-        if (static_cast<int64_t>(i) >= best.load(std::memory_order_relaxed)) {
-            break;
-        }
-        if (recognize_hit(i)) {
-            best.store(static_cast<int64_t>(i), std::memory_order_relaxed);
-            break;
-        }
+        recognize_one(i);
     }
 
-    const int64_t hit = best.load(std::memory_order_relaxed);
-    const int64_t hit_index = hit == std::numeric_limits<int64_t>::max() ? -1 : hit;
-    LogTrace << VAR(getptr()) << VAR(hit_index) << VAR(count);
-    return hit_index;
+    LogTrace << VAR(getptr()) << VAR(reco_ids) << VAR(count);
+    return reco_ids;
 }
 
 MaaActId

--- a/source/MaaFramework/Task/Context.cpp
+++ b/source/MaaFramework/Task/Context.cpp
@@ -1,9 +1,15 @@
 #include "Context.h"
 
+#include <atomic>
+#include <future>
+#include <limits>
+#include <thread>
+
 #include <meojson/json.hpp>
 
 #include "ActionTask.h"
 #include "Component/ActionHelper.h"
+#include "Component/Recognizer.h"
 #include "MaaUtils/Logger.h"
 #include "MaaUtils/Uuid.h"
 #include "PipelineTask.h"
@@ -105,6 +111,133 @@ MaaRecoId Context::run_recognition(const std::string& entry, const json::value& 
         return MaaInvalidId;
     }
     return subtask.run_impl();
+}
+
+int64_t Context::run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image_in)
+{
+    LogFunc << VAR(getptr()) << VAR(entries) << VAR(pipeline_override);
+
+    if (entries.empty()) {
+        return -1;
+    }
+    if (!tasker_) {
+        LogError << "tasker is null";
+        return -1;
+    }
+
+    // 用一个 clone 承载可选的 override，识别期间只读，供多线程共享。
+    auto work_ctx = make_clone();
+    if (!pipeline_override.empty() && !work_ctx->override_pipeline(pipeline_override)) {
+        LogError << "failed to override_pipeline" << VAR(pipeline_override);
+        return -1;
+    }
+
+    // 与 run_recognition 一致：画面由调用方传入，所有 entry 共用同一画面，本函数不负责抓取。
+    const cv::Mat& image = image_in;
+    if (image.empty()) {
+        LogError << "empty image";
+        return -1;
+    }
+
+    const size_t count = entries.size();
+
+    // 预取每个 entry 的 pipeline 数据并按"识别类型是否会触发 Agent 回调"分流（串行，开销很小）：
+    //   - Custom 识别在主进程里会经由 reco_agent 反向 IPC 调用 Agent，必须串行跑在当前 IPC 处理线程上，
+    //     绝不能塞进 worker 线程（多线程同时占用同一 socket + 嵌套 send/recv 会冲垮协议）。
+    //   - 其余纯本地识别（TemplateMatch/OCR/ColorMatch/And/Or 等）无副作用，可安全并行。
+    // 注意：若 And/Or 的子识别引用了 Custom 节点，同样会触发回调；实时任务当前不存在该用法，故只判顶层类型。
+    std::vector<PipelineData> datas(count);
+    std::vector<size_t> parallel_indices; // 升序，非 Custom
+    std::vector<size_t> custom_indices;    // 升序，Custom
+    for (size_t i = 0; i < count; ++i) {
+        auto data_opt = work_ctx->get_pipeline_data(entries[i]);
+        if (!data_opt) {
+            LogWarn << "node not found, skip" << VAR(entries[i]);
+            continue;
+        }
+        if (!data_opt->enabled) {
+            continue;
+        }
+        datas[i] = std::move(*data_opt);
+        if (datas[i].reco_type == MAA_RES_NS::Recognition::Type::Custom) {
+            custom_indices.emplace_back(i);
+        }
+        else {
+            parallel_indices.emplace_back(i);
+        }
+    }
+
+    // best 记录已命中的最小 entry 下标，保留 next 列表"下标即优先级"的语义。
+    std::atomic<int64_t> best { std::numeric_limits<int64_t>::max() };
+
+    // 直接走 Recognizer，绕过 RecognitionTask 的逐节点回调（避免并发回调竞态与日志洪泛）。
+    // 与 TaskBase::run_recognition 一致：node 级 inverse 需在此翻转命中结果。
+    auto recognize_hit = [&](size_t i) -> bool {
+        Recognizer recognizer(tasker_, *work_ctx, image);
+        RecoResult res = recognizer.recognize(datas[i].reco_type, datas[i].reco_param, datas[i].name);
+        bool hit = res.box.has_value();
+        if (datas[i].inverse) {
+            hit = !hit;
+        }
+        return hit;
+    };
+
+    // 并行阶段：只跑非 Custom 节点。parallel_indices 升序，故 worker 跨步遍历到的下标也升序，
+    // 一旦当前下标已高于已命中的 best，后续都不可能成为更高优先级命中，直接 break 提前退出。
+    const size_t parallel_count = parallel_indices.size();
+    const unsigned hardware_threads = std::max(1U, std::thread::hardware_concurrency());
+    const size_t worker_count = std::min(parallel_count, static_cast<size_t>(hardware_threads));
+
+    auto worker = [&](size_t start) {
+        for (size_t k = start; k < parallel_count; k += worker_count) {
+            const size_t i = parallel_indices[k];
+            if (static_cast<int64_t>(i) > best.load(std::memory_order_relaxed)) {
+                break;
+            }
+            if (!recognize_hit(i)) {
+                continue;
+            }
+            int64_t prev = best.load(std::memory_order_relaxed);
+            while (static_cast<int64_t>(i) < prev
+                   && !best.compare_exchange_weak(prev, static_cast<int64_t>(i), std::memory_order_relaxed)) {
+            }
+            break;
+        }
+    };
+
+    if (worker_count <= 1) {
+        if (worker_count == 1) {
+            worker(0);
+        }
+    }
+    else {
+        std::vector<std::future<void>> futures;
+        futures.reserve(worker_count - 1);
+        for (size_t w = 1; w < worker_count; ++w) {
+            futures.emplace_back(std::async(std::launch::async, worker, w));
+        }
+        worker(0);
+        for (auto& f : futures) {
+            f.get();
+        }
+    }
+
+    // 串行阶段：Custom 节点按下标升序逐个跑，只在其优先级高于已命中 best 时才识别；
+    // 命中即为剩余范围内的最高优先级，直接收敛。
+    for (size_t i : custom_indices) {
+        if (static_cast<int64_t>(i) >= best.load(std::memory_order_relaxed)) {
+            break;
+        }
+        if (recognize_hit(i)) {
+            best.store(static_cast<int64_t>(i), std::memory_order_relaxed);
+            break;
+        }
+    }
+
+    const int64_t hit = best.load(std::memory_order_relaxed);
+    const int64_t hit_index = hit == std::numeric_limits<int64_t>::max() ? -1 : hit;
+    LogTrace << VAR(getptr()) << VAR(hit_index) << VAR(count);
+    return hit_index;
 }
 
 MaaActId

--- a/source/MaaFramework/Task/Context.h
+++ b/source/MaaFramework/Task/Context.h
@@ -41,6 +41,8 @@ public:
 public: // from MaaContextAPI
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) override;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) override;
+    virtual int64_t
+        run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) override;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail)
             override;

--- a/source/MaaFramework/Task/Context.h
+++ b/source/MaaFramework/Task/Context.h
@@ -41,7 +41,7 @@ public:
 public: // from MaaContextAPI
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) override;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) override;
-    virtual int64_t
+    virtual std::vector<MaaRecoId>
         run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) override;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail)

--- a/source/include/Common/MaaTypes.h
+++ b/source/include/Common/MaaTypes.h
@@ -166,9 +166,10 @@ public:
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) = 0;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) = 0;
 
-    // 对一组 entry 在同一帧画面上并行识别，返回最高优先级（最小下标）命中的下标，未命中返回 -1。
-    // image 为空时由实现侧自行抓取一帧；并行调度在实现侧完成；不发送每节点的识别回调。
-    virtual int64_t
+    // 对一组 entry 在同一帧画面上并行识别，全部识别完成后再返回；
+    // 返回与 entries 等长、按下标对齐的 reco_id 数组（被跳过的 entry 为 MaaInvalidId）。
+    // 并行调度在实现侧完成；不发送每节点的识别回调。
+    virtual std::vector<MaaRecoId>
         run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) = 0;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail) = 0;

--- a/source/include/Common/MaaTypes.h
+++ b/source/include/Common/MaaTypes.h
@@ -165,6 +165,11 @@ public:
 
     virtual MaaTaskId run_task(const std::string& entry, const json::value& pipeline_override) = 0;
     virtual MaaRecoId run_recognition(const std::string& entry, const json::value& pipeline_override, const cv::Mat& image) = 0;
+
+    // 对一组 entry 在同一帧画面上并行识别，返回最高优先级（最小下标）命中的下标，未命中返回 -1。
+    // image 为空时由实现侧自行抓取一帧；并行调度在实现侧完成；不发送每节点的识别回调。
+    virtual int64_t
+        run_recognition_list(const std::vector<std::string>& entries, const json::value& pipeline_override, const cv::Mat& image) = 0;
     virtual MaaActId
         run_action(const std::string& entry, const json::value& pipeline_override, const cv::Rect& box, const std::string& reco_detail) = 0;
 

--- a/source/include/MaaAgent/Message.hpp
+++ b/source/include/MaaAgent/Message.hpp
@@ -14,7 +14,7 @@ MAA_AGENT_NS_BEGIN
 // ReverseRequest: server -> client
 
 using MessageTypePlaceholder = int;
-inline static constexpr int kProtocolVersion = 7;
+inline static constexpr int kProtocolVersion = 8;
 
 struct StartUpRequest
 {
@@ -201,6 +201,26 @@ struct ContextRunRecognitionReverseResponse
 
     MessageTypePlaceholder _ContextRunRecognitionReverseResponse = 1;
     MEO_JSONIZATION(reco_id, _ContextRunRecognitionReverseResponse);
+};
+
+struct ContextRunRecognitionListReverseRequest
+{
+    std::string context_id;
+    std::vector<std::string> entries;
+    json::value pipeline_override;
+    std::string image;
+
+    MessageTypePlaceholder _ContextRunRecognitionListReverseRequest = 1;
+    MEO_JSONIZATION(context_id, entries, pipeline_override, image, _ContextRunRecognitionListReverseRequest);
+};
+
+struct ContextRunRecognitionListReverseResponse
+{
+    // 最高优先级（最小下标）命中的 entry 下标，未命中为 -1
+    int64_t hit_index = -1;
+
+    MessageTypePlaceholder _ContextRunRecognitionListReverseResponse = 1;
+    MEO_JSONIZATION(hit_index, _ContextRunRecognitionListReverseResponse);
 };
 
 struct ContextRunActionReverseRequest

--- a/source/include/MaaAgent/Message.hpp
+++ b/source/include/MaaAgent/Message.hpp
@@ -216,11 +216,11 @@ struct ContextRunRecognitionListReverseRequest
 
 struct ContextRunRecognitionListReverseResponse
 {
-    // 最高优先级（最小下标）命中的 entry 下标，未命中为 -1
-    int64_t hit_index = -1;
+    // 与请求 entries 等长、按下标对齐的 reco_id 数组，被跳过的 entry 为 MaaInvalidId
+    std::vector<int64_t> reco_ids;
 
     MessageTypePlaceholder _ContextRunRecognitionListReverseResponse = 1;
-    MEO_JSONIZATION(hit_index, _ContextRunRecognitionListReverseResponse);
+    MEO_JSONIZATION(reco_ids, _ContextRunRecognitionListReverseResponse);
 };
 
 struct ContextRunActionReverseRequest

--- a/source/modules/MaaFramework.cppm
+++ b/source/modules/MaaFramework.cppm
@@ -131,6 +131,7 @@ export using ::MaaCustomActionCallback;
 
 export using ::MaaContextRunTask;
 export using ::MaaContextRunRecognition;
+export using ::MaaContextRunRecognitionList;
 export using ::MaaContextRunAction;
 export using ::MaaContextRunRecognitionDirect;
 export using ::MaaContextRunActionDirect;


### PR DESCRIPTION
背景：maaend实时任务用，ipc只能串行执行，因此加一个RecognitionList方法，全部识别完成后返回结果。

内部实现：
普通节点并行识别，custom节点串行执行

返回值：博爱成功或失败
输出：MaaRecoId* 识别结果数组，长度根据传入entries_json 个数决定
```
MAA_FRAMEWORK_API MaaBool MaaContextRunRecognitionList(
        MaaContext* context,
        const char* entries_json,
        const char* pipeline_override,
        const MaaImageBuffer* image,
        /* out */ MaaRecoId* reco_ids);
```


opus4.8

## Summary by Sourcery

添加了一个新的 API 和 IPC 路径，用于在单帧图像上并行运行针对多个条目的识别，并返回首个命中的索引；同时使模型/模板资源管理器在并发识别场景下实现线程安全。

New Features:
- 引入 `Context::run_recognition_list` 以及对应的 C API `MaaContextRunRecognitionList`，用于在同一张图像上识别多个条目，并返回优先级最高的命中索引。
- 增加远程/agent 消息类型和处理程序，以在 MaaAgent IPC 协议上支持 context run-recognition-list，并更新协议版本。
- 从 MaaFramework 模块接口中重新导出 `MaaContextRunRecognitionList`。

Enhancements:
- 将对多个条目的识别拆分为并行的本地识别和串行的 Custom 识别，以避免 IPC 争用，同时保持优先级语义。
- 通过使用互斥锁保护惰性加载的模型和图像缓存，使 OCR、ONNX 和模板资源管理器线程安全，从而支持安全的并发识别。

Documentation:
- 在公共头文件中记录 `MaaContextRunRecognitionList` API 的行为、参数和返回值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new API and IPC path to run recognition on a list of entries against a single frame in parallel, returning the first hit index, and make model/template resource managers thread-safe for concurrent recognition.

New Features:
- Introduce Context::run_recognition_list and corresponding MaaContextRunRecognitionList C API to recognize multiple entries on the same image and return the highest-priority hit index.
- Add remote/agent message types and handlers to support context run-recognition-list over the MaaAgent IPC protocol, updating the protocol version.
- Re-export MaaContextRunRecognitionList from the MaaFramework module interface.

Enhancements:
- Split recognition of multiple entries into parallel local recognitions and serialized Custom recognitions to avoid IPC contention while preserving priority semantics.
- Make OCR, ONNX, and template resource managers thread-safe by guarding lazy-loaded model and image caches with mutexes, enabling safe concurrent recognition.

Documentation:
- Document the MaaContextRunRecognitionList API behavior, parameters, and return value in the public header.

</details>