### PR TITLE
feat: 實作 Win32 的啟動與關閉應用 / Impliment start app and stop app for Win32

### DIFF
--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -441,7 +441,7 @@ Asynchronously input text. This is an asynchronous operation that immediately re
 
 - `intent`: Target app
   - Adb Controller: package name or activity
-  - Win32 Controller: not supported yet
+  - Win32 Controller: path or command of the executable (e.g., `D:\Endfield\Endfield.exe` or `notepad.exe`)
 
 Asynchronously start app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -449,7 +449,7 @@ Asynchronously start app. This is an asynchronous operation that immediately ret
 
 - `intent`: Target app
   - Adb Controller: package name
-  - Win32 Controller: ignored (closes the currently associated target window directly)
+  - Win32 Controller: optional, if provided closes the process by name (e.g., `Endfield.exe`); if empty, directly closes the associated window process
 
 Asynchronously stop app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -449,7 +449,7 @@ Asynchronously start app. This is an asynchronous operation that immediately ret
 
 - `intent`: Target app
   - Adb Controller: package name
-  - Win32 Controller: not supported yet
+  - Win32 Controller: ignored (closes the currently associated target window directly)
 
 Asynchronously stop app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -449,7 +449,7 @@ Asynchronously start app. This is an asynchronous operation that immediately ret
 
 - `intent`: Target app
   - Adb Controller: package name
-  - Win32 Controller: optional, if provided closes the process by name; if empty, directly closes the associated window process
+  - Win32 Controller: process name (optional), default to the associated window process
 
 Asynchronously stop app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -441,7 +441,7 @@ Asynchronously input text. This is an asynchronous operation that immediately re
 
 - `intent`: Target app
   - Adb Controller: package name or activity
-  - Win32 Controller: path or command of the executable (e.g., `D:\Endfield\Endfield.exe` or `notepad.exe`)
+  - Win32 Controller: path or command of the executable
 
 Asynchronously start app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 
@@ -449,7 +449,7 @@ Asynchronously start app. This is an asynchronous operation that immediately ret
 
 - `intent`: Target app
   - Adb Controller: package name
-  - Win32 Controller: optional, if provided closes the process by name (e.g., `Endfield.exe`); if empty, directly closes the associated window process
+  - Win32 Controller: optional, if provided closes the process by name; if empty, directly closes the associated window process
 
 Asynchronously stop app. This is an asynchronous operation that immediately returns an operation id. You can query the status via `MaaControllerStatus` and `MaaControllerWait`.
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -449,7 +449,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name
-  - Win32 控制器：无需参数（直接关联当前目标窗口关闭）
+  - Win32 控制器：可选参数，若提供则依据进程名称关闭（如 `Endfield.exe`）；若为空则直接关闭关联的视窗进程
 
 异步关闭应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -449,7 +449,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name
-  - Win32 控制器：暂不支持
+  - Win32 控制器：无需参数（直接关联当前目标窗口关闭）
 
 异步关闭应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -441,7 +441,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name 或 activity
-  - Win32 控制器：执行文件的路径或命令（如 `D:\Endfield\Endfield.exe` 或 `notepad.exe`）
+  - Win32 控制器：执行文件的路径或命令
 
 异步启动应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 
@@ -449,7 +449,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name
-  - Win32 控制器：可选参数，若提供则依据进程名称关闭（如 `Endfield.exe`）；若为空则直接关闭关联的视窗进程
+  - Win32 控制器：可选参数，若提供则依据进程名称关闭；若为空则直接关闭关联的视窗进程
 
 异步关闭应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -441,7 +441,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name 或 activity
-  - Win32 控制器：暂不支持
+  - Win32 控制器：执行文件的路径或命令（如 `D:\Endfield\Endfield.exe` 或 `notepad.exe`）
 
 异步启动应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -449,7 +449,7 @@
 
 - `intent`: 目标应用
   - Adb 控制器：package name
