### PR TITLE
fix: use Androws input viewport for display info

### DIFF
--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
@@ -2,15 +2,112 @@
 
 #include "AndrowsExtras.h"
 
+#include <array>
 #include <charconv>
 #include <cmath>
 #include <format>
 #include <sstream>
+#include <string_view>
 
 #include "MaaUtils/Logger.h"
 #include "MaaUtils/NoWarningCV.hpp"
 
 MAA_CTRL_UNIT_NS_BEGIN
+
+namespace
+{
+
+struct DisplayViewportInfo
+{
+    int width = 0;
+    int height = 0;
+    int orientation = 0;
+};
+
+std::string_view trim(std::string_view s)
+{
+    while (!s.empty() && s.front() == ' ') {
+        s.remove_prefix(1);
+    }
+    while (!s.empty() && s.back() == ' ') {
+        s.remove_suffix(1);
+    }
+    return s;
+}
+
+std::optional<int> parse_int(std::string_view s)
+{
+    s = trim(s);
+    if (s.empty()) {
+        return std::nullopt;
+    }
+
+    int value = 0;
+    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+    if (ec != std::errc() || ptr == s.data()) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::optional<DisplayViewportInfo> parse_display_viewport_info(std::string_view output)
+{
+    constexpr std::string_view kOrientation = "orientation=";
+    auto orientation_pos = output.find(kOrientation);
+    if (orientation_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    auto orientation = parse_int(output.substr(orientation_pos + kOrientation.size(), 1));
+    if (!orientation || *orientation < 0 || *orientation > 3) {
+        return std::nullopt;
+    }
+
+    constexpr std::string_view kLogicalFrame = "logicalFrame=[";
+    auto frame_begin = output.find(kLogicalFrame);
+    if (frame_begin == std::string_view::npos) {
+        return std::nullopt;
+    }
+    frame_begin += kLogicalFrame.size();
+
+    auto frame_end = output.find(']', frame_begin);
+    if (frame_end == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    std::string_view frame = output.substr(frame_begin, frame_end - frame_begin);
+    std::array<int, 4> values = { 0, 0, 0, 0 };
+    for (int i = 0; i != 4; ++i) {
+        auto comma = frame.find(',');
+        std::string_view part = i == 3 ? frame : frame.substr(0, comma);
+        auto value = parse_int(part);
+        if (!value) {
+            return std::nullopt;
+        }
+
+        values[i] = *value;
+        if (i != 3) {
+            if (comma == std::string_view::npos) {
+                return std::nullopt;
+            }
+            frame.remove_prefix(comma + 1);
+        }
+    }
+
+    int width = values[2] - values[0];
+    int height = values[3] - values[1];
+    if (width <= 0 || height <= 0) {
+        return std::nullopt;
+    }
+
+    return DisplayViewportInfo {
+        .width = width,
+        .height = height,
+        .orientation = *orientation,
+    };
+}
+
+} // namespace
 
 AndrowsExtras::AndrowsExtras(std::filesystem::path agent_path)
 {
@@ -109,6 +206,22 @@ bool AndrowsExtras::request_display_info()
         return false;
     }
 
+    auto viewport_output = adb_shell(std::format("dumpsys input | grep -E 'Viewport .*displayId={},' | head -1", display_id_));
+    if (viewport_output && !viewport_output->empty()) {
+        auto viewport_info = parse_display_viewport_info(*viewport_output);
+        if (viewport_info) {
+            display_width_ = viewport_info->width;
+            display_height_ = viewport_info->height;
+            orientation_ = viewport_info->orientation;
+
+            LogInfo << "Androws: virtual display viewport" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_)
+                    << VAR(viewport_info->orientation) << VAR(orientation_);
+            return true;
+        }
+
+        LogWarn << "Androws: failed to parse input viewport output" << VAR(*viewport_output);
+    }
+
     // Query virtual display resolution: wm size -d {display_id}
     // Output format: "Physical size: 1280x720" (may also have "Override size: ...")
     auto output = adb_shell(std::format("wm size -d {}", display_id_));
@@ -162,9 +275,10 @@ bool AndrowsExtras::request_display_info()
 
     display_width_ = w;
     display_height_ = h;
-    orientation_ = 0; // Androws virtual display has no rotation
+    orientation_ = 0;
 
-    LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_);
+    LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_)
+            << VAR(orientation_);
     return true;
 }
 
