### PR TITLE
feat: upgrade NDK from r27d to r29

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,7 +423,7 @@ jobs:
             - uses: nttld/setup-ndk@v1
               id: setup-ndk
               with:
-                  ndk-version: r27d
+                  ndk-version: r29
 
             - name: Export ANDROID_NDK_ROOT
               run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary by Sourcery

构建：
- 更新 CI 构建工作流以安装 Android NDK r29。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update CI build workflow to install Android NDK r29.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

构建：
- 更新 CI 构建工作流以安装 Android NDK r29。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update CI build workflow to install Android NDK r29.

</details>

</details>