-  - Win32 控制器：可选参数，若提供则依据进程名称关闭；若为空则直接关闭关联的视窗进程
+  - Win32 控制器：进程名称（可选），预设为关联的视窗进程
 
 异步关闭应用。这是一个异步操作，会立即返回一个操作 id，可通过 `MaaControllerStatus` 和 `MaaControllerWait` 查询状态。
 

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -255,10 +255,36 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
 
 bool Win32ControlUnitMgr::stop_app(const std::string& intent)
 {
-    // TODO
+    LogFunc << VAR(intent);
     std::ignore = intent;
 
-    return false;
+    if (!hwnd_ || !IsWindow(hwnd_)) {
+        LogError << "hwnd_ is invalid";
+        return false;
+    }
+
+    DWORD processId = 0;
+    GetWindowThreadProcessId(hwnd_, &processId);
+    if (processId == 0) {
+        LogError << "GetWindowThreadProcessId failed, error:" << GetLastError();
+        return false;
+    }
+
+    HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, processId);
+    if (!hProcess) {
+        LogError << "OpenProcess failed, error:" << GetLastError();
+        return false;
+    }
+
+    if (!TerminateProcess(hProcess, 0)) {
+        LogError << "TerminateProcess failed, error:" << GetLastError();
+        CloseHandle(hProcess);
+        return false;
+    }
+
+    CloseHandle(hProcess);
+    LogInfo << "Process" << processId << "terminated successfully";
+    return true;
 }
 
 bool Win32ControlUnitMgr::screencap(cv::Mat& image)

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -265,55 +265,53 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
     si.cb = sizeof(si);
     ZeroMemory(&pi, sizeof(pi));
 
-    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
-        DWORD err = GetLastError();
-        if (err == ERROR_ELEVATION_REQUIRED) {
-            LogInfo << "Elevation required. Falling back to ShellExecuteExW...";
-            std::wstring file = cmd;
-            std::wstring args;
-            if (!cmd.empty()) {
-                if (cmd[0] == L'\"') {
-                    auto pos = cmd.find(L'\"', 1);
-                    if (pos != std::wstring::npos) {
-                        file = cmd.substr(1, pos - 1);
-                        if (pos + 1 < cmd.length()) {
-                            args = cmd.substr(pos + 1);
-                            args.erase(0, args.find_first_not_of(L" \t"));
-                        }
-                    }
-                } else {
-                    auto pos = cmd.find(L' ');
-                    if (pos != std::wstring::npos) {
-                        file = cmd.substr(0, pos);
-                        args = cmd.substr(pos + 1);
-                        args.erase(0, args.find_first_not_of(L" \t"));
-                    }
-                }
-            }
+    if (CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+        LogInfo << "CreateProcessW succeeded, PID:" << pi.dwProcessId;
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        return true;
+    }
 
-            SHELLEXECUTEINFOW sei = { sizeof(sei) };
-            sei.fMask = SEE_MASK_NOCLOSEPROCESS;
-            sei.lpVerb = L"runas";
-            sei.lpFile = file.c_str();
-            sei.lpParameters = args.empty() ? nullptr : args.c_str();
-            sei.nShow = SW_SHOWNORMAL;
-            if (ShellExecuteExW(&sei)) {
-                LogInfo << "ShellExecuteExW succeeded.";
-                if (sei.hProcess) {
-                    CloseHandle(sei.hProcess);
-                }
-                return true;
-            }
-            LogError << "ShellExecuteExW failed, error:" << GetLastError();
-            return false;
-        }
+    DWORD err = GetLastError();
+    if (err != ERROR_ELEVATION_REQUIRED) {
         LogError << "CreateProcessW failed, error:" << err;
         return false;
     }
