### PR TITLE
fix(python): tighten binding type annotations

### DIFF
--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -2,7 +2,7 @@ import ctypes
 import platform
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Callable, List, Tuple, Union, Dict, Optional
+from typing import Callable, Iterator, List, Tuple, Union, Dict, Optional
 
 import numpy
 from strenum import StrEnum  # For Python 3.9/3.10
@@ -750,11 +750,11 @@ class Point:
 
         raise TypeError(f"Cannot add {type(other).__name__} to Point")
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         yield self.x
         yield self.y
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> int:
         return list(self)[key]
 
 
@@ -789,13 +789,13 @@ class Rect:
 
         raise TypeError(f"Cannot add {type(other).__name__} to Rect")
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[int]:
         yield self.x
         yield self.y
         yield self.w
         yield self.h
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> int:
         return list(self)[key]
 
 
@@ -1137,7 +1137,13 @@ class TaskDetail:
     def nodes(self) -> List[NodeDetail]:
         if self._nodes is None:
             if self._node_detail_func is not None:
-                self._nodes = [self._node_detail_func(nid) for nid in self.node_id_list]
+                nodes = []
+                for nid in self.node_id_list:
+                    node = self._node_detail_func(nid)
+                    if node is None:
+                        raise RuntimeError(f"Failed to get node detail: {nid}")
+                    nodes.append(node)
+                self._nodes = nodes
             else:
                 self._nodes = []
         return self._nodes


### PR DESCRIPTION
## Summary
- annotate Point and Rect sequence-like helpers with Iterator[int] and int index returns
- make TaskDetail.nodes fail clearly if a node detail cannot be loaded instead of caching Optional entries

## Validation
- pnpm exec pyright tmp/MaaFramework/source/binding/Python/maa

## Summary by Sourcery

收紧 Python 绑定辅助方法的类型注解，并将节点详情加载失败显式化。

Bug 修复：
- 当无法加载某个节点详情时，抛出运行时错误，而不是在 `TaskDetail.nodes` 中缓存 `None`。

增强：
- 为 `Point` 和 `Rect` 这类序列风格的辅助工具添加 `Iterator[int]` 的迭代类型注解以及 `int` 类型的索引返回值，以提升类型安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten type annotations for Python binding helpers and make node detail loading failures explicit.

Bug Fixes:
- Raise a runtime error when a node detail cannot be loaded instead of caching None in TaskDetail.nodes.

Enhancements:
- Annotate Point and Rect sequence-like helpers with Iterator[int] iteration and int index returns to improve type safety.

</details>