### PR TITLE
feat(kwin):python绑定

### DIFF
--- a/source/binding/Python/maa/controller.py
+++ b/source/binding/Python/maa/controller.py
@@ -23,6 +23,7 @@ __all__ = [
     "RecordController",
     "PlayCoverController",
     "Win32Controller",
+    "KWinController",
     "GamepadController",
     "WlRootsController",
     "AndroidNativeController",
@@ -1055,6 +1056,57 @@ class WlRootsController(Controller):
         Library.framework().MaaWlRootsControllerCreate.restype = MaaControllerHandle
         Library.framework().MaaWlRootsControllerCreate.argtypes = [
             ctypes.c_char_p,
+            MaaBool,
+        ]
+
+
+class KWinController(Controller):
+    """KWin 控制器 (Linux Wayland) / KWin controller (Linux Wayland)
+
+    通过 PipeWire / xdg-desktop-portal 截图，通过 /dev/uinput 模拟输入。
+    Screencap via PipeWire / xdg-desktop-portal, input via /dev/uinput.
+    """
+
+    def __init__(
+        self,
+        device_node: str,
+        screen_width: int,
+        screen_height: int,
+        use_win32_vk_code: bool = False,
+    ):
+        """创建 KWin 控制器 / Create KWin controller
+
+        Args:
+            device_node: uinput 设备节点路径 (如 "/dev/uinput") / uinput device node path
+            screen_width: 屏幕宽度（像素） / Screen width in pixels
+            screen_height: 屏幕高度（像素） / Screen height in pixels
+            use_win32_vk_code: 为 True 时按键被视为 Win32 VK 键码并转换为 Linux evdev 码；
+                默认 False，按原始 evdev 码处理
+                / When True, key codes are interpreted as Win32 Virtual-Key codes and translated
+                to Linux evdev codes internally; default False passes raw evdev codes through
+
+        Raises:
+            RuntimeError: 如果创建失败
+        """
+        super().__init__()
+        self._set_kwin_api_properties()
+
+        self._handle = Library.framework().MaaKWinControllerCreate(
+            device_node.encode(),
+            screen_width,
+            screen_height,
+            MaaBool(use_win32_vk_code),
+        )
+
+        if not self._handle:
+            raise RuntimeError("Failed to create KWin controller.")
+
+    def _set_kwin_api_properties(self):
+        Library.framework().MaaKWinControllerCreate.restype = MaaControllerHandle
+        Library.framework().MaaKWinControllerCreate.argtypes = [
+            ctypes.c_char_p,
+            ctypes.c_int32,
+            ctypes.c_int32,
             MaaBool,
         ]
 

--- a/source/binding/Python/maa/controller.py
+++ b/source/binding/Python/maa/controller.py
@@ -1091,8 +1091,13 @@ class KWinController(Controller):
         super().__init__()
         self._set_kwin_api_properties()
 
+        if not hasattr(Library.framework(), "MaaKWinControllerCreate"):
+            raise RuntimeError(
+                "MaaKWinControllerCreate API is not available in the current build."
+            )
+
         self._handle = Library.framework().MaaKWinControllerCreate(
-            device_node.encode(),
+            os.fsencode(os.fspath(device_node)),
             screen_width,
             screen_height,
             MaaBool(use_win32_vk_code),

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -40,7 +40,7 @@ if str(binding_dir) not in sys.path:
 
 from maa.library import Library
 from maa.resource import Resource, ResourceEventSink
-from maa.controller import DbgController, CustomController, Win32Controller, ControllerEventSink
+from maa.controller import DbgController, CustomController, Win32Controller, KWinController, ControllerEventSink
 from maa.tasker import Tasker, TaskerEventSink
 from maa.toolkit import Toolkit
 from maa.custom_action import CustomAction
@@ -835,6 +835,46 @@ def test_win32_relative_move():
     print("  PASS: win32 relative_move")
 
 
+def test_kwin_controller_create():
+    print("\n=== test_kwin_controller_create ===")
+
+    # KWinController 仅在 Linux 上可用，且需要 MaaKWinControllerCreate API 存在
+    try:
+        controller = KWinController(
+            device_node="/dev/uinput",
+            screen_width=1920,
+            screen_height=1080,
+            use_win32_vk_code=False,
+        )
+        print(f"  KWinController created: {controller}")
+
+        # 检查连接前状态
+        print(f"  connected: {controller.connected}")
+        print(f"  uuid: {controller.uuid}")
+        print(f"  info: {controller.info}")
+
+        # 验证 info 中的类型
+        info = controller.info
+        assert isinstance(info, dict), "info should be a dict"
+        assert "type" in info, "info should contain 'type'"
+        assert info["type"] == "KWin", "KWin controller type should be 'KWin'"
+
+        # 测试 post_inactive (空操作，应总是成功)
+        controller.post_inactive().wait()
+
+        print("  PASS: KWinController creation")
+
+    except AttributeError as e:
+        if "MaaKWinControllerCreate" in str(e):
+            print("  SKIP: MaaKWinControllerCreate not available in this build")
+        else:
+            raise
+
+    except RuntimeError as e:
+        # KWin 控制器创建可能因缺少 /dev/uinput 权限等环境问题失败
+        print(f"  SKIP: KWinController not available in this environment ({e})")
+
+
 # ============================================================================
 # 主入口
 # ============================================================================
@@ -844,29 +884,32 @@ if __name__ == "__main__":
     print(f"MaaFw Version: {Library.version()}")
 
     Toolkit.init_option(install_dir / "bin")
+    #
+    # # 测试各模块 API
+    # resource = test_resource_api()
+    # controller = test_controller_api()
+    # test_buffer_api()
+    # tasker = test_tasker_api(resource, controller)
+    #
+    # # 验证自定义识别和动作被调用
+    # if not analyzed or not runned:
+    #     print("FAIL: custom recognition or action not called")
+    #     raise RuntimeError("custom recognition or action not called")
+    #
+    # # 测试 CustomController
+    # test_custom_controller()
+    #
+    # # 测试 Toolkit
+    # test_toolkit()
+    #
+    # # 测试 BackgroundManagedKeys 选项
+    # test_background_managed_keys_api()
+    #
+    # # 测试 Win32 relative_move 正路径
+    # test_win32_relative_move()
 
-    # 测试各模块 API
-    resource = test_resource_api()
-    controller = test_controller_api()
-    test_buffer_api()
-    tasker = test_tasker_api(resource, controller)
-
-    # 验证自定义识别和动作被调用
-    if not analyzed or not runned:
-        print("FAIL: custom recognition or action not called")
-        raise RuntimeError("custom recognition or action not called")
-
-    # 测试 CustomController
-    test_custom_controller()
-
-    # 测试 Toolkit
-    test_toolkit()
-
-    # 测试 BackgroundManagedKeys 选项
-    test_background_managed_keys_api()
-
-    # 测试 Win32 relative_move 正路径
-    test_win32_relative_move()
+    # 测试 KWinController 创建
+    test_kwin_controller_create()
 
     print("\n" + "=" * 50)
     print("All binding tests passed!")

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -864,14 +864,8 @@ def test_kwin_controller_create():
 
         print("  PASS: KWinController creation")
 
-    except AttributeError as e:
-        if "MaaKWinControllerCreate" in str(e):
-            print("  SKIP: MaaKWinControllerCreate not available in this build")
-        else:
-            raise
-
     except RuntimeError as e:
-        # KWin 控制器创建可能因缺少 /dev/uinput 权限等环境问题失败
+        # KWin 控制器创建可能因 API 缺失或缺少 /dev/uinput 权限等环境问题失败
         print(f"  SKIP: KWinController not available in this environment ({e})")
 
 

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -884,31 +884,31 @@ if __name__ == "__main__":
     print(f"MaaFw Version: {Library.version()}")
 
     Toolkit.init_option(install_dir / "bin")
-    #
-    # # 测试各模块 API
-    # resource = test_resource_api()
-    # controller = test_controller_api()
-    # test_buffer_api()
-    # tasker = test_tasker_api(resource, controller)
-    #
-    # # 验证自定义识别和动作被调用
-    # if not analyzed or not runned:
-    #     print("FAIL: custom recognition or action not called")
-    #     raise RuntimeError("custom recognition or action not called")
-    #
-    # # 测试 CustomController
-    # test_custom_controller()
-    #
-    # # 测试 Toolkit
-    # test_toolkit()
-    #
-    # # 测试 BackgroundManagedKeys 选项
-    # test_background_managed_keys_api()
-    #
-    # # 测试 Win32 relative_move 正路径
-    # test_win32_relative_move()
 
-    # 测试 KWinController 创建
+    # 测试各模块 API
+    resource = test_resource_api()
+    controller = test_controller_api()
+    test_buffer_api()
+    tasker = test_tasker_api(resource, controller)
+
+    # 验证自定义识别和动作被调用
+    if not analyzed or not runned:
+        print("FAIL: custom recognition or action not called")
+        raise RuntimeError("custom recognition or action not called")
+
+    # 测试 CustomController
+    test_custom_controller()
+
+    # 测试 Toolkit
+    test_toolkit()
+
+    # 测试 BackgroundManagedKeys 选项
+    test_background_managed_keys_api()
+
+    # 测试 Win32 relative_move 正路径
+    test_win32_relative_move()
+
+    测试 KWinController 创建
     test_kwin_controller_create()
 
     print("\n" + "=" * 50)

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -902,7 +902,7 @@ if __name__ == "__main__":
     # 测试 Win32 relative_move 正路径
     test_win32_relative_move()
 
-    测试 KWinController 创建
+    # 测试 KWinController 创建
     test_kwin_controller_create()
 
     print("\n" + "=" * 50)


### PR DESCRIPTION
为KWinController添加python绑定

## Summary by Sourcery

为 Linux 上的 KWin Wayland 控制器添加一个 Python 绑定以及基础测试覆盖。

新功能：
- 在 Python 绑定中暴露一个 `KWinController` 类，通过 PipeWire/xdg-desktop-portal 和 `/dev/uinput` 控制 KWin。

测试：
- 添加一个 Python 绑定测试，用于创建 `KWinController`、验证其基础属性，并在控制器不可用时优雅地跳过测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Python binding and basic test coverage for the KWin Wayland controller on Linux.

New Features:
- Expose a KWinController class in the Python bindings to control KWin via PipeWire/xdg-desktop-portal and /dev/uinput.

Tests:
- Add a Python binding test that creates a KWinController, validates its basic properties, and skips gracefully when the controller is unavailable.

</details>

新特性：
- 在 Python 绑定中暴露 `KWinController` 类，通过 PipeWire/xdg-desktop-portal 和 `/dev/uinput` 驱动 KWin。

测试：
- 添加一个 Python 绑定测试，用于创建 `KWinController` 并验证其基本属性和空操作行为；在不可用时能优雅地跳过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 Linux 上的 KWin Wayland 控制器添加一个 Python 绑定以及基础测试覆盖。

新功能：
- 在 Python 绑定中暴露一个 `KWinController` 类，通过 PipeWire/xdg-desktop-portal 和 `/dev/uinput` 控制 KWin。

测试：
- 添加一个 Python 绑定测试，用于创建 `KWinController`、验证其基础属性，并在控制器不可用时优雅地跳过测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a Python binding and basic test coverage for the KWin Wayland controller on Linux.

New Features:
- Expose a KWinController class in the Python bindings to control KWin via PipeWire/xdg-desktop-portal and /dev/uinput.

Tests:
- Add a Python binding test that creates a KWinController, validates its basic properties, and skips gracefully when the controller is unavailable.

</details>

</details>