### PR TITLE
docs: update entry description in ProjectInterfaceV2

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -372,7 +372,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
     Task display name, shown in the user interface. Supports internationalized strings (starting with `$`). If not set, the value of the `name` field is displayed. _Optional._
 
   - **entry** `string`  
-    The task entry, which is the name of the `Task` in the `pipeline`.
+    The task entry, which is the name of the starting `Node` in the `pipeline`.
 
   - **default_check** `boolean`  
     Whether this task is selected by default. _Optional_, defaults to false. The Client will use this value to determine whether to check this task by default during initialization.

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -373,7 +373,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
     任务显示名称，用于在用户界面中展示。支持国际化字符串（以`$`开头）。如果未设置，则显示 `name` 字段的值。可选。
 
   - entry `string`  
-    任务入口，为 `pipeline` 中 `Task` 的名称。
+    任务入口，为 `pipeline` 中起点 `Node` 的名称。
 
   - default_check `boolean`  
     是否默认选中该任务。可选，默认false。Client 在初始化时会根据该值决定是否默认勾选该任务。


### PR DESCRIPTION
又来水文档了)

## Summary by Sourcery

文档：
- 更新英文版 ProjectInterfaceV2 文档，将任务条目描述为流水线中起始节点的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the English ProjectInterfaceV2 documentation to describe the task entry as the name of the starting Node in the pipeline.

</details>