### PR TITLE
docs: PI v2.8.1 pretask 支持 controller/resource 过滤

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -29,6 +29,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-04-18 | v2.6.0  | Added `resource.hash` resource integrity check field |
 | 2026-05-06 | v2.7.0  | Added the `pretask` field for running custom programs before Controller startup, with support for passing option values as the last argument |
 | 2026-06-30 | v2.8.0  | Added `setting` task settings page UI declaration field; `import` supports importing `global_option` and `setting` fields; added `hotkey` option type |
+| 2026-07-01 | v2.8.1  | Added `controller` / `resource` filters for `pretask`, with the same semantics as `task.controller` / `task.resource` |
 
 ## `interface.json`
 
@@ -257,6 +258,12 @@ We have designated the version number for the independent release (January 30, 2
   _Optional._ Pre-task configuration to run before Controller startup. It can be a single object or an array of objects. The Client should start these programs in order before creating or connecting the Controller, and wait for each program to finish. If a pre-task fails to start or exits with a non-zero code, the Client should abort the current startup and report the error to the user.  
   The pre-task's CWD is the directory containing interface.json.  
   The same `pretask` field may appear in files loaded through the top-level `import` array; the Client should merge all resulting pre-tasks into one ordered list: first those from the main `interface.json` (a single object counts as one entry), then those from each imported file in the order listed in `import`, appending each file's own `pretask` entries in array order (or the single object, if not an array). Execution order follows that merged list.  
+
+  - **resource** `string[]` **💡 v2.8.1**  
+    _Optional._ List of supported resources for this pre-task. Each element should match a `name` in the top-level `resource` array. If omitted, the pre-task is available for all resources. The Client may hide it or show it as unavailable (disabled/greyed out) when the current resource is not supported.
+
+  - **controller** `string[]` **💡 v2.8.1**  
+    _Optional._ List of supported controllers for this pre-task. Each element should match a `name` in the top-level `controller` array. If omitted, the pre-task is available for all controllers. The Client may hide it or show it as unavailable (disabled/greyed out) when the current controller is not supported.
 
   - **exec** `string`  
     _Required._ The program to execute. It may be an executable available in the system `PATH`, such as `"python"`.

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -29,6 +29,7 @@
 | 2026-4-18 | v2.6.0 | 新增 `resource.hash` 资源完整性校验字段 |
 | 2026-5-6 | v2.7.0 | 新增 `pretask` 字段，用于在 Controller 启动前执行自定义程序，并支持将 option 取值作为最后一个参数传入 |
 | 2026-6-30 | v2.8.0 | 新增 `setting` 任务设置页 UI 声明字段；`import` 支持导入 `global_option` 与 `setting` 字段；新增 `hotkey` 配置项类型 |
+| 2026-7-1 | v2.8.1 | `pretask` 支持 `controller` / `resource` 过滤字段，与 `task.controller` / `task.resource` 语义一致 |
 
 ## `interface.json`
 
@@ -258,6 +259,12 @@
   可选。Controller 启动前执行的预任务配置，可以是单个对象或对象数组。Client 应在创建或连接 Controller 前按顺序启动这些程序，并等待其执行结束。若预任务启动失败或返回非零退出码，Client 应中止本次启动并向用户报告错误。  
   预任务的 CWD 为 interface.json 所在目录。  
   同一 `pretask` 字段也可出现在由顶层 `import` 加载的其他 PI 片段文件中；Client 应将各处的预任务合并为一条有序列表：先执行主 `interface.json` 中的条目（单个对象视为一项），再按 `import` 数组顺序依次追加各被引用文件中的 `pretask`（若为数组则按数组顺序；若为单个对象则视为一项）。实际执行顺序与该合并后的列表一致。  
+
+  - resource `string[]` **💡 v2.8.1**  
+    可选。指定该预任务支持的资源包列表。数组元素应与 `resource` 配置中的 `name` 字段对应。若不指定，则表示该预任务在所有资源包中都可用。Client 可将不支持当前资源包的预任务隐藏，或以不可用（灰色/禁用）状态展示以提示用户。
+
+  - controller `string[]` **💡 v2.8.1**  
+    可选。指定该预任务支持的控制器类型列表。数组元素应与 `controller` 配置中的 `name` 字段对应。若不指定，则表示该预任务在所有控制器类型中都可用。Client 可将不支持当前控制器的预任务隐藏，或以不可用（灰色/禁用）状态展示以提示用户。
 
   - exec `string`  
     必须。要执行的程序路径，可以是系统 `PATH` 中的可执行文件，例如 `"python"`。

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -976,6 +976,22 @@
             "title": "预任务配置",
             "description": "💡 v2.7.0 Controller 启动前执行的自定义程序配置。Client 应在创建或连接 Controller 前运行该程序；若配置 option，则将 option 取值序列化为紧凑 JSON 字符串并追加为最后一个参数",
             "properties": {
+                "resource": {
+                    "type": "array",
+                    "title": "支持的资源包",
+                    "description": "💡 v2.8.1 可选。指定该预任务支持的资源包列表。数组元素应与 resource 配置中的 name 字段对应。若不指定，则表示该预任务在所有资源包中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "controller": {
+                    "type": "array",
+                    "title": "支持的控制器",
+                    "description": "💡 v2.8.1 可选。指定该预任务支持的控制器类型列表。数组元素应与 controller 配置中的 name 字段对应。若不指定，则表示该预任务在所有控制器类型中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "exec": {
                     "type": "string",
                     "title": "预任务程序路径",


### PR DESCRIPTION
## Summary by Sourcery

在 Project Interface v2.8.1 中记录预任务（pretask）控制器/资源过滤支持。

增强功能：
- 扩展接口 schema，在预任务条目中加入可选的 `controller` 和 `resource` 过滤器。

文档更新：
- 更新英文和中文的 Project Interface v2 文档，说明 v2.8.1 中预任务的 `controller` 和 `resource` 过滤字段。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document pretask controller/resource filtering support in Project Interface v2.8.1.

Enhancements:
- Extend the interface schema to include optional `controller` and `resource` filters for pretask entries.

Documentation:
- Update English and Chinese Project Interface v2 documentation to describe v2.8.1 pretask `controller` and `resource` filter fields.

</details>