### PR TITLE
fix(Task): get_target_rect 对所有 target 类型处理 offset 引入的负宽高

### DIFF
--- a/source/MaaFramework/Task/Component/ActionHelper.cpp
+++ b/source/MaaFramework/Task/Component/ActionHelper.cpp
@@ -227,12 +227,28 @@ cv::Rect ActionHelper::get_target_rect(const MAA_RES_NS::Action::Target& target,
         raw = MAA_VISION_NS::normalize_rect(raw, image.cols, image.rows);
     }
 
-    int x = std::clamp(raw.x + target.offset.x, 0, image.cols);
-    int y = std::clamp(raw.y + target.offset.y, 0, image.rows);
-    int width = std::clamp(raw.width + target.offset.width, 0, image.cols - x);
-    int height = std::clamp(raw.height + target.offset.height, 0, image.rows - y);
+    raw.x += target.offset.x;
+    raw.y += target.offset.y;
+    raw.width += target.offset.width;
+    raw.height += target.offset.height;
 
-    return cv::Rect(x, y, width, height);
+    // 对所有 target 类型，offset 引入的负宽高按 ROI 语义取绝对值并反向调整位置
+    // 注：不直接调 normalize_rect，因为它的负 x/y 语义（从右/下边缘算起）对 offset 不适用
+    if (raw.width < 0) {
+        raw.x += raw.width;
+        raw.width = -raw.width;
+    }
+    if (raw.height < 0) {
+        raw.y += raw.height;
+        raw.height = -raw.height;
+    }
+
+    raw.x = std::clamp(raw.x, 0, image.cols);
+    raw.y = std::clamp(raw.y, 0, image.rows);
+    raw.width = std::clamp(raw.width, 0, image.cols - raw.x);
+    raw.height = std::clamp(raw.height, 0, image.rows - raw.y);
+
+    return raw;
 }
 
 cv::Rect ActionHelper::get_rect_from_node(const std::string& node_name) const

--- a/source/MaaFramework/Task/Component/ActionHelper.cpp
+++ b/source/MaaFramework/Task/Component/ActionHelper.cpp
@@ -227,28 +227,29 @@ cv::Rect ActionHelper::get_target_rect(const MAA_RES_NS::Action::Target& target,
         raw = MAA_VISION_NS::normalize_rect(raw, image.cols, image.rows);
     }
 
-    raw.x += target.offset.x;
-    raw.y += target.offset.y;
-    raw.width += target.offset.width;
-    raw.height += target.offset.height;
+    cv::Rect rect = raw;
+    rect.x += target.offset.x;
+    rect.y += target.offset.y;
+    rect.width += target.offset.width;
+    rect.height += target.offset.height;
 
     // 对所有 target 类型，offset 引入的负宽高按 ROI 语义取绝对值并反向调整位置
     // 注：不直接调 normalize_rect，因为它的负 x/y 语义（从右/下边缘算起）对 offset 不适用
-    if (raw.width < 0) {
-        raw.x += raw.width;
-        raw.width = -raw.width;
+    if (rect.width < 0) {
+        rect.x += rect.width;
+        rect.width = -rect.width;
     }
-    if (raw.height < 0) {
-        raw.y += raw.height;
-        raw.height = -raw.height;
+    if (rect.height < 0) {
+        rect.y += rect.height;
+        rect.height = -rect.height;
     }
 
-    raw.x = std::clamp(raw.x, 0, image.cols);
-    raw.y = std::clamp(raw.y, 0, image.rows);
-    raw.width = std::clamp(raw.width, 0, image.cols - raw.x);
-    raw.height = std::clamp(raw.height, 0, image.rows - raw.y);
+    rect.x = std::clamp(rect.x, 0, image.cols);
+    rect.y = std::clamp(rect.y, 0, image.rows);
+    rect.width = std::clamp(rect.width, 0, image.cols - rect.x);
+    rect.height = std::clamp(rect.height, 0, image.rows - rect.y);
 
-    return raw;
+    return rect;
 }
 
 cv::Rect ActionHelper::get_rect_from_node(const std::string& node_name) const


### PR DESCRIPTION
- fix https://github.com/MaaEnd/MaaEnd/issues/3721

此前 target_offset 的负宽高仅 Region 类型通过 normalize_rect 间接 支持。Self/PreTask/Anchor 类型的 offset 若含负宽高，会直接被
std::clamp 变为 0，导致 cv::Rect::empty() 命中，动作报 "failed to get target rect" 错误。

示例:

``` jsonc
{
    "1": {
        "roi": [
            790,
            308,
            154,
            18
        ],
        "action": "Click",// 这样会报错
        "target_offset": [
            0,
            -50,
            0,
            -30
        ]
    },
    "2": {
        "roi": [
            790,
            258,
            154,
            -12
        ] // 直接点击偏移后结果这样不会
    }
}

```
对 offset 应用后的负宽高按 ROI 语义（取绝对值并反向调整 x/y）处理，
该逻辑对所有 target 类型生效。不直接调 normalize_rect，因为其负 x/y
的"从边缘算起"语义对 offset 不适用，x/y 仍由 clamp 裁剪。（因为这样是原逻辑，而且更有用）

## Sourcery 总结

修复目标矩形计算问题，确保带有负尺寸的偏移量能够在所有目标类型中生成有效且位置正确的区域。

错误修复：
- 处理所有目标类型中由目标偏移引入的负宽度和负高度，避免将有效的调整后区域误判为空矩形。

增强功能：
- 保留 ROI 语义：在应用图像边界裁剪之前，反转受影响矩形的位置，并取其尺寸的绝对值。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复目标矩形计算问题，确保对于所有目标类型，负尺寸偏移都能生成有效且位置正确的区域。

错误修复：
- 处理所有目标类型因目标偏移引入的负宽度和负高度，确保有效的调整后区域不再被视为空矩形。

改进：
- 保留 ROI 语义：在应用图像边界裁剪之前，反转受影响矩形的位置并使用绝对尺寸。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix target rectangle calculation so negative-size offsets produce valid, correctly positioned regions for all target types.

Bug Fixes:
- Handle negative width and height introduced by target offsets for every target type so valid adjusted regions are no longer treated as empty rectangles.

Enhancements:
- Preserve ROI semantics by reversing the affected rectangle position and using absolute dimensions before applying image-boundary clipping.

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>