@@ -230,8 +344,12 @@ bool AndrowsExtras::query_display_id()
     }
 
     if (!display_output || display_output->empty()) {
-        LogWarn << "Androws: failed to get display ID by package, falling back to second display";
-        display_output = adb_shell("dumpsys display | grep -o 'mDisplayId=[0-9]*' | head -2 | tail -1 | grep -o '[0-9]*'");
+        if (!app_package_.empty()) {
+            LogWarn << "Androws: failed to get display ID by package, falling back to resumed display";
+        }
+        display_output = adb_shell(
+            "dumpsys activity activities | grep -A30 'ResumedActivity:' "
+            "| grep -o 'displayId=[0-9]*' | head -1 | grep -o '[0-9]*'");
     }
 
     if (!display_output || display_output->empty()) {

--- a/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
+++ b/source/MaaAdbControlUnit/EmulatorExtras/AndrowsExtras.cpp
@@ -2,15 +2,104 @@
 
 #include "AndrowsExtras.h"
 
+#include <array>
 #include <charconv>
 #include <cmath>
 #include <format>
 #include <sstream>
+#include <string_view>
 
 #include "MaaUtils/Logger.h"
 #include "MaaUtils/NoWarningCV.hpp"
+#include "MaaUtils/StringMisc.hpp"
 
 MAA_CTRL_UNIT_NS_BEGIN
+
+namespace
+{
+
+struct DisplayViewportInfo
+{
+    int width = 0;
+    int height = 0;
+    int orientation = 0;
+};
+
+std::optional<int> parse_int(std::string_view s)
+{
+    std::string str { s };
+    string_trim_(str);
+    s = str;
+    if (s.empty()) {
+        return std::nullopt;
+    }
+
+    int value = 0;
+    auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+    if (ec != std::errc() || ptr == s.data()) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+std::optional<DisplayViewportInfo> parse_display_viewport_info(std::string_view output)
+{
+    constexpr std::string_view kOrientation = "orientation=";
+    auto orientation_pos = output.find(kOrientation);
+    if (orientation_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    auto orientation = parse_int(output.substr(orientation_pos + kOrientation.size(), 1));
+    if (!orientation || *orientation < 0 || *orientation > 3) {
+        return std::nullopt;
+    }
+
+    constexpr std::string_view kLogicalFrame = "logicalFrame=[";
+    auto frame_begin = output.find(kLogicalFrame);
+    if (frame_begin == std::string_view::npos) {
+        return std::nullopt;
+    }
+    frame_begin += kLogicalFrame.size();
+
+    auto frame_end = output.find(']', frame_begin);
+    if (frame_end == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    std::string_view frame = output.substr(frame_begin, frame_end - frame_begin);
+    std::array<int, 4> values = { 0, 0, 0, 0 };
+    for (int i = 0; i != 4; ++i) {
+        auto comma = frame.find(',');
+        std::string_view part = i == 3 ? frame : frame.substr(0, comma);
+        auto value = parse_int(part);
+        if (!value) {
+            return std::nullopt;
+        }
+
+        values[i] = *value;
+        if (i != 3) {
+            if (comma == std::string_view::npos) {
+                return std::nullopt;
+            }
+            frame.remove_prefix(comma + 1);
+        }
+    }
+
+    int width = values[2] - values[0];
+    int height = values[3] - values[1];
+    if (width <= 0 || height <= 0) {
+        return std::nullopt;
+    }
+
+    return DisplayViewportInfo {
+        .width = width,
+        .height = height,
+        .orientation = *orientation,
+    };
+}
+
+} // namespace
 
 AndrowsExtras::AndrowsExtras(std::filesystem::path agent_path)
 {
@@ -109,6 +198,22 @@ bool AndrowsExtras::request_display_info()
         return false;
     }
 
+    auto viewport_output = adb_shell(std::format("dumpsys input | grep -E 'Viewport .*displayId={},' | head -1", display_id_));
+    if (viewport_output && !viewport_output->empty()) {
+        auto viewport_info = parse_display_viewport_info(*viewport_output);
+        if (viewport_info) {
+            display_width_ = viewport_info->width;
+            display_height_ = viewport_info->height;
+            orientation_ = viewport_info->orientation;
+
+            LogInfo << "Androws: virtual display viewport" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_)
+                    << VAR(viewport_info->orientation) << VAR(orientation_);
+            return true;
+        }
+
+        LogWarn << "Androws: failed to parse input viewport output" << VAR(*viewport_output);
+    }
+
     // Query virtual display resolution: wm size -d {display_id}
     // Output format: "Physical size: 1280x720" (may also have "Override size: ...")
     auto output = adb_shell(std::format("wm size -d {}", display_id_));
@@ -117,15 +222,6 @@ bool AndrowsExtras::request_display_info()
         return MtouchHelper::request_display_info();
     }
 
-    auto trim = [](std::string_view s) {
-        while (!s.empty() && s.front() == ' ') {
-            s.remove_prefix(1);
-        }
-        while (!s.empty() && s.back() == ' ') {
-            s.remove_suffix(1);
-        }
-        return s;
-    };
     // Parse width and height from output (take the last "WxH" pattern to prefer Override size)
     int w = 0;
     int h = 0;
@@ -141,8 +237,10 @@ bool AndrowsExtras::request_display_info()
         if (xpos == std::string::npos) {
             continue;
         }
-        auto ws = trim(std::string_view(value_part.data(), xpos));
-        auto hs = trim(std::string_view(value_part.data() + xpos + 1, value_part.size() - xpos - 1));
+        std::string ws = value_part.substr(0, xpos);
+        std::string hs = value_part.substr(xpos + 1);
+        string_trim_(ws);
+        string_trim_(hs);
         int tw = 0, th = 0;
         auto [p1, ec1] = std::from_chars(ws.data(), ws.data() + ws.size(), tw);
         auto [p2, ec2] = std::from_chars(hs.data(), hs.data() + hs.size(), th);
@@ -162,9 +260,10 @@ bool AndrowsExtras::request_display_info()
 
     display_width_ = w;
     display_height_ = h;
-    orientation_ = 0; // Androws virtual display has no rotation
+    orientation_ = 0;
 
-    LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_);
+    LogInfo << "Androws: virtual display resolution" << VAR(display_id_) << VAR(display_width_) << VAR(display_height_)
+            << VAR(orientation_);
     return true;
 }
 
