### PR TITLE
fix(Task): get_target_rect 所有 target 类型均 normalize 负宽高

### DIFF
--- a/source/MaaFramework/Task/Component/ActionHelper.cpp
+++ b/source/MaaFramework/Task/Component/ActionHelper.cpp
@@ -227,12 +227,20 @@ cv::Rect ActionHelper::get_target_rect(const MAA_RES_NS::Action::Target& target,
         raw = MAA_VISION_NS::normalize_rect(raw, image.cols, image.rows);
     }
 
-    int x = std::clamp(raw.x + target.offset.x, 0, image.cols);
-    int y = std::clamp(raw.y + target.offset.y, 0, image.rows);
-    int width = std::clamp(raw.width + target.offset.width, 0, image.cols - x);
-    int height = std::clamp(raw.height + target.offset.height, 0, image.rows - y);
+    raw.x += target.offset.x;
+    raw.y += target.offset.y;
+    raw.width += target.offset.width;
+    raw.height += target.offset.height;
 
-    return cv::Rect(x, y, width, height);
+    // 对所有 target 类型，offset 后 normalize 以支持负宽高（ROI 语义）
+    raw = MAA_VISION_NS::normalize_rect(raw, image.cols, image.rows);
+
+    raw.x = std::clamp(raw.x, 0, image.cols);
+    raw.y = std::clamp(raw.y, 0, image.rows);
+    raw.width = std::clamp(raw.width, 0, image.cols - raw.x);
+    raw.height = std::clamp(raw.height, 0, image.rows - raw.y);
+
+    return raw;
 }
 
 cv::Rect ActionHelper::get_rect_from_node(const std::string& node_name) const


### PR DESCRIPTION
此前 normalize_rect 仅对 Region 类型生效。Self/PreTask/Anchor 类型 的 target_offset 若包含负宽高，会直接送入 std::clamp 变为为 0，导致
cv::Rect::empty() 命中和 "failed to get target rect" 错误。
示例:

``` jsonc
{
    "1": {
        "roi": [
            790,
            308,
            154,
            18
        ],
        "action": "Click", // 这样会报错
        "target_offset": [
            0,
            -50,
            0,
            -30
        ]
    },
    "2": {
        "roi": [
            790,
            258,
            154,
            -12
        ],
        "action": "Click" // 直接点击偏移后位置不会
    }
}

```

将 normalize_rect 移至 offset 应用之后并对所有 target 类型生效，使
负宽高遵循 ROI 语义（取绝对值并反向调整 x/y），与 roi 字段行为一致。

## Summary by Sourcery

Bug Fixes:
- 防止在偏移量中具有负宽度/高度的目标矩形被折叠为空矩形，从而在所有目标类型中导致“failed to get target rect”错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent target rectangles with negative width/height in offsets from collapsing to empty rectangles and causing "failed to get target rect" errors across all target types.

</details>