### PR TITLE
feat(wlroots): add support for 24bpc RGB formats

### DIFF
--- a/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
+++ b/source/MaaWlRootsControlUnit/Manager/WlRootsControlUnitMgr.cpp
@@ -1,6 +1,7 @@
 #include "WlRootsControlUnitMgr.h"
 
 #include <filesystem>
+#include <optional>
 #include <system_error>
 
 #include <opencv2/imgproc.hpp>
@@ -93,24 +94,41 @@ bool WlRootsControlUnitMgr::screencap(cv::Mat& image)
         LogError << "Failed to screencap";
         return false;
     }
-    int cvt_mode = cv::COLOR_RGBA2BGR;
+    std::optional<int> cvt_mode;
+    int cv_format = -1;
     switch (format) { // TODO: Other possible format?
     case WL_SHM_FORMAT_XBGR8888:
     case WL_SHM_FORMAT_ABGR8888:
         cvt_mode = cv::COLOR_RGBA2BGR;
+        cv_format = CV_8UC4;
         break;
     case WL_SHM_FORMAT_ARGB8888:
     case WL_SHM_FORMAT_XRGB8888:
         cvt_mode = cv::COLOR_BGRA2BGR;
+        cv_format = CV_8UC4;
+        break;
+    case WL_SHM_FORMAT_RGB888:
+        // no need to cvtColor
+        cvt_mode = {};
+        cv_format = CV_8UC3;
+        break;
+    case WL_SHM_FORMAT_BGR888:
+        cvt_mode = cv::COLOR_RGB2BGR;
+        cv_format = CV_8UC3;
         break;
     default:
-        LogWarn << "Unsupported color format" << VAR(format) << "Using RGBA2BGR";
+        LogError << "Unsupported wl_shm_format" << VAR(format);
+        return false;
     }
-    LogDebug << "Converting buffer" << VAR(format) << VAR(cvt_mode);
 
-    const cv::Mat raw(height, width, CV_8UC4, buffer);
+    const cv::Mat raw(height, width, cv_format, buffer);
+    if (cvt_mode.has_value()) {
+        LogDebug << "Converting buffer" << VAR(format) << VAR(cvt_mode.value());
+        cv::cvtColor(raw, image, cvt_mode.value());
+    } else {
+        raw.copyTo(image);
+    }
 
-    cv::cvtColor(raw, image, cvt_mode);
     return true;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

扩展 Wayland 屏幕捕获处理逻辑，以支持更多的 `wl_shm` 缓冲区格式，并收紧对不支持格式的错误处理。

增强内容：
- 在通过 wlroots 捕获帧时，新增对 24bpp `RGB888` 和 `BGR888` `wl_shm` 格式的支持。
- 调整屏幕捕获流水线，以选择合适的 OpenCV 缓冲区格式，并在不需要时跳过颜色转换。
- 将对未知 `wl_shm` 格式的处理，从回退转换修改为显式失败并记录错误日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend Wayland screencapture handling to support additional wl_shm buffer formats and tighten error handling for unsupported formats.

Enhancements:
- Add support for 24bpp RGB888 and BGR888 wl_shm formats when capturing frames via wlroots.
- Adjust screencapture pipeline to select appropriate OpenCV buffer formats and bypass color conversion when not needed.
- Change handling of unknown wl_shm formats from fallback conversion to explicit failure with an error log.

</details>