### PR TITLE
fix(AdbControlUnit): 兼容部分 vivo 和较新 Android 设备上 Viewport INTERNAL 格式的输出

### DIFF
--- a/source/MaaAdbControlUnit/General/DeviceInfo.cpp
+++ b/source/MaaAdbControlUnit/General/DeviceInfo.cpp
@@ -13,8 +13,17 @@ bool DeviceInfo::parse(const json::value& config)
     static const json::array kDefaultResolutionArgv = {
         "{ADB}", "-s", "{ADB_SERIAL}", "shell", "dumpsys window displays | grep DisplayFrames | tail -n 1 | grep -o -E [0-9]+",
     };
+
+    // 兼容两类输出：
+    // 1. 旧逻辑：SurfaceOrientation
+    // 2. 部分 vivo / 新 Android 输出：Viewport INTERNAL ... orientation=0
+    //
+    // 使用 sed 而不是 grep 管道的原因：
+    // grep 匹配不到时会返回非 0，导致 startup_and_read_pipe 判定 child return error。
+    // sed 即使没有匹配到内容，一般也会正常退出；后续由 request_orientation 判断空输出。
     static const json::array kDefaultOrientationArgv = {
-        "{ADB}", "-s", "{ADB_SERIAL}", "shell", "dumpsys input | grep SurfaceOrientation | tail -n 1 | grep -m 1 -o -E [0-9]",
+        "{ADB}", "-s", "{ADB_SERIAL}", "shell",
+        "dumpsys input | sed -n 's/.*SurfaceOrientation[^0-9]*\\([0-3]\\).*/\\1/p; s/.*Viewport INTERNAL.*orientation=\\([0-3]\\).*/\\1/p' | tail -n 1",
     };
 
     return parse_command("UUID", config, kDefaultUuidArgv, uuid_argv_)
@@ -80,17 +89,15 @@ std::optional<int> DeviceInfo::request_orientation()
 
     const auto& s = output_opt.value();
 
-    if (s.empty()) {
-        return std::nullopt;
+    // 原逻辑只取 s.front()，如果输出前面带空格、换行、日志文本等，会误判。
+    // 这里改成扫描第一个合法方向值。
+    for (unsigned char c : s) {
+        if (c >= '0' && c <= '3') {
+            return static_cast<int>(c - '0');
+        }
     }
 
-    int ori = s.front() - '0';
-
-    if (!(ori >= 0 && ori <= 3)) {
-        return std::nullopt;
-    }
-
-    return ori;
+    return std::nullopt;
 }
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaAdbControlUnit/General/DeviceInfo.cpp
+++ b/source/MaaAdbControlUnit/General/DeviceInfo.cpp
@@ -13,17 +13,8 @@ bool DeviceInfo::parse(const json::value& config)
     static const json::array kDefaultResolutionArgv = {
         "{ADB}", "-s", "{ADB_SERIAL}", "shell", "dumpsys window displays | grep DisplayFrames | tail -n 1 | grep -o -E [0-9]+",
     };
-
-    // 兼容两类输出：
-    // 1. 旧逻辑：SurfaceOrientation
-    // 2. 部分 vivo / 新 Android 输出：Viewport INTERNAL ... orientation=0
-    //
-    // 使用 sed 而不是 grep 管道的原因：
-    // grep 匹配不到时会返回非 0，导致 startup_and_read_pipe 判定 child return error。
-    // sed 即使没有匹配到内容，一般也会正常退出；后续由 request_orientation 判断空输出。
     static const json::array kDefaultOrientationArgv = {
-        "{ADB}", "-s", "{ADB_SERIAL}", "shell",
-        "dumpsys input | sed -n 's/.*SurfaceOrientation[^0-9]*\\([0-3]\\).*/\\1/p; s/.*Viewport INTERNAL.*orientation=\\([0-3]\\).*/\\1/p' | tail -n 1",
+        "{ADB}", "-s", "{ADB_SERIAL}", "shell", "dumpsys input | grep SurfaceOrientation | tail -n 1 | grep -m 1 -o -E [0-9]",
     };
 
     return parse_command("UUID", config, kDefaultUuidArgv, uuid_argv_)
@@ -89,15 +80,17 @@ std::optional<int> DeviceInfo::request_orientation()
 
     const auto& s = output_opt.value();
 