-
-    LogInfo << "CreateProcessW succeeded, PID:" << pi.dwProcessId;
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
+    LogInfo << "Elevation required. Falling back to ShellExecuteExW...";
+    std::wstring file = cmd;
+    std::wstring args;
+    // Parse
+    if (cmd[0] == L'\"') {
+        auto pos = cmd.find(L'\"', 1);
+        if (pos == std::wstring::npos) {
+            LogError << "Mismatched quotes in command, cannot parse file and arguments";
+            return false;
+        }
+        file = cmd.substr(1, pos - 1);
+        if (pos + 1 < cmd.length()) {
+            args = cmd.substr(pos + 1);
+            args.erase(0, args.find_first_not_of(L" \t"));
+        }
+    } else if (auto pos = cmd.find(L' '); pos != std::wstring::npos) {
+        file = cmd.substr(0, pos);
+        args = cmd.substr(pos + 1);
+        args.erase(0, args.find_first_not_of(L" \t"));
+    }
+    // execute
+    SHELLEXECUTEINFOW sei = { sizeof(sei) };
+    sei.fMask = SEE_MASK_NOCLOSEPROCESS;
+    sei.lpVerb = L"runas";
+    sei.lpFile = file.c_str();
+    sei.lpParameters = args.empty() ? nullptr : args.c_str();
+    sei.nShow = SW_SHOWNORMAL;
+    if (!ShellExecuteExW(&sei)) {
+        LogError << "ShellExecuteExW failed, error:" << GetLastError();
+        return false;
+    }
+    LogInfo << "ShellExecuteExW succeeded.";
+    if (sei.hProcess) {
+        CloseHandle(sei.hProcess);
+    }
     return true;
 }
 
@@ -362,24 +360,33 @@ bool Win32ControlUnitMgr::stop_app(const std::string& intent)
     pe.dwSize = sizeof(pe);
     bool terminated_any = false;
 
-    if (Process32FirstW(hSnap, &pe)) {
-        do {
-            if (target_exe == pe.szExeFile) {
-                HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pe.th32ProcessID);
-                if (hProcess) {
-                    if (TerminateProcess(hProcess, 0)) {
-                        LogInfo << "Process" << pe.th32ProcessID << "terminated successfully by intent matching";
-                        terminated_any = true;
-                    } else {
-                        LogError << "TerminateProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
-                    }
-                    CloseHandle(hProcess);
-                } else {
-                    LogError << "OpenProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
-                }
-            }
-        } while (Process32NextW(hSnap, &pe));
+    if (!Process32FirstW(hSnap, &pe)) {
+        LogError << "Process32FirstW failed, error:" << GetLastError();
+        CloseHandle(hSnap);
+        return false;
     }
