### PR TITLE
docs: 补充interface 2.8 hotkey详细说明

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -675,7 +675,9 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - **hotkeys** `object[]`  
     Used only when `type` is `"hotkey"`. Hotkey configuration, an array of objects defining hotkey fields the user can capture. **💡 v2.8.0**
 
-    The Client should render a hotkey capture control. After the user presses the target key (or key combination), the Client converts it to a virtual key code array based on the **currently selected controller**. The conversion rules match the `list<int>` form of the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) action `key` field and must use the virtual key code table supported by that controller. A single key is also represented as a one-element array (e.g. `[69]`).
+    The Client should render a hotkey capture control. After the user presses the target key (or key combination), the Client stores it as a human-readable shortcut string (e.g. `"E"`, `"Ctrl+A"`). Do **not** store virtual key codes or JSON arrays directly. Combined shortcuts use `+` as the separator; the **last segment is the primary key**, and preceding segments are modifiers in order (e.g. in `Ctrl+Shift+A`, `A` is primary and `Ctrl` / `Shift` are modifiers).
+
+    When generating `pipeline_override`, the Client should map the shortcut string to virtual key codes supported by the **currently selected controller `type`** (e.g. `Win32`, `Adb`, `WlRoots`). The mapping rules must match the key code tables used by actions such as [`ClickKey`](3.1-PipelineProtocol.md#clickkey) and [`KeyDown`](3.1-PipelineProtocol.md#keydown).
 
     - **name** `string`  
       Unique hotkey field identifier, used as the field ID.
@@ -687,12 +689,33 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       Detailed hotkey field description to help users understand the purpose of this shortcut. Supports file paths, URLs, or direct text. Content supports Markdown format. _Optional._ Supports internationalization (starting with `$`).
 
     - **default** `string`  
-      Default value for the hotkey field. _Optional._ Provide a human-readable shortcut string directly (e.g. `"E"`, `"1"`, `"ALT+A"`). Do not use virtual key codes or JSON arrays. The Client uses this to initialize the control display; after the user recaptures a shortcut, output still follows the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) rules as a virtual key code array.
+      Default value for the hotkey field. _Optional._ Provide a human-readable shortcut string directly (e.g. `"E"`, `"1"`, `"Ctrl+A"`). Do not use virtual key codes. The Client uses this to initialize the control display; after the user recaptures a shortcut, the stored value should still be a shortcut string.
 
   - **pipeline_override** `pipeline`  
     Used when the option type is `"input"` or `"hotkey"`, as a substitution template for user-provided values. Supports using `{name}` format in strings to reference input field or hotkey field values. _Optional._
 
