### PR TITLE
docs: pi 2.9 exe_task

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -29,6 +29,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-04-18 | v2.6.0  | Added `resource.hash` resource integrity check field |
 | 2026-05-06 | v2.7.0  | Added the `pretask` field for running custom programs before Controller startup, with support for passing option values as the last argument |
 | 2026-06-30 | v2.8.0  | Added `setting` task settings page UI declaration field; `import` supports importing `global_option` and `setting` fields; added `hotkey` option type |
+| 2026-07-08 | v2.9.0  | Added the `exec_task` field for declaring runnable external program tasks whose scheduling and timing are decided by the Client |
 
 ## `interface.json`
 
@@ -257,26 +258,27 @@ We have designated the version number for the independent release (January 30, 2
   _Optional._ Pre-task configuration to run before Controller startup. It can be a single object or an array of objects. The Client should start these programs in order before creating or connecting the Controller, and wait for each program to finish. If a pre-task fails to start or exits with a non-zero code, the Client should abort the current startup and report the error to the user.  
   The pre-task's CWD is the directory containing interface.json.  
   The same `pretask` field may appear in files loaded through the top-level `import` array; the Client should merge all resulting pre-tasks into one ordered list: first those from the main `interface.json` (a single object counts as one entry), then those from each imported file in the order listed in `import`, appending each file's own `pretask` entries in array order (or the single object, if not an array). Execution order follows that merged list.  
+  The entry field structure (`exec`, `args`, `name`, `label`, `description`, `icon`, `option`) is shared with `exec_task`; only the execution timing differs (see [`exec_task`](#exec_task)).  
 
-  - **exec** `string`  
+  - **exec** `string`
     _Required._ The program to execute. It may be an executable available in the system `PATH`, such as `"python"`.
 
-  - **args** `string[]`  
+  - **args** `string[]`
     _Optional._ Fixed arguments passed to `exec` in order.
 
-  - **name** `string`  
+  - **name** `string`
     _Optional._ A unique identifier for this pre-task. It is recommended to keep it unique within the project so the Client can distinguish entries in configuration files and logs. When `name` is omitted, the Client may fall back to `exec` as the identifier.
 
-  - **label** `string`  
+  - **label** `string`
     _Optional._ Display name shown by the Client in its UI. Supports internationalized strings (starting with `$`). If not set, the Client may fall back to `name` or `exec`.
 
-  - **description** `string`  
+  - **description** `string`
     _Optional._ Detailed description shown by the Client (e.g. tooltip). Supports internationalized strings, file paths, or URLs. The content supports Markdown (same semantics as `task.description`).
 
-  - **icon** `string`  
+  - **icon** `string`
     _Optional._ Icon path displayed by the Client in its UI, relative to the directory containing interface.json. Supports internationalized strings.
 
-  - **option** `string[]`  
+  - **option** `string[]`
     _Optional._ Pre-task configuration options, an array whose elements should correspond to key names in the outer `option` configuration. The Client will prompt the user to make selections for these options.  
     If `option` is set, the Client should serialize the current values of these options as a **single-line compact JSON string**, and automatically append it as the last argument after `args`. If `option` is omitted or empty, this JSON argument is not appended.  
     The JSON object uses option key names as field names, and the value type is the same as `OptionValue` in `preset.task[].option`: `select` / `switch` use a `case.name` string, `checkbox` uses an array of `case.name` strings, and `input` uses an object from input field `name` to string value. Sub-options (`option.option`) activated by the user's selection should also be included under their own option key names; options that do not satisfy the current `controller` / `resource` constraints should not be included.  
@@ -361,6 +363,29 @@ We have designated the version number for the independent release (January 30, 2
   ```
 
   After merge, the Client runs `main_prepare.py` first, then `check_env.py`, before starting the Controller.
+
+- **exec_task** `object | object[]` **💡 v2.9.0**  
+  _Optional._ External program task configuration. It can be a single object or an array of objects. The Client should start these programs at an appropriate time and wait for each program to finish; the exact scheduling and timing is decided by the Client (for example, scheduling them alongside other tasks as selectable, reorderable task items). If a program fails to start or exits with a non-zero code, the Client should abort the current run and report the error to the user.  
+  The program's CWD is the directory containing interface.json.  
+
+  Except for the execution timing and scheduling behavior above, **field definitions, import merge rules, and option serialization semantics are identical to [`pretask`](#pretask)**. Replace `pretask` with `exec_task` when reading those sections.
+
+  **exec_task example:**
+
+  ```jsonc
+  "exec_task": {
+      "exec": "python",
+      "args": [
+          "./scripts/prepare.py",
+          "--prepare"
+      ],
+      "option": [
+          "PrepareConfig"
+      ]
+  }
+  ```
+
+  For complete field descriptions, option argument derivation, multi-entry examples, and `import` split-file examples, see the [`pretask`](#pretask) section.
 
 - **agent** `object | object[]`  
   Agent configuration; it can be a single object or an array of objects, containing information about the subprocess(es) (AgentServer). Supports configuring multiple Agents simultaneously for more complex automation scenarios.  
@@ -675,7 +700,9 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - **hotkeys** `object[]`  
     Used only when `type` is `"hotkey"`. Hotkey configuration, an array of objects defining hotkey fields the user can capture. **💡 v2.8.0**
 
-    The Client should render a hotkey capture control. After the user presses the target key (or key combination), the Client converts it to a virtual key code array based on the **currently selected controller**. The conversion rules match the `list<int>` form of the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) action `key` field and must use the virtual key code table supported by that controller. A single key is also represented as a one-element array (e.g. `[69]`).
+    The Client should render a hotkey capture control. After the user presses the target key (or key combination), the Client stores it as a human-readable shortcut string (e.g. `"E"`, `"Ctrl+A"`). Do **not** store virtual key codes or JSON arrays directly. Combined shortcuts use `+` as the separator; the **last segment is the primary key**, and preceding segments are modifiers in order (e.g. in `Ctrl+Shift+A`, `A` is primary and `Ctrl` / `Shift` are modifiers).
+
+    When generating `pipeline_override`, the Client should map the shortcut string to virtual key codes supported by the **currently selected controller `type`** (e.g. `Win32`, `Adb`, `WlRoots`). The mapping rules must match the key code tables used by actions such as [`ClickKey`](3.1-PipelineProtocol.md#clickkey) and [`KeyDown`](3.1-PipelineProtocol.md#keydown).
 
     - **name** `string`  
       Unique hotkey field identifier, used as the field ID.
@@ -687,12 +714,33 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       Detailed hotkey field description to help users understand the purpose of this shortcut. Supports file paths, URLs, or direct text. Content supports Markdown format. _Optional._ Supports internationalization (starting with `$`).
 
     - **default** `string`  
-      Default value for the hotkey field. _Optional._ Provide a human-readable shortcut string directly (e.g. `"E"`, `"1"`, `"ALT+A"`). Do not use virtual key codes or JSON arrays. The Client uses this to initialize the control display; after the user recaptures a shortcut, output still follows the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) rules as a virtual key code array.
+      Default value for the hotkey field. _Optional._ Provide a human-readable shortcut string directly (e.g. `"E"`, `"1"`, `"Ctrl+A"`). Do not use virtual key codes. The Client uses this to initialize the control display; after the user recaptures a shortcut, the stored value should still be a shortcut string.
 
   - **pipeline_override** `pipeline`  
     Used when the option type is `"input"` or `"hotkey"`, as a substitution template for user-provided values. Supports using `{name}` format in strings to reference input field or hotkey field values. _Optional._
 
-    When the option type is `"hotkey"`, the Client must substitute `{name}` as an **integer array** (consistent with the [`ClickKey`](3.1-PipelineProtocol.md#clickkey) `list<int>` form), not as a string.
+    When the option type is `"hotkey"`, the Client must substitute placeholders with **integers** (virtual key codes), not strings. Supported placeholder forms:
+
+    | Placeholder | Meaning |
+    | --- | --- |
+    | `{name}` | Equivalent to `{name}.primary` |
+    | `{name}.primary` | Primary key in a combined shortcut |
+    | `{name}.modifier1` | First modifier (e.g. `Ctrl`) |
+    | `{name}.modifier2` | Second modifier (e.g. `Alt`, `Shift`) |
+
+    These placeholders are replaced with a **single integer** (virtual key code), suitable for key actions whose `key` field is *int*, for example:
+
+    ```jsonc
+    "pipeline_override": {
+        "__SomeActionKeyDown": {
+            "key": "{UseTool.primary}"
+        }
+    }
+    ```
+
+    > [!NOTE]
+    >
+    > In the Pipeline protocol, [`ClickKey`](3.1-PipelineProtocol.md#clickkey) also accepts `key` as *list<int>* (press multiple keys in one action, e.g. `[17, 65]` for Ctrl+A). `hotkey` placeholders are replaced with a single integer only and do **not** expand into an array automatically. For typical single-key rebinding (e.g. combat keys `E`, `1`, `F1`), `{name}.primary` is sufficient. If an Integrator truly needs a one-shot `ClickKey` array form for a combo, they must design it separately in the pipeline (e.g. hard-code the key code array, or split into multiple `KeyDown`/`KeyUp` nodes).
 
   - **default_case** `string` | `string[]`  
     Default option name. _Optional._
@@ -749,7 +797,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
 
 - **import** `string[]` **💡 v2.2.0**  
   _Optional._ An array of paths to other PI files to import. File paths are relative to the directory containing interface.json.  
-  Supports importing `task`, `option`, `preset` **💡 v2.3.0**, `group` **💡 v2.4.0**, `pretask` **💡 v2.7.0**, `global_option`, and `setting` **💡 v2.8.0** fields from these files.  
+  Supports importing `task`, `option`, `preset` **💡 v2.3.0**, `group` **💡 v2.4.0**, `pretask` **💡 v2.7.0**, `global_option`, and `setting` **💡 v2.8.0**, `exec_task` **💡 v2.9.0** fields from these files.  
   The Client will load these files sequentially and merge their contents with the current file, enabling configuration splitting and reuse.
 
   **Merge rules:**
@@ -887,7 +935,7 @@ In other words: `task.option` > `controller.option` > `resource.option` > `globa
 
 Before applying the merge order above, inactive options must be filtered out. Any option that does not satisfy the current `controller` / `resource` constraints (including options referenced by `global_option`, `resource.option`, `controller.option`, `task.option`, and nested `option.option`) must not generate `pipeline_override`. **💡 v2.3.1**
 
-`pretask.option` does not participate in the override order above; it only serializes the current option values as the last argument for the pre-task process. **💡 v2.7.0**
+`pretask.option` and `exec_task.option` do not participate in the override order above; they only serialize current option values as the last argument for the corresponding external program process. **💡 v2.7.0 / v2.9.0**
 
 The reasoning behind this design is that more specific configuration (task-level) should have higher priority, while more general configuration (global-level) serves as the fallback default.
 

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -29,6 +29,7 @@
 | 2026-4-18 | v2.6.0 | 新增 `resource.hash` 资源完整性校验字段 |
 | 2026-5-6 | v2.7.0 | 新增 `pretask` 字段，用于在 Controller 启动前执行自定义程序，并支持将 option 取值作为最后一个参数传入 |
 | 2026-6-30 | v2.8.0 | 新增 `setting` 任务设置页 UI 声明字段；`import` 支持导入 `global_option` 与 `setting` 字段；新增 `hotkey` 配置项类型 |
+| 2026-7-8 | v2.9.0 | 新增 `exec_task` 字段，用于声明可执行的外部程序任务，其调度与执行时机由 Client 决定 |
 
 ## `interface.json`
 
@@ -258,6 +259,7 @@
   可选。Controller 启动前执行的预任务配置，可以是单个对象或对象数组。Client 应在创建或连接 Controller 前按顺序启动这些程序，并等待其执行结束。若预任务启动失败或返回非零退出码，Client 应中止本次启动并向用户报告错误。  
   预任务的 CWD 为 interface.json 所在目录。  
   同一 `pretask` 字段也可出现在由顶层 `import` 加载的其他 PI 片段文件中；Client 应将各处的预任务合并为一条有序列表：先执行主 `interface.json` 中的条目（单个对象视为一项），再按 `import` 数组顺序依次追加各被引用文件中的 `pretask`（若为数组则按数组顺序；若为单个对象则视为一项）。实际执行顺序与该合并后的列表一致。  
+  条目字段结构（`exec`、`args`、`name`、`label`、`description`、`icon`、`option`）与 `exec_task` 相同，区别仅在于执行时机（见 [`exec_task`](#exec_task) 节）。  
 
   - exec `string`  
     必须。要执行的程序路径，可以是系统 `PATH` 中的可执行文件，例如 `"python"`。
@@ -362,6 +364,29 @@
   ```
 
   合并后，Client 应先执行 `main_prepare.py`，再执行 `check_env.py`，然后再启动 Controller。
+
+- exec_task `object | object[]` **💡 v2.9.0**  
+  可选。外部程序任务配置，可以是单个对象或对象数组。Client 应在合适的时机启动这些程序并等待其执行结束；具体的调度与执行时机由 Client 决定（例如作为可勾选、可排序的任务项与其他任务一同调度）。若程序启动失败或返回非零退出码，Client 应中止本次执行并向用户报告错误。  
+  程序的 CWD 为 interface.json 所在目录。  
+
+  除上述执行时机与调度方式外，**字段定义、import 合并规则、`option` 参数序列化语义与 [`pretask`](#pretask) 完全一致**。阅读时将 pretask 文档中的 `pretask` 替换为 `exec_task` 即可。
+
+  **exec_task 示例：**
+
+  ```jsonc
+  "exec_task": {
+      "exec": "python",
+      "args": [
+          "./scripts/prepare.py",
+          "--prepare"
+      ],
+      "option": [
+          "运行前配置"
+      ]
+  }
+  ```
+
+  完整字段说明、`option` 传参推导、多条目与 `import` 分文件示例见 [`pretask`](#pretask) 节。
 
 - agent `object | object[]`  
   代理配置，可以是单个对象或对象数组，含有子进程（AgentServer）的信息。支持同时配置多个 Agent 以实现更复杂的自动化场景。  
@@ -673,7 +698,9 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - hotkeys `object[]`  
     仅在 `type` 为 `"hotkey"` 时使用。快捷键配置，为一个对象数组，定义用户可捕获的快捷键字段。 **💡 v2.8.0**
 
-    Client 应渲染快捷键捕获控件；用户按下目标键（或组合键）后，Client 根据**当前所选控制器**将其转换为虚拟按键码数组。转换规则与 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 动作 `key` 字段的 `list<int>` 形式一致，取值范围为该控制器支持的虚拟按键码表。单键亦以单元素数组表示（如 `[69]`）。
+    Client 应渲染快捷键捕获控件。用户按下目标键（或组合键）后，Client 将其保存为人类可读的快捷键字符串（如 `"E"`、`"Ctrl+A"`），**不应**直接保存虚拟按键码或 JSON 数组。组合键以 `+` 连接，**末段为主键**，前段依次为修饰键（如 `Ctrl+Shift+A` 中 `A` 为主键，`Ctrl`、`Shift` 为修饰键）。
+
+    在生成 `pipeline_override` 时，Client 应依据**当前所选控制器的 `type`**（如 `Win32`、`Adb`、`WlRoots`），将快捷键字符串映射为该控制器支持的虚拟按键码。映射规则应与 [`ClickKey`](3.1-任务流水线协议.md#clickkey)、[`KeyDown`](3.1-任务流水线协议.md#keydown) 等动作所用键码表一致。
 
     - name `string`  
       快捷键字段唯一标识符，用作字段 ID。
@@ -685,12 +712,33 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       快捷键字段详细描述信息，帮助用户理解该快捷键的用途。支持文件路径、URL 或直接文本，内容支持 Markdown 格式。可选。支持国际化（以`$`开头）。
 
     - default `string`  
-      快捷键字段的默认值。可选。直接填写人类可读的快捷键字符串（如 `"E"`、`"1"`、`"ALT+A"`），无需填写虚拟按键码或 JSON 数组。Client 据此初始化控件展示；用户重新捕获后，仍按 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 规则输出虚拟按键码数组。
+      快捷键字段的默认值。可选。直接填写人类可读的快捷键字符串（如 `"E"`、`"1"`、`"Ctrl+A"`），无需填写虚拟按键码。Client 据此初始化控件展示；用户重新捕获后，保存的仍应为快捷键字符串。
 
   - pipeline_override `pipeline`  
     当配置项为 `"input"` 或 `"hotkey"` 类型时使用，作为用户输入内容的替换模板。支持在字符串中使用 `{名称}` 格式引用输入字段或快捷键字段的值。可选。
 
-    当配置项为 `"hotkey"` 类型时，Client 在替换 `{名称}` 时应将其转换为 **整数数组**（与 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `list<int>` 形式一致），而非字符串。
+    当配置项为 `"hotkey"` 类型时，Client 在替换占位符时应输出**整数**（虚拟按键码），而非字符串。支持的占位符形式：
+
+    | 占位符 | 含义 |
+    | --- | --- |
+    | `{名称}` | 等价于 `{名称}.primary` |
+    | `{名称}.primary` | 组合键中的主键 |
+    | `{名称}.modifier1` | 第 1 个修饰键（如 `Ctrl`） |
+    | `{名称}.modifier2` | 第 2 个修饰键（如 `Alt`、`Shift`） |
+
+    上述占位符的替换结果为**单个整数**（虚拟按键码），适用于 `key` 为 *int* 的按键动作，例如：
+
+    ```jsonc
+    "pipeline_override": {
+        "__SomeActionKeyDown": {
+            "key": "{UseTool.primary}"
+        }
+    }
+    ```
+
+    > [!NOTE]
+    >
+    > Pipeline 协议中 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `key` 字段还支持 *list<int>*（一次动作依次按下多个键，如 `[17, 65]` 表示 Ctrl+A）。`hotkey` 占位符**仅**替换为单个整数，不会自动展开为数组。一般单键改绑（如战斗技能 `E`、`1`、`F1`）使用 `{名称}.primary` 即可；若确需组合键的一次性 `ClickKey` 数组形式，Integrator 需在 pipeline 中另行设计（例如直接写键码数组，或拆成多个 `KeyDown`/`KeyUp` 节点）。
 
   - default_case `string` | `string[]`  
     默认选项名称。可选。
@@ -747,7 +795,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
 
 - import `string[]` **💡 v2.2.0**  
     可选。导入其他 PI 文件的路径数组。文件相对路径为 interface.json 同目录下的相对路径。  
-    支持导入这些文件中的 `task`、`option`、`preset` **💡 v2.3.0**、`group` **💡 v2.4.0**、`pretask` **💡 v2.7.0**、`global_option` 与 `setting` **💡 v2.8.0** 字段。  
+    支持导入这些文件中的 `task`、`option`、`preset` **💡 v2.3.0**、`group` **💡 v2.4.0**、`pretask` **💡 v2.7.0**、`global_option` 与 `setting` **💡 v2.8.0**、`exec_task` **💡 v2.9.0** 字段。  
     Client 会依次加载这些文件，并将它们的内容与当前文件进行合并，从而实现配置的拆分和复用。
 
     **合并规则：**
@@ -885,7 +933,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
 
 在进入上述合并顺序前，需先过滤“未激活”的 option。任何不满足当前 `controller` / `resource` 条件的 option（包括来自 `global_option`、`resource.option`、`controller.option`、`task.option` 以及嵌套 `option.option`）都不得产生 `pipeline_override`。 **💡 v2.3.1**
 
-`pretask.option` 不参与上述覆盖顺序；它只会将 option 的当前取值序列化为预任务进程的最后一个参数。 **💡 v2.7.0**
+`pretask.option` 与 `exec_task.option` 均不参与上述覆盖顺序；仅将 option 当前取值序列化为对应外部程序进程的最后一个参数。 **💡 v2.7.0 / v2.9.0**
 
 这样设计的理由是：越具体的配置（任务级）应当具有越高的优先级，越通用的配置（全局级）则作为兜底默认值。
 

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -264,7 +264,7 @@
                         "hotkeys": {
                             "type": "array",
                             "title": "快捷键配置",
-                            "description": "定义用户可捕获的快捷键字段；输出为 ClickKey 可用的虚拟按键码",
+                            "description": "定义用户可捕获的快捷键字段；持久化值为人类可读字符串，pipeline_override 替换时映射为虚拟按键码整数",
                             "items": {
                                 "$ref": "#/definitions/hotkeyItem"
                             }
@@ -272,7 +272,7 @@
                         "pipeline_override": {
                             "$ref": "#/definitions/pipelineOverride",
                             "title": "Pipeline 覆盖模板",
-                            "description": "支持使用 {名称} 格式引用快捷键字段的值，替换结果应为整数数组"
+                            "description": "支持使用 {名称}、{名称}.primary、{名称}.modifier1 等占位符引用快捷键字段，替换结果为整数（虚拟按键码）"
                         }
                     },
                     "required": [
@@ -1023,6 +1023,58 @@
             ],
             "additionalProperties": false
         },
+        "execTaskConfig": {
+            "type": "object",
+            "title": "外部程序任务配置",
+            "description": "💡 v2.9.0 可执行的外部程序任务配置。Client 应在合适的时机运行该程序，执行时机由 Client 决定（例如作为可勾选、可排序的任务项调度）；若配置 option，则将 option 取值序列化为紧凑 JSON 字符串并追加为最后一个参数",
+            "properties": {
+                "exec": {
+                    "type": "string",
+                    "title": "程序路径",
+                    "description": "要执行的程序路径，可以是系统 PATH 中的可执行文件。CWD 为 interface.json 所在目录"
+                },
+                "args": {
+                    "type": "array",
+                    "title": "程序参数",
+                    "description": "可选。固定参数数组，按顺序传递给 exec",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "title": "唯一标识",
+                    "description": "可选。建议项目内不重复，便于 Client 在配置文件、日志中区分不同外部程序任务；缺省时 Client 可回退到 exec"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "可选。Client UI 中展示的名称，支持国际化字符串。缺省时 Client 可回退到 name 或 exec"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "可选。Client UI 中的提示/Tooltip。支持国际化字符串、文件路径或 URL，内容支持 Markdown"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "图标路径",
+                    "description": "可选。Client UI 中显示的图标路径，相对于 interface.json 所在目录，支持国际化字符串"
+                },
+                "option": {
+                    "type": "array",
+                    "title": "选项配置",
+                    "description": "可选。数组元素应与外层 option 配置中的键名对应。Client 会收集这些 option 的当前取值并序列化为紧凑 JSON 字符串，追加为最后一个参数；该 option 不参与 pipeline_override 合并",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "exec"
+            ],
+            "additionalProperties": false
+        },
         "agentConfig": {
             "type": "object",
             "title": "代理配置",
@@ -1175,6 +1227,22 @@
                 }
             ]
         },
+        "exec_task": {
+            "description": "💡 v2.9.0 可选。可执行的外部程序任务配置。执行时机由 Client 决定；若配置 option，Client 应将 option 取值序列化为最后一个参数",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/execTaskConfig"
+                },
+                {
+                    "type": "array",
+                    "title": "外部程序任务配置数组",
+                    "description": "多个外部程序任务配置，Client 按数组顺序合并为有序列表",
+                    "items": {
+                        "$ref": "#/definitions/execTaskConfig"
+                    }
+                }
+            ]
+        },
         "agent": {
             "description": "💡 v2.5.0：启动各子进程时 Client 应注入 PI_* 环境变量，详见 Project Interface 文档",
             "oneOf": [
@@ -1226,7 +1294,7 @@
         "import": {
             "type": "array",
             "title": "导入其他 PI 文件",
-            "description": "可选。导入其他 PI 文件的路径数组。文件相对路径为 interface.json 同目录下的相对路径。支持导入这些文件中的 task、option、preset（💡 v2.3.0）、group（💡 v2.4.0）、pretask（💡 v2.7.0）、global_option 与 setting（💡 v2.8.0）字段",
+            "description": "可选。导入其他 PI 文件的路径数组。文件相对路径为 interface.json 同目录下的相对路径。支持导入这些文件中的 task、option、preset（💡 v2.3.0）、group（💡 v2.4.0）、pretask（💡 v2.7.0）、global_option 与 setting（💡 v2.8.0）、exec_task（💡 v2.9.0）字段",
             "items": {
                 "type": "string"
             }


### PR DESCRIPTION
背景：
需要在游戏关闭后运行一些自定义任务
实现方式：
和pretask差不多，pretask是在连接窗口前执行
exe_task是在任意时间执行，有点不一样

有点怪，想不到什么更好的方案
## Summary by Sourcery

在 Project Interface v2 规范中，为新的 `exec_task` 外部程序任务配置编写文档，并优化快捷键处理行为。

新功能：
- 引入 `exec_task` 字段，用于声明由客户端控制执行时机的外部程序任务，并支持从拆分的 PI 文件中导入这些定义。

增强：
- 统一 `pretask` 和 `exec_task` 字段结构，并澄清它们的选项值仅会被序列化为参数，不会影响 pipeline override 的优先级。
- 调整快捷键选项行为，使快捷键值以人类可读的字符串形式存储，并明确客户端在生成 `pipeline_override` 时应如何将其映射为虚拟键码。
- 详细说明 `pipeline_override` 中快捷键占位符的替换规则，包括如何将主键和修饰键提取为单个整数虚拟键码。

文档：
- 在 Project Interface v2 文档中新增 `exec_task` 的版本历史条目和使用示例。
- 澄清导入合并规则以包含 `exec_task`，并引用 `pretask` 文档以说明共享字段语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the new exec_task external program task configuration and refine hotkey handling behavior in the Project Interface v2 specification.

New Features:
- Introduce the exec_task field for declaring external program tasks whose execution timing is controlled by the Client and support importing these definitions from split PI files.

Enhancements:
- Align pretask and exec_task field structures and clarify that their option values are only serialized as arguments and do not affect pipeline override precedence.
- Revise hotkey option behavior so shortcut values are stored as human-readable strings and clarify how Clients should map them to virtual key codes when generating pipeline_override.
- Detail pipeline_override substitution rules for hotkey placeholders, including primary and modifier key extraction as single integer virtual key codes.

Documentation:
- Add version history entry and example usage for exec_task in the Project Interface v2 documentation.
- Clarify import merge rules to include exec_task and reference pretask documentation for shared field semantics.

</details>