-    // 原逻辑只取 s.front()，如果输出前面带空格、换行、日志文本等，会误判。
-    // 这里改成扫描第一个合法方向值。
-    for (unsigned char c : s) {
-        if (c >= '0' && c <= '3') {
-            return static_cast<int>(c - '0');
-        }
+    if (s.empty()) {
+        return std::nullopt;
     }
 
-    return std::nullopt;
+    int ori = s.front() - '0';
+
+    if (!(ori >= 0 && ori <= 3)) {
+        return std::nullopt;
+    }
+
+    return ori;
 }
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -1,7 +1,5 @@
 #include "AdbDeviceFinder.h"
 
-#include <algorithm>
-#include <cctype>
 #include <filesystem>
 #include <ranges>
 #include <unordered_set>
@@ -10,6 +8,7 @@
 #include "MaaControlUnit/ControlUnitAPI.h"
 #include "MaaUtils/IOStream/BoostIO.hpp"
 #include "MaaUtils/Logger.h"
+#include "MaaUtils/StringMisc.hpp"
 
 MAA_TOOLKIT_NS_BEGIN
 
@@ -114,25 +113,6 @@ std::vector<std::string> AdbDeviceFinder::find_serials_by_adb_command(const std:
     return devices;
 }
 
-static void trim_inplace(std::string& s)
-{
-    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
-        s.pop_back();
-    }
-
-    auto it = std::ranges::find_if(s, [](unsigned char c) {
-        return !std::isspace(c);
-    });
-    s.erase(s.begin(), it);
-}
-
-static void lowercase_inplace(std::string& s)
-{
-    std::ranges::transform(s, s.begin(), [](unsigned char c) {
-        return static_cast<char>(std::tolower(c));
-    });
-}
-
 bool request_waydroid_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> control_unit, AdbDevice& device)
 {
     if (!control_unit) {
@@ -144,8 +124,10 @@ bool request_waydroid_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI
     if (!ret) {
         return false;
     }
-    trim_inplace(output);
-    lowercase_inplace(output);
+
+    string_trim_(output);
+    tolowers_(output);
+
     if (output.find("waydroid") == std::string::npos) {
         return false;
     }
@@ -175,7 +157,9 @@ bool request_androws_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI>
     if (!ret) {
         return false;
     }
-    trim_inplace(output);
+
+    string_trim_(output);
+
     if (output.empty()) {
         return false;
     }
@@ -204,8 +188,10 @@ bool request_avd_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> con
     if (!control_unit->shell("getprop ro.product.model", output)) {
         return false;
     }
-    trim_inplace(output);
-    lowercase_inplace(output);
+
+    string_trim_(output);
+    tolowers_(output);
+
     if (!output.starts_with("android sdk") && !output.starts_with("sdk_")) {
         return false;
     }
@@ -227,43 +213,40 @@ bool request_vivo_orientation_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbContro
         return false;
     }
 
-    trim_inplace(brand);
-    lowercase_inplace(brand);
+    string_trim_(brand);
+    tolowers_(brand);
 
     std::string manufacturer;
     if (control_unit->shell("getprop ro.product.manufacturer", manufacturer)) {
-        trim_inplace(manufacturer);
-        lowercase_inplace(manufacturer);
+        string_trim_(manufacturer);
+        tolowers_(manufacturer);
     }
 
     std::string model;
     if (control_unit->shell("getprop ro.product.model", model)) {
-        trim_inplace(model);
-        lowercase_inplace(model);
+        string_trim_(model);
+        tolowers_(model);
     }
 
-    const bool is_vivo_device =
-        brand.find("vivo") != std::string::npos
-        || manufacturer.find("vivo") != std::string::npos
-        || model.find("vivo") != std::string::npos
-        || model.find("iqoo") != std::string::npos;
+    const bool is_vivo_device = brand.find("vivo") != std::string::npos || manufacturer.find("vivo") != std::string::npos
+                                || model.find("vivo") != std::string::npos || model.find("iqoo") != std::string::npos;
 
     if (!is_vivo_device) {
         return false;
     }
 
-    // 如果 SurfaceOrientation 存在，说明默认 Orientation 命令仍可用。
-    // 为了缩小影响范围，这种情况下不覆盖默认命令。
+    // If SurfaceOrientation exists, the default Orientation command should still work.
+    // In this case, do not override the default command to minimize the impact scope.
     std::string surface_orientation;
     if (control_unit->shell("dumpsys input | grep -m 1 SurfaceOrientation", surface_orientation)) {
-        trim_inplace(surface_orientation);
+        string_trim_(surface_orientation);
         if (!surface_orientation.empty()) {
             return false;
         }
     }
 
-    // 部分 vivo / iQOO 设备 dumpsys input 中没有 SurfaceOrientation，
-    // 但 Viewport INTERNAL 中包含 orientation=0/1/2/3。
+    // Some vivo / iQOO devices do not have SurfaceOrientation in dumpsys input,
+    // but Viewport INTERNAL contains orientation=0/1/2/3.
     std::string viewport;
     if (!control_unit->shell("dumpsys input | grep -m 1 'Viewport INTERNAL'", viewport)) {
         return false;
@@ -325,14 +308,12 @@ std::optional<AdbDevice>
     }
     else if (request_avd_config(control_unit, device)) {
     }
+    else if (request_vivo_orientation_config(control_unit, device)) {
+    }
     // else if (request_xxx_config(control_unit, device)) {
     // }
     else {
     }
-
-    // Orientation 命令兼容属于附加配置，不参与上面的互斥设备类型判断。
-    // 只在特定 vivo / iQOO 设备上覆盖 command.Orientation，避免修改全局默认解析。
-    request_vivo_orientation_config(control_unit, device);
 
     return device;
 }

