### PR TITLE
ci: pin runner to macos-15 to keep Xcode 16.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,7 +301,7 @@ jobs:
             matrix:
                 arch: [aarch64, x86_64]
             fail-fast: false
-        runs-on: macos-latest
+        runs-on: macos-15
 
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -339,7 +339,7 @@ jobs:
             matrix:
                 arch: [aarch64]
             fail-fast: false
-        runs-on: macos-latest
+        runs-on: macos-15
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
苹果怎么又不管兼容性啊（）

## Summary by Sourcery

CI:
- 将构建和测试的 GitHub Actions 工作流从使用 `macos-latest` 运行器更新为使用 `macos-15` 运行器。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update build and test GitHub Actions workflows to use macos-15 runners instead of macos-latest.

</details>