-    When the option type is `"hotkey"`, the Client must substitute `{name}` as an **integer array** (consistent with the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) `list<int>` form), not as a string.
+    When the option type is `"hotkey"`, the Client must substitute placeholders with **integers** (virtual key codes), not strings. Supported placeholder forms:
+
+    | Placeholder | Meaning |
+    | --- | --- |
+    | `{name}` | Equivalent to `{name}.primary` |
+    | `{name}.primary` | Primary key in a combined shortcut |
+    | `{name}.modifier1` | First modifier (e.g. `Ctrl`) |
+    | `{name}.modifier2` | Second modifier (e.g. `Alt`, `Shift`) |
+
+    These placeholders are replaced with a **single integer** (virtual key code), suitable for key actions whose `key` field is *int*, for example:
+
+    ```jsonc
+    "pipeline_override": {
+        "__SomeActionKeyDown": {
+            "key": "{UseTool.primary}"
+        }
+    }
+    ```
+
+    > [!NOTE]
+    >
+    > In the Pipeline protocol, [`ClickKey`](3.1-PipelineProtocol.md#clickkey) also accepts `key` as *list<int>* (press multiple keys in one action, e.g. `[17, 65]` for Ctrl+A). `hotkey` placeholders are replaced with a single integer only and do **not** expand into an array automatically. For typical single-key rebinding (e.g. combat keys `E`, `1`, `F1`), `{name}.primary` is sufficient. If an Integrator truly needs a one-shot `ClickKey` array form for a combo, they must design it separately in the pipeline (e.g. hard-code the key code array, or split into multiple `KeyDown`/`KeyUp` nodes).
 
   - **default_case** `string` | `string[]`  
     Default option name. _Optional._

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -673,7 +673,9 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - hotkeys `object[]`  
     仅在 `type` 为 `"hotkey"` 时使用。快捷键配置，为一个对象数组，定义用户可捕获的快捷键字段。 **💡 v2.8.0**
 
-    Client 应渲染快捷键捕获控件；用户按下目标键（或组合键）后，Client 根据**当前所选控制器**将其转换为虚拟按键码数组。转换规则与 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 动作 `key` 字段的 `list<int>` 形式一致，取值范围为该控制器支持的虚拟按键码表。单键亦以单元素数组表示（如 `[69]`）。
+    Client 应渲染快捷键捕获控件。用户按下目标键（或组合键）后，Client 将其保存为人类可读的快捷键字符串（如 `"E"`、`"Ctrl+A"`），**不应**直接保存虚拟按键码或 JSON 数组。组合键以 `+` 连接，**末段为主键**，前段依次为修饰键（如 `Ctrl+Shift+A` 中 `A` 为主键，`Ctrl`、`Shift` 为修饰键）。
+
+    在生成 `pipeline_override` 时，Client 应依据**当前所选控制器的 `type`**（如 `Win32`、`Adb`、`WlRoots`），将快捷键字符串映射为该控制器支持的虚拟按键码。映射规则应与 [`ClickKey`](3.1-任务流水线协议.md#clickkey)、[`KeyDown`](3.1-任务流水线协议.md#keydown) 等动作所用键码表一致。
 
     - name `string`  
       快捷键字段唯一标识符，用作字段 ID。
@@ -685,12 +687,33 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       快捷键字段详细描述信息，帮助用户理解该快捷键的用途。支持文件路径、URL 或直接文本，内容支持 Markdown 格式。可选。支持国际化（以`$`开头）。
 
     - default `string`  
-      快捷键字段的默认值。可选。直接填写人类可读的快捷键字符串（如 `"E"`、`"1"`、`"ALT+A"`），无需填写虚拟按键码或 JSON 数组。Client 据此初始化控件展示；用户重新捕获后，仍按 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 规则输出虚拟按键码数组。
+      快捷键字段的默认值。可选。直接填写人类可读的快捷键字符串（如 `"E"`、`"1"`、`"Ctrl+A"`），无需填写虚拟按键码。Client 据此初始化控件展示；用户重新捕获后，保存的仍应为快捷键字符串。
 
   - pipeline_override `pipeline`  
     当配置项为 `"input"` 或 `"hotkey"` 类型时使用，作为用户输入内容的替换模板。支持在字符串中使用 `{名称}` 格式引用输入字段或快捷键字段的值。可选。
 
-    当配置项为 `"hotkey"` 类型时，Client 在替换 `{名称}` 时应将其转换为 **整数数组**（与 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `list<int>` 形式一致），而非字符串。
+    当配置项为 `"hotkey"` 类型时，Client 在替换占位符时应输出**整数**（虚拟按键码），而非字符串。支持的占位符形式：
+
+    | 占位符 | 含义 |
+    | --- | --- |
+    | `{名称}` | 等价于 `{名称}.primary` |
+    | `{名称}.primary` | 组合键中的主键 |
+    | `{名称}.modifier1` | 第 1 个修饰键（如 `Ctrl`） |
+    | `{名称}.modifier2` | 第 2 个修饰键（如 `Alt`、`Shift`） |
+
+    上述占位符的替换结果为**单个整数**（虚拟按键码），适用于 `key` 为 *int* 的按键动作，例如：
+
+    ```jsonc
+    "pipeline_override": {
+        "__SomeActionKeyDown": {
+            "key": "{UseTool.primary}"
+        }
+    }
+    ```
+
+    > [!NOTE]
+    >
+    > Pipeline 协议中 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `key` 字段还支持 *list<int>*（一次动作依次按下多个键，如 `[17, 65]` 表示 Ctrl+A）。`hotkey` 占位符**仅**替换为单个整数，不会自动展开为数组。一般单键改绑（如战斗技能 `E`、`1`、`F1`）使用 `{名称}.primary` 即可；若确需组合键的一次性 `ClickKey` 数组形式，Integrator 需在 pipeline 中另行设计（例如直接写键码数组，或拆成多个 `KeyDown`/`KeyUp` 节点）。
 
   - default_case `string` | `string[]`  
     默认选项名称。可选。

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -264,7 +264,7 @@
                         "hotkeys": {
                             "type": "array",
                             "title": "快捷键配置",
-                            "description": "定义用户可捕获的快捷键字段；输出为 ClickKey 可用的虚拟按键码",
+                            "description": "定义用户可捕获的快捷键字段；持久化值为人类可读字符串，pipeline_override 替换时映射为虚拟按键码整数",
                             "items": {
                                 "$ref": "#/definitions/hotkeyItem"
                             }
@@ -272,7 +272,7 @@
                         "pipeline_override": {
                             "$ref": "#/definitions/pipelineOverride",
                             "title": "Pipeline 覆盖模板",
-                            "description": "支持使用 {名称} 格式引用快捷键字段的值，替换结果应为整数数组"
+                            "description": "支持使用 {名称}、{名称}.primary、{名称}.modifier1 等占位符引用快捷键字段，替换结果为整数（虚拟按键码）"
                         }
                     },
                     "required": [


### PR DESCRIPTION
https://github.com/MistEO/MXU/pull/266

## Summary by Sourcery

完善 Project Interface v2 快捷键文档，以标准化快捷键字符串表示方式，并解释热键值如何转换为虚拟按键码以用于 pipeline 覆盖。

Enhancements:
- 在 Project Interface v2 文档中澄清快捷键是如何存储的，以及如何映射到控制器特定的虚拟按键码。
- 记录基于快捷键的 pipeline 覆盖中详细的占位符语义，包括主键和修饰键映射。

Documentation:
- 更新英文版 Project Interface 文档，描述可读性良好的快捷键字符串及其在 pipeline 覆盖中的使用方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine Project Interface v2 hotkey documentation to standardize shortcut string representation and explain how hotkey values are translated into virtual key codes for use in pipeline overrides.

Enhancements:
- Clarify how hotkey shortcuts are stored and mapped to controller-specific virtual key codes in the Project Interface v2 documentation.
- Document detailed placeholder semantics for hotkey-based pipeline overrides, including primary and modifier key mappings.

Documentation:
- Update English Project Interface documentation to describe human-readable hotkey shortcut strings and their use in pipeline overrides.

</details>