--- a/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceFinder.cpp
@@ -1,5 +1,7 @@
 #include "AdbDeviceFinder.h"
 
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <ranges>
 #include <unordered_set>
@@ -112,6 +114,25 @@ std::vector<std::string> AdbDeviceFinder::find_serials_by_adb_command(const std:
     return devices;
 }
 
+static void trim_inplace(std::string& s)
+{
+    while (!s.empty() && std::isspace(static_cast<unsigned char>(s.back()))) {
+        s.pop_back();
+    }
+
+    auto it = std::ranges::find_if(s, [](unsigned char c) {
+        return !std::isspace(c);
+    });
+    s.erase(s.begin(), it);
+}
+
+static void lowercase_inplace(std::string& s)
+{
+    std::ranges::transform(s, s.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+}
+
 bool request_waydroid_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> control_unit, AdbDevice& device)
 {
     if (!control_unit) {
@@ -123,6 +144,8 @@ bool request_waydroid_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI
     if (!ret) {
         return false;
     }
+    trim_inplace(output);
+    lowercase_inplace(output);
     if (output.find("waydroid") == std::string::npos) {
         return false;
     }
@@ -152,10 +175,7 @@ bool request_androws_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI>
     if (!ret) {
         return false;
     }
-    // Trim whitespace/newlines
-    while (!output.empty() && (output.back() == '\n' || output.back() == '\r' || output.back() == ' ')) {
-        output.pop_back();
-    }
+    trim_inplace(output);
     if (output.empty()) {
         return false;
     }
@@ -184,13 +204,86 @@ bool request_avd_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> con
     if (!control_unit->shell("getprop ro.product.model", output)) {
         return false;
     }
-    if (!output.starts_with("Android SDK") && !output.starts_with("sdk_")) {
+    trim_inplace(output);
+    lowercase_inplace(output);
+    if (!output.starts_with("android sdk") && !output.starts_with("sdk_")) {
         return false;
     }
 
     device.config["extras"]["avd"]["enable"] = true;
 
     LogInfo << "AVDExtras enabled for" << VAR(device);
+    return true;
+}
+
+bool request_vivo_orientation_config(std::shared_ptr<MAA_CTRL_UNIT_NS::AdbControlUnitAPI> control_unit, AdbDevice& device)
+{
+    if (!control_unit) {
+        return false;
+    }
+
+    std::string brand;
+    if (!control_unit->shell("getprop ro.product.brand", brand)) {
+        return false;
+    }
+
+    trim_inplace(brand);
+    lowercase_inplace(brand);
+
+    std::string manufacturer;
+    if (control_unit->shell("getprop ro.product.manufacturer", manufacturer)) {
+        trim_inplace(manufacturer);
+        lowercase_inplace(manufacturer);
+    }
+
+    std::string model;
+    if (control_unit->shell("getprop ro.product.model", model)) {
+        trim_inplace(model);
+        lowercase_inplace(model);
+    }
+
+    const bool is_vivo_device =
+        brand.find("vivo") != std::string::npos
+        || manufacturer.find("vivo") != std::string::npos
+        || model.find("vivo") != std::string::npos
+        || model.find("iqoo") != std::string::npos;
+
+    if (!is_vivo_device) {
+        return false;
+    }
+
+    // 如果 SurfaceOrientation 存在，说明默认 Orientation 命令仍可用。
+    // 为了缩小影响范围，这种情况下不覆盖默认命令。
+    std::string surface_orientation;
+    if (control_unit->shell("dumpsys input | grep -m 1 SurfaceOrientation", surface_orientation)) {
+        trim_inplace(surface_orientation);
+        if (!surface_orientation.empty()) {
+            return false;
+        }
+    }
+
+    // 部分 vivo / iQOO 设备 dumpsys input 中没有 SurfaceOrientation，
+    // 但 Viewport INTERNAL 中包含 orientation=0/1/2/3。
+    std::string viewport;
+    if (!control_unit->shell("dumpsys input | grep -m 1 'Viewport INTERNAL'", viewport)) {
+        return false;
+    }
+
+    if (viewport.find("orientation=") == std::string::npos) {
+        return false;
+    }
+
+    auto& command = device.config["command"];
+
+    command["Orientation"] = json::array {
+        "{ADB}",
+        "-s",
+        "{ADB_SERIAL}",
+        "shell",
+        "dumpsys input | sed -n 's/.*Viewport INTERNAL.*orientation=\\([0-3]\\).*/\\1/p' | tail -n 1",
+    };
+
+    LogInfo << "vivo orientation config enabled" << VAR(device);
     return true;
 }
 
@@ -236,6 +329,10 @@ std::optional<AdbDevice>
     // }
     else {
     }
+
+    // Orientation 命令兼容属于附加配置，不参与上面的互斥设备类型判断。
+    // 只在特定 vivo / iQOO 设备上覆盖 command.Orientation，避免修改全局默认解析。
+    request_vivo_orientation_config(control_unit, device);
 
     return device;
 }


### PR DESCRIPTION
兼容部分 vivo 和较新 Android 设备上 Viewport INTERNAL 格式的输出， 同时使用 sed 替代 grep 避免匹配失败时子进程非零退出的问题；
优化方向值解析逻辑，扫描全字符串取第一个合法值而非仅取首字符。

fix: https://github.com/MaaXYZ/MaaFramework/issues/1380#issue-4762520226

## Summary by Sourcery

改进对通过 adb 控制的 Android 设备的屏幕方向检测，以适配新版 Viewport INTERNAL 输出格式，并更稳健地从 `dumpsys input` 中解析方向值。

Bug 修复：
- 通过将 `dumpsys input` 的过滤方式从 `grep` 改为 `sed`，在方向输出缺失时防止子进程启动失败。
- 当 `dumpsys` 输出包含前导空格或日志文本时，通过扫描结果中的第一个有效方向数字，避免误解析方向。

增强：
- 支持从某些 vivo 设备和新版 Android 设备使用的 Viewport INTERNAL 风格的 `dumpsys input` 输出中提取方向信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve device orientation detection for adb-controlled Android devices to handle newer Viewport INTERNAL output formats and more robustly parse orientation values from dumpsys input.

Bug Fixes:
- Prevent child process startup failure when orientation output is missing by switching dumpsys input filtering from grep to sed.
- Avoid mis-parsing orientation when dumpsys output contains leading spaces or log text by scanning for the first valid orientation digit in the result.

Enhancements:
- Support orientation extraction from Viewport INTERNAL-style dumpsys input output used on some vivo and newer Android devices.

</details>

## Summary by Sourcery

改进 adb 设备检测和屏幕方向配置，包括针对部分 vivo 设备的厂商特定处理。

新功能：
- 为 vivo 和 iQOO 设备添加厂商特定的屏幕方向配置，使用来自 `dumpsys input` 的 Viewport INTERNAL 输出。

增强优化：
- 通过裁剪和小写化规范化 `adb shell` 属性输出，使模拟器和设备类型检测更加健壮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve adb device detection and orientation configuration, including vendor-specific handling for certain vivo devices.

New Features:
- Add vendor-specific orientation configuration for vivo and iQOO devices using Viewport INTERNAL output from dumpsys input.

Enhancements:
- Normalize adb shell property outputs with trimming and lowercasing to make emulator and device type detection more robust.

</details>