### PR TITLE
fix: 修复 And 识别器引用多结果 ROI 时 Or 子识别未按候选框短路的问题 fix #1313

### DIFF
--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -13,6 +13,8 @@
 #include "Vision/TemplateMatcher.h"
 #include "Vision/VisionUtils.hpp"
 
+#include <type_traits>
+
 MAA_TASK_NS_BEGIN
 
 Recognizer::Recognizer(Tasker* tasker, Context& context, const cv::Mat& image_, std::shared_ptr<MAA_VISION_NS::OCRCache> ocr_batch_cache)
@@ -359,6 +361,205 @@ RecoResult Recognizer::custom_recognize(const MAA_VISION_NS::CustomRecognitionPa
         CustomRecognition(image_, rois.front(), param, resource()->custom_recognition(param.name), context_, name));
 }
 
+RecoResult Recognizer::run_sub_recognition(const MAA_RES_NS::Recognition::SubRecognition& sub_reco, const std::string& combinator_name)
+{
+    using namespace MAA_RES_NS::Recognition;
+
+    Recognizer sub_recognizer(*this);
+
+    if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
+        auto node_opt = context_.get_pipeline_data(*node_name);
+        if (!node_opt) {
+            LogError << combinator_name << "failed to get pipeline data for node" << VAR(*node_name);
+            return { };
+        }
+        LogDebug << combinator_name << "run node reference" << VAR(*node_name);
+        return sub_recognizer.recognize(node_opt->reco_type, node_opt->reco_param, *node_name);
+    }
+
+    const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
+    LogDebug << combinator_name << "run inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
+    return sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
+}
+
+Recognizer::AndBranchResult Recognizer::match_and_branch(const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of, size_t index)
+{
+    if (index >= all_of.size()) {
+        return { .hit = true };
+    }
+
+    RecoResult result = run_sub_recognition(all_of[index], "And:");
+    register_sub_result_in_cache(result);
+
+    if (!result.box) {
+        LogDebug << "And: sub recognition failed";
+        return {
+            .hit = false,
+            .sub_results = { std::move(result) },
+        };
+    }
+
+    auto sub_filtered_boxes_snapshot = *sub_filtered_boxes_;
+    auto sub_best_box_snapshot = *sub_best_box_;
+
+    AndBranchResult first_failed_branch;
+    bool has_failed_branch = false;
+
+    for (const cv::Rect& candidate_box : get_candidate_boxes_for_and_branch(all_of, index, result)) {
+        *sub_filtered_boxes_ = sub_filtered_boxes_snapshot;
+        *sub_best_box_ = sub_best_box_snapshot;
+
+        RecoResult branch_result = result;
+        branch_result.box = candidate_box;
+        if (!branch_result.name.empty()) {
+            sub_filtered_boxes_->insert_or_assign(branch_result.name, std::vector<cv::Rect> { candidate_box });
+            sub_best_box_->insert_or_assign(branch_result.name, candidate_box);
+        }
+
+        AndBranchResult tail_result = match_and_branch(all_of, index + 1);
+        std::vector<RecoResult> branch_results;
+        branch_results.reserve(tail_result.sub_results.size() + 1);
+        branch_results.emplace_back(std::move(branch_result));
+        branch_results.insert(
+            branch_results.end(),
+            std::make_move_iterator(tail_result.sub_results.begin()),
+            std::make_move_iterator(tail_result.sub_results.end()));
+
+        if (tail_result.hit) {
+            return {
+                .hit = true,
+                .sub_results = std::move(branch_results),
+            };
+        }
+
+        if (!has_failed_branch) {
+            first_failed_branch = {
+                .hit = false,
+                .sub_results = std::move(branch_results),
+            };
+            has_failed_branch = true;
+        }
+    }
+
+    *sub_filtered_boxes_ = std::move(sub_filtered_boxes_snapshot);
+    *sub_best_box_ = std::move(sub_best_box_snapshot);
+
+    if (has_failed_branch) {
+        return first_failed_branch;
+    }
+
+    return {
+        .hit = false,
+        .sub_results = { std::move(result) },
+    };
+}
+
+std::vector<cv::Rect> Recognizer::get_candidate_boxes_for_and_branch(
+    const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of,
+    size_t index,
+    const RecoResult& result) const
+{
+    if (!result.box) {
+        return { };
+    }
+
+    if (result.name.empty() || !later_sub_recognitions_use_roi_target(all_of, index + 1, result.name)) {
+        return { *result.box };
+    }
+
+    auto it = sub_filtered_boxes_->find(result.name);
+    if (it == sub_filtered_boxes_->end() || it->second.empty()) {
+        return { *result.box };
+    }
+
+    return it->second;
+}
+
+bool Recognizer::later_sub_recognitions_use_roi_target(
+    const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of,
+    size_t index,
+    const std::string& target_name) const
+{
+    for (size_t i = index; i < all_of.size(); ++i) {
+        std::unordered_set<std::string> visited_nodes;
+        if (sub_recognition_uses_roi_target(all_of[i], target_name, visited_nodes)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Recognizer::sub_recognition_uses_roi_target(
+    const MAA_RES_NS::Recognition::SubRecognition& sub_reco,
+    const std::string& target_name,
+    std::unordered_set<std::string>& visited_nodes) const
+{
+    using namespace MAA_RES_NS::Recognition;
+
+    if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
+        if (!visited_nodes.emplace(*node_name).second) {
+            return false;
+        }
+
+        auto node_opt = context_.get_pipeline_data(*node_name);
+        if (!node_opt) {
+            return false;
+        }
+        return recognition_param_uses_roi_target(node_opt->reco_param, target_name, visited_nodes);
+    }
+
+    const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
+    return recognition_param_uses_roi_target(inline_sub.param, target_name, visited_nodes);
+}
+
+bool Recognizer::recognition_param_uses_roi_target(
+    const MAA_RES_NS::Recognition::Param& param,
+    const std::string& target_name,
+    std::unordered_set<std::string>& visited_nodes) const
+{
+    auto target_uses_name = [&target_name](const MAA_VISION_NS::Target& target) {
+        if (target.type != MAA_VISION_NS::Target::Type::PreTask) {
+            return false;
+        }
+        auto* name = std::get_if<std::string>(&target.param);
+        return name && *name == target_name;
+    };
+
+    return std::visit(
+        [&](const auto& value) -> bool {
+            using T = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<T, std::shared_ptr<MAA_RES_NS::Recognition::AndParam>>) {
+                if (!value) {
+                    return false;
+                }
+                for (const auto& sub : value->all_of) {
+                    if (sub_recognition_uses_roi_target(sub, target_name, visited_nodes)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            else if constexpr (std::is_same_v<T, std::shared_ptr<MAA_RES_NS::Recognition::OrParam>>) {
+                if (!value) {
+                    return false;
+                }
+                for (const auto& sub : value->any_of) {
+                    if (sub_recognition_uses_roi_target(sub, target_name, visited_nodes)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            else if constexpr (requires { value.roi_target; }) {
+                return target_uses_name(value.roi_target);
+            }
+            else {
+                return false;
+            }
+        },
+        param);
+}
+
 RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndParam>& param, const std::string& name)
 {
     using namespace MAA_RES_NS::Recognition;
@@ -370,40 +571,9 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
 
     LogDebug << "And recognition" << VAR(name) << VAR(param->all_of.size()) << VAR(param->box_index);
 
-    std::vector<RecoResult> sub_results;
-    bool all_hit = true;
-
-    for (const auto& sub_reco : param->all_of) {
-        Recognizer sub_recognizer(*this);
-        RecoResult res;
-
-        if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
-            // Resolve node name to get recognition params
-            auto node_opt = context_.get_pipeline_data(*node_name);
-            if (!node_opt) {
-                LogError << "And: failed to get pipeline data for node" << VAR(*node_name);
-                all_hit = false;
-                break;
-            }
-            LogDebug << "And: run node reference" << VAR(*node_name);
-            res = sub_recognizer.recognize(node_opt->reco_type, node_opt->reco_param, *node_name);
-        }
-        else {
-            const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
-            LogDebug << "And: run inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
-            res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
-        }
-
-        register_sub_result_in_cache(res);
-
-        all_hit &= res.box.has_value();
-        sub_results.emplace_back(std::move(res));
-
-        if (!all_hit) {
-            LogDebug << "And: sub recognition failed";
-            break;
-        }
-    }
+    AndBranchResult branch_result = match_and_branch(param->all_of, 0);
+    bool all_hit = branch_result.hit;
+    std::vector<RecoResult> sub_results = std::move(branch_result.sub_results);
 
     std::vector<ImageEncodedBuffer> all_draws;
     for (auto& sub : sub_results) {
@@ -459,24 +629,7 @@ RecoResult Recognizer::or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrPara
     bool has_hit = false;
 
     for (const auto& sub_reco : param->any_of) {
-        Recognizer sub_recognizer(*this);
-        RecoResult res;
-
-        if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
-            // Resolve node name to get recognition params
-            auto node_opt = context_.get_pipeline_data(*node_name);
-            if (!node_opt) {
-                LogError << "Or: failed to get pipeline data for node" << VAR(*node_name);
-                continue;
-            }
-            LogDebug << "Or: run node reference" << VAR(*node_name);
-            res = sub_recognizer.recognize(node_opt->reco_type, node_opt->reco_param, *node_name);
-        }
-        else {
-            const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
-            LogDebug << "Or: run inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
-            res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
-        }
+        RecoResult res = run_sub_recognition(sub_reco, "Or:");
 
         has_hit = res.box.has_value();
         register_sub_result_in_cache(res);

--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -23,6 +23,7 @@ Recognizer::Recognizer(Tasker* tasker, Context& context, const cv::Mat& image_, 
     , image_(image_)
     , sub_filtered_boxes_(std::make_shared<typename decltype(sub_filtered_boxes_)::element_type>())
     , sub_best_box_(std::make_shared<typename decltype(sub_best_box_)::element_type>())
+    , pending_sub_results_(std::make_shared<typename decltype(pending_sub_results_)::element_type>())
     , ocr_batch_cache_(std::move(ocr_batch_cache))
 {
 }
@@ -34,6 +35,8 @@ Recognizer::Recognizer(const Recognizer& recognizer)
     // do not copy reco_id_
     , sub_filtered_boxes_(recognizer.sub_filtered_boxes_)
     , sub_best_box_(recognizer.sub_best_box_)
+    , pending_sub_results_(recognizer.pending_sub_results_)
+    , cache_sub_results_(recognizer.cache_sub_results_)
     , ocr_batch_cache_(recognizer.ocr_batch_cache_)
 {
 }
@@ -103,8 +106,12 @@ RecoResult Recognizer::recognize(MAA_RES_NS::Recognition::Type type, const MAA_R
     }
 
     LogInfo << "reco" << VAR(result);
-    auto& rt_cache = tasker_->runtime_cache();
-    rt_cache.set_reco_detail(result.reco_id, result);
+
+    // 投机执行（And 候选分支匹配）期间不立即落盘，待分支整体命中后由 flush_pending_sub_results 统一提交，
+    // 否则失败分支的 reco_detail 会残留在 runtime cache 中造成泄漏
+    if (cache_sub_results_) {
+        tasker_->runtime_cache().set_reco_detail(result.reco_id, result);
+    }
 
     save_draws(name, result);
 
@@ -388,17 +395,19 @@ Recognizer::AndBranchResult Recognizer::match_and_branch(const std::vector<MAA_R
         return { .hit = true };
     }
 
+    const size_t pending_snapshot = pending_sub_results_->size();
     RecoResult result = run_sub_recognition(all_of[index], "And:");
-    register_sub_result_in_cache(result);
 
     if (!result.box) {
         LogDebug << "And: sub recognition failed";
+        pending_sub_results_->resize(pending_snapshot);
         return {
             .hit = false,
             .sub_results = { std::move(result) },
         };
     }
 
+    const size_t pending_after_result = pending_sub_results_->size();
     auto sub_filtered_boxes_snapshot = *sub_filtered_boxes_;
     auto sub_best_box_snapshot = *sub_best_box_;
 
@@ -406,6 +415,7 @@ Recognizer::AndBranchResult Recognizer::match_and_branch(const std::vector<MAA_R
     bool has_failed_branch = false;
 
     for (const cv::Rect& candidate_box : get_candidate_boxes_for_and_branch(all_of, index, result)) {
+        pending_sub_results_->resize(pending_after_result);
         *sub_filtered_boxes_ = sub_filtered_boxes_snapshot;
         *sub_best_box_ = sub_best_box_snapshot;
 
@@ -415,6 +425,7 @@ Recognizer::AndBranchResult Recognizer::match_and_branch(const std::vector<MAA_R
             sub_filtered_boxes_->insert_or_assign(branch_result.name, std::vector<cv::Rect> { candidate_box });
             sub_best_box_->insert_or_assign(branch_result.name, candidate_box);
         }
+        register_sub_result_in_cache(branch_result);
 
         AndBranchResult tail_result = match_and_branch(all_of, index + 1);
         std::vector<RecoResult> branch_results;
@@ -443,6 +454,7 @@ Recognizer::AndBranchResult Recognizer::match_and_branch(const std::vector<MAA_R
 
     *sub_filtered_boxes_ = std::move(sub_filtered_boxes_snapshot);
     *sub_best_box_ = std::move(sub_best_box_snapshot);
+    pending_sub_results_->resize(pending_snapshot);
 
     if (has_failed_branch) {
         return first_failed_branch;
@@ -571,7 +583,12 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
 
     LogDebug << "And recognition" << VAR(name) << VAR(param->all_of.size()) << VAR(param->box_index);
 
+    const bool should_commit_sub_results = cache_sub_results_;
+    const size_t pending_snapshot = pending_sub_results_->size();
+    cache_sub_results_ = false;
     AndBranchResult branch_result = match_and_branch(param->all_of, 0);
+    cache_sub_results_ = should_commit_sub_results;
+
     bool all_hit = branch_result.hit;
     std::vector<RecoResult> sub_results = std::move(branch_result.sub_results);
 
@@ -590,6 +607,7 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
 
     if (!all_hit) {
         LogDebug << "And recognition failed" << VAR(name);
+        pending_sub_results_->resize(pending_snapshot);
         sub_filtered_boxes_->insert_or_assign(name, std::vector<cv::Rect> { });
         sub_best_box_->insert_or_assign(name, cv::Rect { });
         return result;
@@ -598,6 +616,7 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
     if (static_cast<int>(sub_results.size()) <= param->box_index) {
         LogError << "all hit, but box_index is out of range" << VAR(name) << VAR(sub_results.size()) << VAR(param->box_index);
         result.box = std::nullopt;
+        pending_sub_results_->resize(pending_snapshot);
         sub_filtered_boxes_->insert_or_assign(name, std::vector<cv::Rect> { });
         sub_best_box_->insert_or_assign(name, cv::Rect { });
         return result;
@@ -609,6 +628,10 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
     // 按理说这里要从 sub 取的，但是太麻烦而且是 corner case，先不管了，后面有需要再加
     sub_filtered_boxes_->insert_or_assign(name, std::vector<cv::Rect> { final_box });
     sub_best_box_->insert_or_assign(name, final_box);
+
+    if (should_commit_sub_results) {
+        flush_pending_sub_results(pending_snapshot);
+    }
 
     return result;
 }
@@ -773,10 +796,37 @@ void Recognizer::register_sub_result_in_cache(const RecoResult& res)
         return;
     }
 
+    if (!cache_sub_results_) {
+        pending_sub_results_->emplace_back(res);
+        return;
+    }
+
+    // 非投机路径：reco_detail 已由 recognize() 写入，这里仅登记节点信息
+    commit_sub_node_detail(res);
+}
+
+void Recognizer::commit_sub_node_detail(const RecoResult& res)
+{
     auto& cache = tasker_->runtime_cache();
     auto sub_node_id = TaskBase::generate_node_id();
     cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id, .completed = true });
     cache.set_latest_node(res.name, sub_node_id);
+}
+
+void Recognizer::flush_pending_sub_results(size_t begin)
+{
+    if (begin >= pending_sub_results_->size()) {
+        return;
+    }
+
+    auto& cache = tasker_->runtime_cache();
+    for (size_t i = begin; i < pending_sub_results_->size(); ++i) {
+        const RecoResult& res = (*pending_sub_results_)[i];
+        // 投机阶段 recognize() 跳过了 reco_detail 写入，命中提交时在此补写
+        cache.set_reco_detail(res.reco_id, res);
+        commit_sub_node_detail(res);
+    }
+    pending_sub_results_->resize(begin);
 }
 
 bool Recognizer::debug_mode() const

--- a/source/MaaFramework/Task/Component/Recognizer.h
+++ b/source/MaaFramework/Task/Component/Recognizer.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <meojson/json.hpp>
+#include <unordered_set>
 
 #include "Common/Conf.h"
 #include "Common/MaaTypes.h"
@@ -40,6 +41,31 @@ private:
     RecoResult and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndParam>& param, const std::string& name);
     RecoResult or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrParam>& param, const std::string& name);
     RecoResult custom_recognize(const MAA_VISION_NS::CustomRecognitionParam& param, const std::string& name);
+
+    struct AndBranchResult
+    {
+        bool hit = false;
+        std::vector<RecoResult> sub_results;
+    };
+
+    RecoResult run_sub_recognition(const MAA_RES_NS::Recognition::SubRecognition& sub_reco, const std::string& combinator_name);
+    AndBranchResult match_and_branch(const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of, size_t index);
+    std::vector<cv::Rect> get_candidate_boxes_for_and_branch(
+        const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of,
+        size_t index,
+        const RecoResult& result) const;
+    bool later_sub_recognitions_use_roi_target(
+        const std::vector<MAA_RES_NS::Recognition::SubRecognition>& all_of,
+        size_t index,
+        const std::string& target_name) const;
+    bool sub_recognition_uses_roi_target(
+        const MAA_RES_NS::Recognition::SubRecognition& sub_reco,
+        const std::string& target_name,
+        std::unordered_set<std::string>& visited_nodes) const;
+    bool recognition_param_uses_roi_target(
+        const MAA_RES_NS::Recognition::Param& param,
+        const std::string& target_name,
+        std::unordered_set<std::string>& visited_nodes) const;
 
     template <typename Analyzer>
     RecoResult build_result(const std::string& name, const std::string& algorithm, Analyzer&& analyzer);

--- a/source/MaaFramework/Task/Component/Recognizer.h
+++ b/source/MaaFramework/Task/Component/Recognizer.h
@@ -74,6 +74,8 @@ private:
     std::vector<cv::Rect> get_rois_from_pretask(const std::string& name, bool use_best);
     void save_draws(const std::string& node_name, const RecoResult& result) const;
     void register_sub_result_in_cache(const RecoResult& res);
+    void commit_sub_node_detail(const RecoResult& res);
+    void flush_pending_sub_results(size_t begin);
 
 private:
     bool debug_mode() const;
@@ -89,6 +91,8 @@ private:
 
     std::shared_ptr<std::unordered_map<std::string, std::vector<cv::Rect>>> sub_filtered_boxes_;
     std::shared_ptr<std::unordered_map<std::string, cv::Rect>> sub_best_box_;
+    std::shared_ptr<std::vector<RecoResult>> pending_sub_results_;
+    bool cache_sub_results_ = true;
 
     std::shared_ptr<MAA_VISION_NS::OCRCache> ocr_batch_cache_;
 };


### PR DESCRIPTION
## Summary by Sourcery

改进复合识别逻辑，以正确处理带有 ROI 依赖的 AND/OR 组合，以及推测性子识别结果缓存。

Bug Fixes:
- 修复 AND 识别器：当某个子识别返回多个候选 ROI 时，后续的 OR 子识别仍能正确进行短路，而不会将失败分支的结果泄漏到运行时缓存中。

Enhancements:
- 抽取通用的子识别执行逻辑为可复用的辅助函数，由 AND 和 OR 组合器共同使用。
- 引入对识别参数的递归分析，以检测依赖特定 ROI 目标的嵌套 AND/OR 子识别，从而在 AND 分支中更好地指导候选框的传递。
- 添加带显式刷新机制的推测性子识别结果缓冲，避免将失败 AND 分支的中间结果写入正式缓存，同时仍能登记成功子节点的详细结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve composite recognition logic to correctly handle AND/OR combinations with ROI dependencies and speculative sub-recognition caching.

Bug Fixes:
- Fix AND recognizer so that when a sub-recognition returns multiple candidate ROIs, subsequent OR sub-recognitions still short-circuit correctly without leaking failed branch results into the runtime cache.

Enhancements:
- Factor out shared sub-recognition execution into a reusable helper used by both AND and OR combinators.
- Introduce recursive analysis of recognition parameters to detect nested AND/OR sub-recognitions that depend on specific ROI targets, guiding candidate box propagation in AND branches.
- Add speculative sub-recognition result buffering with explicit flushing to avoid committing intermediate results from failed AND branches while still registering successful sub-node details.

</details>

Bug 修复：
- 确保 And 识别器在某个子识别返回多个候选 ROI 时，能够正确评估各分支，同时在包含 Or 子识别和 ROI 依赖关系的情况下，仍然保持短路求值行为。

增强功能：
- 提取通用的子识别调用逻辑到一个共享的辅助方法中，由 And 和 Or 组合器共同使用。
- 引入对识别参数的递归分析，以检测嵌套的 And/Or 子识别之间的 ROI 目标依赖关系，从而防止错误的候选框传播。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进复合识别逻辑，以正确处理带有 ROI 依赖的 AND/OR 组合，以及推测性子识别结果缓存。

Bug Fixes:
- 修复 AND 识别器：当某个子识别返回多个候选 ROI 时，后续的 OR 子识别仍能正确进行短路，而不会将失败分支的结果泄漏到运行时缓存中。

Enhancements:
- 抽取通用的子识别执行逻辑为可复用的辅助函数，由 AND 和 OR 组合器共同使用。
- 引入对识别参数的递归分析，以检测依赖特定 ROI 目标的嵌套 AND/OR 子识别，从而在 AND 分支中更好地指导候选框的传递。
- 添加带显式刷新机制的推测性子识别结果缓冲，避免将失败 AND 分支的中间结果写入正式缓存，同时仍能登记成功子节点的详细结果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve composite recognition logic to correctly handle AND/OR combinations with ROI dependencies and speculative sub-recognition caching.

Bug Fixes:
- Fix AND recognizer so that when a sub-recognition returns multiple candidate ROIs, subsequent OR sub-recognitions still short-circuit correctly without leaking failed branch results into the runtime cache.

Enhancements:
- Factor out shared sub-recognition execution into a reusable helper used by both AND and OR combinators.
- Introduce recursive analysis of recognition parameters to detect nested AND/OR sub-recognitions that depend on specific ROI targets, guiding candidate box propagation in AND branches.
- Add speculative sub-recognition result buffering with explicit flushing to avoid committing intermediate results from failed AND branches while still registering successful sub-node details.

</details>

</details>