@@ -230,8 +329,12 @@ bool AndrowsExtras::query_display_id()
     }
 
     if (!display_output || display_output->empty()) {
-        LogWarn << "Androws: failed to get display ID by package, falling back to second display";
-        display_output = adb_shell("dumpsys display | grep -o 'mDisplayId=[0-9]*' | head -2 | tail -1 | grep -o '[0-9]*'");
+        if (!app_package_.empty()) {
+            LogWarn << "Androws: failed to get display ID by package, falling back to resumed display";
+        }
+        display_output = adb_shell(
+            "dumpsys activity activities | grep -A30 'ResumedActivity:' "
+            "| grep -o 'displayId=[0-9]*' | head -1 | grep -o '[0-9]*'");
     }
 
     if (!display_output || display_output->empty()) {


### PR DESCRIPTION
修复新版PC应用宝方向问题

## Sourcery 总结

修复在较新 PC 应用商店环境中的 Androws 显示信息检测问题。

Bug 修复：
- 使用 Androws 输入视口确定显示尺寸和方向，修复较新 PC 应用商店版本中的方向处理问题。
- 解析虚拟显示 ID 时，回退到已恢复的 Activity。

改进：
- 当输入视口数据不可用或无法解析时，保留基于 WM 的显示分辨率检测作为回退方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Androws display information detection for newer PC App Store environments.

Bug Fixes:
- Use the Androws input viewport to determine display dimensions and orientation, fixing direction handling for newer PC App Store versions.
- Fall back to the resumed activity when resolving the virtual display ID.

Enhancements:
- Retain WM-based display resolution detection as a fallback when input viewport data is unavailable or cannot be parsed.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复在较新 PC 应用商店环境中的 Androws 显示信息检测问题。

Bug 修复：
- 使用 Androws 输入视口确定显示尺寸和方向，修复较新 PC 应用商店版本中的方向处理问题。
- 解析虚拟显示 ID 时，回退到已恢复的 Activity。

改进：
- 当输入视口数据不可用或无法解析时，保留基于 WM 的显示分辨率检测作为回退方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Androws display information detection for newer PC App Store environments.

Bug Fixes:
- Use the Androws input viewport to determine display dimensions and orientation, fixing direction handling for newer PC App Store versions.
- Fall back to the resumed activity when resolving the virtual display ID.

Enhancements:
- Retain WM-based display resolution detection as a fallback when input viewport data is unavailable or cannot be parsed.

</details>

</details>