### PR TITLE
fix(KWin): correct MaaKWinControllerCreate signature

### DIFF
--- a/include/MaaFramework/Instance/MaaController.h
+++ b/include/MaaFramework/Instance/MaaController.h
@@ -134,6 +134,9 @@ extern "C"
      * @param device_node The uinput device node path (e.g., "/dev/uinput").
      * @param screen_width The screen width in pixels.
      * @param screen_height The screen height in pixels.
+     * @param use_win32_vk_code If true, key codes passed to click_key / key_down / key_up are
+     *        interpreted as Win32 Virtual-Key codes (VK_*) and translated to Linux evdev codes
+     *        internally. If false, key codes are passed through as raw evdev codes.
      * @return The controller handle, or nullptr on failure.
      *
      * @note This controller is designed for KWin (pure Wayland) on Linux.
@@ -144,7 +147,8 @@ extern "C"
      * @note Requires write permission to /dev/uinput (typically via the "input" group).
      * @note Only single touch is supported (contact must be 0).
      */
-    MAA_FRAMEWORK_API MaaController* MaaKWinControllerCreate(const char* device_node, int screen_width, int screen_height);
+    MAA_FRAMEWORK_API MaaController*
+        MaaKWinControllerCreate(const char* device_node, int screen_width, int screen_height, MaaBool use_win32_vk_code);
 
     /**
      * @brief Create a virtual gamepad controller for Windows.


### PR DESCRIPTION
`MaaKWinControllerCreate` 的头文件声明和实际定义参数对不上

头文件 [include/MaaFramework/Instance/MaaController.h](https://github.com/MaaXYZ/MaaFramework/blob/main/include/MaaFramework/Instance/MaaController.h)(3个参数):
`MAA_FRAMEWORK_API MaaController* MaaKWinControllerCreate(const char* device_node, int screen_width, int screen_height);`

定义 [source/MaaFramework/API/MaaFramework.cpp](https://github.com/MaaXYZ/MaaFramework/blob/main/source/MaaFramework/API/MaaFramework.cpp)(4个参数):
`MaaController* MaaKWinControllerCreate(const char* device_node, int screen_width, int screen_height, MaaBool use_win32_vk_code)`

两处定义(`MaaFramework.cpp`和`MaaAgentServerNotImpl.cpp`)都是4个参数 只有头文件是3个 下游按头文件链接会炸

## Summary by Sourcery

通过在头文件中添加缺失的参数并记录其行为，使 `MaaKWinControllerCreate` 公共 API 声明与其实现保持一致。

New Features:
- 记录 `use_win32_vk_code` 参数的用途，该参数用于控制 KWin 控制器中从 Win32 Virtual-Key 到 Linux evdev 键码的转换。

Bug Fixes:
- 修复 `MaaKWinControllerCreate` 函数在公共头文件与源文件实现之间的函数签名不匹配问题，以防止下游用户在链接阶段出现问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the MaaKWinControllerCreate public API declaration with its implementation by adding the missing parameter to the header and documenting its behavior.

New Features:
- Document the use_win32_vk_code parameter controlling Win32 Virtual-Key to Linux evdev key code translation for KWin controllers.

Bug Fixes:
- Fix the MaaKWinControllerCreate function signature mismatch between the public header and source implementations to prevent linkage issues for downstream users.

</details>