+
+    do {
+        if (target_exe != pe.szExeFile) {
+            continue;
+        }
+
+        HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pe.th32ProcessID);
+        if (!hProcess) {
+            LogError << "OpenProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
+            continue;
+        }
+
+        if (TerminateProcess(hProcess, 0)) {
+            LogInfo << "Process" << pe.th32ProcessID << "terminated successfully by intent matching";
+            terminated_any = true;
+        } else {
+            LogError << "TerminateProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
+        }
+
+        CloseHandle(hProcess);
+
+    } while (Process32NextW(hSnap, &pe));
     CloseHandle(hSnap);
 
     return terminated_any;

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -269,10 +269,33 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
         DWORD err = GetLastError();
         if (err == ERROR_ELEVATION_REQUIRED) {
             LogInfo << "Elevation required. Falling back to ShellExecuteExW...";
+            std::wstring file = cmd;
+            std::wstring args;
+            if (!cmd.empty()) {
+                if (cmd[0] == L'\"') {
+                    auto pos = cmd.find(L'\"', 1);
+                    if (pos != std::wstring::npos) {
+                        file = cmd.substr(1, pos - 1);
+                        if (pos + 1 < cmd.length()) {
+                            args = cmd.substr(pos + 1);
+                            args.erase(0, args.find_first_not_of(L" \t"));
+                        }
+                    }
+                } else {
+                    auto pos = cmd.find(L' ');
+                    if (pos != std::wstring::npos) {
+                        file = cmd.substr(0, pos);
+                        args = cmd.substr(pos + 1);
+                        args.erase(0, args.find_first_not_of(L" \t"));
+                    }
+                }
+            }
+
             SHELLEXECUTEINFOW sei = { sizeof(sei) };
             sei.fMask = SEE_MASK_NOCLOSEPROCESS;
             sei.lpVerb = L"runas";
-            sei.lpFile = cmd.c_str();
+            sei.lpFile = file.c_str();
+            sei.lpParameters = args.empty() ? nullptr : args.c_str();
             sei.nShow = SW_SHOWNORMAL;
             if (ShellExecuteExW(&sei)) {
                 LogInfo << "ShellExecuteExW succeeded.";

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -250,10 +250,30 @@ MaaControllerFeature Win32ControlUnitMgr::get_features() const
 
 bool Win32ControlUnitMgr::start_app(const std::string& intent)
 {
-    // TODO
-    std::ignore = intent;
+    LogFunc << VAR(intent);
 
-    return false;
+    if (intent.empty()) {
+        LogError << "intent is empty";
+        return false;
+    }
+
+    std::wstring cmd = MAA_NS::to_u16(intent);
+
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
+    ZeroMemory(&si, sizeof(si));
+    si.cb = sizeof(si);
+    ZeroMemory(&pi, sizeof(pi));
+
+    if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
+        LogError << "CreateProcessW failed, error:" << GetLastError();
+        return false;
+    }
+
+    LogInfo << "CreateProcessW succeeded, PID:" << pi.dwProcessId;
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    return true;
 }
 
 bool Win32ControlUnitMgr::stop_app(const std::string& intent)

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -266,7 +266,26 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
     ZeroMemory(&pi, sizeof(pi));
 
     if (!CreateProcessW(nullptr, cmd.data(), nullptr, nullptr, FALSE, 0, nullptr, nullptr, &si, &pi)) {
-        LogError << "CreateProcessW failed, error:" << GetLastError();
+        DWORD err = GetLastError();
+        if (err == ERROR_ELEVATION_REQUIRED) {
+            LogInfo << "Elevation required. Falling back to ShellExecuteExW...";
+            SHELLEXECUTEINFOW sei = { sizeof(sei) };
+            sei.fMask = SEE_MASK_NOCLOSEPROCESS;
+            sei.lpVerb = L"runas";
+            sei.lpFile = cmd.c_str();
+            sei.nShow = SW_SHOWNORMAL;
+            if (ShellExecuteExW(&sei)) {
+                LogInfo << "ShellExecuteExW succeeded.";
+                if (sei.hProcess) {
+                    CloseHandle(sei.hProcess);
+                }
+                return true;
+            } else {
+                LogError << "ShellExecuteExW failed, error:" << GetLastError();
+                return false;
+            }
+        }
+        LogError << "CreateProcessW failed, error:" << err;
         return false;
     }
 

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -280,10 +280,9 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
                     CloseHandle(sei.hProcess);
                 }
                 return true;
-            } else {
-                LogError << "ShellExecuteExW failed, error:" << GetLastError();
-                return false;
             }
+            LogError << "ShellExecuteExW failed, error:" << GetLastError();
+            return false;
         }
         LogError << "CreateProcessW failed, error:" << err;
         return false;

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -5,6 +5,9 @@
 #include "MaaFramework/MaaMsg.h"
 #include "MaaUtils/Logger.h"
 #include "MaaUtils/Time.hpp"
+#include "MaaUtils/Encoding.h"
+
+#include <tlhelp32.h>
 
 #include "Input/BackgroundManagedKeyInput.h"
 #include "Input/LegacyEventInput.h"
