### PR TITLE
ci: target windows-2025-vs2026 (VS 2026) for Windows builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
 
     windows:
         needs: meta
-        runs-on: windows-latest
+        runs-on: windows-2025-vs2026
         strategy:
             matrix:
                 arch: [x86_64, aarch64]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
     windows:
         needs: meta
-        runs-on: windows-latest
+        runs-on: windows-2025-vs2026
         strategy:
             matrix:
                 arch: [x86_64]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -86,7 +86,6 @@
             "name": "MSVC 2022",
             "displayName": "MSVC 2022",
             "description": "MSVC 2022",
-            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build",
             "condition": {
                 "type": "equals",
@@ -98,7 +97,6 @@
             "name": "MSVC 2022 ARM",
             "displayName": "MSVC 2022 ARM",
             "description": "MSVC 2022 ARM",
-            "generator": "Visual Studio 17 2022",
             "binaryDir": "${sourceDir}/build",
             "condition": {
                 "type": "equals",


### PR DESCRIPTION
`windows-latest` now ships Visual Studio 2026 (v18) instead of 2022 (v17), so the "Visual Studio 17 2022" CMake generator fails with "could not find any instance of Visual Studio".

nuget_pack (build.yml) is left on windows-latest; it only packages, no VS.

Ref: https://github.com/actions/runner-images/issues/13638

## 由 Sourcery 提供的摘要

将 Windows CI 任务更新为在 Visual Studio 2026 托管运行器镜像上运行，而不是使用通用的最新 Windows 镜像。

CI：
- 将 Windows 构建工作流切换为使用 `windows-2025-vs2026` 运行器镜像。
- 将 Windows 测试工作流切换为使用 `windows-2025-vs2026` 运行器镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Windows CI jobs to run on the Visual Studio 2026 hosted runner image instead of the generic latest Windows image.

CI:
- Switch Windows build workflow to use the windows-2025-vs2026 runner image.
- Switch Windows test workflow to use the windows-2025-vs2026 runner image.

</details>