@@ -256,35 +259,69 @@ bool Win32ControlUnitMgr::start_app(const std::string& intent)
 bool Win32ControlUnitMgr::stop_app(const std::string& intent)
 {
     LogFunc << VAR(intent);
-    std::ignore = intent;
 
-    if (!hwnd_ || !IsWindow(hwnd_)) {
-        LogError << "hwnd_ is invalid";
-        return false;
-    }
+    if (intent.empty()) {
+        if (!hwnd_ || !IsWindow(hwnd_)) {
+            LogError << "hwnd_ is invalid and intent is empty";
+            return false;
+        }
 
-    DWORD processId = 0;
-    GetWindowThreadProcessId(hwnd_, &processId);
-    if (processId == 0) {
-        LogError << "GetWindowThreadProcessId failed, error:" << GetLastError();
-        return false;
-    }
+        DWORD processId = 0;
+        GetWindowThreadProcessId(hwnd_, &processId);
+        if (processId == 0) {
+            LogError << "GetWindowThreadProcessId failed, error:" << GetLastError();
+            return false;
+        }
 
-    HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, processId);
-    if (!hProcess) {
-        LogError << "OpenProcess failed, error:" << GetLastError();
-        return false;
-    }
+        HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, processId);
+        if (!hProcess) {
+            LogError << "OpenProcess failed, error:" << GetLastError();
+            return false;
+        }
 
-    if (!TerminateProcess(hProcess, 0)) {
-        LogError << "TerminateProcess failed, error:" << GetLastError();
+        if (!TerminateProcess(hProcess, 0)) {
+            LogError << "TerminateProcess failed, error:" << GetLastError();
+            CloseHandle(hProcess);
+            return false;
+        }
+
         CloseHandle(hProcess);
+        LogInfo << "Process" << processId << "terminated successfully by hwnd";
+        return true;
+    }
+
+    std::wstring target_exe = MAA_NS::to_u16(intent);
+    HANDLE hSnap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnap == INVALID_HANDLE_VALUE) {
+        LogError << "CreateToolhelp32Snapshot failed, error:" << GetLastError();
         return false;
     }
 
-    CloseHandle(hProcess);
-    LogInfo << "Process" << processId << "terminated successfully";
-    return true;
+    PROCESSENTRY32W pe;
+    pe.dwSize = sizeof(pe);
+    bool terminated_any = false;
+
+    if (Process32FirstW(hSnap, &pe)) {
+        do {
+            if (target_exe == pe.szExeFile) {
+                HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, FALSE, pe.th32ProcessID);
+                if (hProcess) {
+                    if (TerminateProcess(hProcess, 0)) {
+                        LogInfo << "Process" << pe.th32ProcessID << "terminated successfully by intent matching";
+                        terminated_any = true;
+                    } else {
+                        LogError << "TerminateProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
+                    }
+                    CloseHandle(hProcess);
+                } else {
+                    LogError << "OpenProcess failed for PID" << pe.th32ProcessID << "error:" << GetLastError();
+                }
+            }
+        } while (Process32NextW(hSnap, &pe));
+    }
+    CloseHandle(hSnap);
+
+    return terminated_any;
 }
 
 bool Win32ControlUnitMgr::screencap(cv::Mat& image)


### PR DESCRIPTION
## Summary by Sourcery

实现 Win32 控制器对应用启动和停止的支持，并记录新的行为。

新功能：
- 添加 Win32 控制器实现，通过可执行文件路径或命令启动应用程序。
- 添加 Win32 控制器实现，通过关联窗口或可执行文件名停止应用程序。

文档：
- 记录 Win32 控制器在启动应用时，将可执行文件路径或命令作为 intent 格式的用法。
- 记录 Win32 控制器在 Win32 上的停止行为，允许在 intent 为空时，使用可选的基于进程名的终止方式或基于窗口的终止方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement Win32 controller support for starting and stopping applications and document the new behavior.

New Features:
- Add Win32 controller implementation for starting applications via executable path or command.
- Add Win32 controller implementation for stopping applications either by associated window or by executable name.

Documentation:
- Document Win32 controller intent format for starting apps as executable path or command.
- Document Win32 controller stop behavior for Win32, allowing optional process-name based termination or window-based termination when intent is empty.

</details>