### PR TITLE
fix(AdbDeviceWin32Finder): 适配mumu v6 的 find_mumu_devices 方法

### DIFF
--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -106,10 +106,8 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     {
         std::string index;
         std::string name;
-        std::string adb_host_ip;
-        int adb_port;
 
-        MEO_JSONIZATION(index, name, adb_host_ip, adb_port);
+        MEO_JSONIZATION(index, name);
     };
 
     json::value& jinfo = *jopt;
@@ -134,6 +132,20 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         return { };
     }
 
+    static const std::vector<std::string> mumu_adb_args = { "adb", "--vmindex", "all" };
+    ChildPipeIOStream adb_ios(mumu_mgr_path, mumu_adb_args);
+    std::string adb_output = adb_ios.read();
+    LogDebug << VAR(mumu_mgr_path) << VAR(mumu_adb_args) << VAR(adb_output);
+
+    auto adb_jopt = json::parse(adb_output);
+    if (!adb_jopt || !adb_jopt->is_object()) {
+        LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
+        return {};
+    }
+
+    json::value& jadb = *adb_jopt;
+    bool adb_single = jadb.contains("adb_host");
+
     std::filesystem::path dir;
     if (emulator.name == "MuMuPlayer12 v5") {
         // MuMuPlayer12 v5: C:\Program Files\Netease\MuMuPlayer-12.0\nx_device\12.0\shell\MuMuNxDevice.exe
@@ -146,10 +158,25 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
 
     std::vector<AdbDevice> result;
     for (const MumuInfo& i : info) {
+        std::string adb_host;
+        int adb_port = 0;
+        if (adb_single) {
+            adb_host = jadb.get("adb_host", std::string {});
+            adb_port = jadb.get("adb_port", 0);
+        }
+        else if (jadb.contains(i.index)) {
+            adb_host = jadb[i.index].get("adb_host", std::string {});
+            adb_port = jadb[i.index].get("adb_port", 0);
+        }
+        else {
+            continue;
+        }
+        if (adb_host.empty()) continue;
+
         AdbDevice device;
         device.name = std::format("{}-{}", i.name, emulator.name);
         device.adb_path = emulator.adb_path;
-        device.serial = std::format("{}:{}", i.adb_host_ip, i.adb_port);
+        device.serial = std::format("{}:{}", adb_host, adb_port);
 
         device.screencap_methods = MaaAdbScreencapMethod_EmulatorExtras;
         device.input_methods = MaaAdbInputMethod_Default;

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -144,7 +144,14 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     }
 
     json::value& jadb = *adb_jopt;
-    bool adb_single = jadb.contains("adb_host");
+
+    struct MumuAdbInfo
+    {
+        std::string adb_host;
+        int adb_port;
+
+        MEO_JSONIZATION(adb_host, adb_port);
+    };
 
     std::filesystem::path dir;
     if (emulator.name == "MuMuPlayer12 v5") {
@@ -159,19 +166,20 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     std::vector<AdbDevice> result;
     for (const MumuInfo& i : info) {
         std::string adb_host;
-        int adb_port = 0;
-        if (adb_single) {
-            adb_host = jadb.get("adb_host", std::string {});
-            adb_port = jadb.get("adb_port", 0);
+        int adb_port;
+        if (jadb.is<MumuAdbInfo>()) {
+            auto a = jadb.as<MumuAdbInfo>();
+            adb_host = std::move(a.adb_host);
+            adb_port = a.adb_port;
         }
-        else if (jadb.contains(i.index)) {
-            adb_host = jadb[i.index].get("adb_host", std::string {});
-            adb_port = jadb[i.index].get("adb_port", 0);
+        else if (jadb.contains(i.index) && jadb[i.index].is<MumuAdbInfo>()) {
+            auto a = jadb[i.index].as<MumuAdbInfo>();
+            adb_host = std::move(a.adb_host);
+            adb_port = a.adb_port;
         }
         else {
             continue;
         }
-        if (adb_host.empty()) continue;
 
         AdbDevice device;
         device.name = std::format("{}-{}", i.name, emulator.name);

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -29,21 +29,21 @@ const AdbDeviceFinder::EmulatorConstDataMap& AdbDeviceWin32Finder::get_emulator_
             .adb_candidate_paths = { "nox_adb.exe"_path },
             .adb_common_serials = { "127.0.0.1:62001", "127.0.0.1:59865" } } },
 
-        { "MuMuPlayer6",
+        { "MuMuPlayer v3",
           { .keyword = "NemuPlayer",
             .adb_candidate_paths = { "vmonitor\\bin\\adb_server.exe"_path,
                                      "MuMu\\emulator\\nemu\\vmonitor\\bin\\adb_server.exe"_path,
                                      "adb.exe"_path },
             .adb_common_serials = { "127.0.0.1:7555" } } },
 
-        { "MuMuPlayer12",
+        { "MuMuPlayer v4",
           {
               .keyword = "MuMuPlayer.exe",
               .adb_candidate_paths = { "vmonitor\\bin\\adb_server.exe"_path,
                                        "MuMu\\emulator\\nemu\\vmonitor\\bin\\adb_server.exe"_path,
                                        "adb.exe"_path },
           } },
-        { "MuMuPlayer12 v5",
+        { "MuMuPlayer v5+",
           {
               .keyword = "MuMuNxDevice.exe",
               .adb_candidate_paths = { "..\\..\\..\\nx_main\\adb.exe"_path, "adb.exe"_path },

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -142,10 +142,10 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
 
     json::value jadb;
     {
-        bool need_adb = !jinfo.is<MumuAdbInfo>();
+        bool need_adb = !jinfo.is<MumuAdbInfo>() && !jinfo.contains("adb_host_ip");
         if (need_adb && jinfo.is_object()) {
             for (auto& v : jinfo.as_object() | std::views::values) {
-                if (v.is<MumuAdbInfo>()) {
+                if (v.is<MumuAdbInfo>() || (v.contains("adb_host_ip") && v.contains("adb_port"))) {
                     need_adb = false;
                     break;
                 }
@@ -189,10 +189,25 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
             adb_host = a.adb_host;
             adb_port = a.adb_port;
         }
-        else if (jadb.contains(i.index) && jadb[i.index].is<MumuAdbInfo>()) {
-            auto a = jadb[i.index].as<MumuAdbInfo>();
-            adb_host = a.adb_host;
-            adb_port = a.adb_port;
+        else if (jadb.contains("adb_host_ip")) {
+            adb_host = jadb.get("adb_host_ip", std::string {});
+            adb_port = jadb.get("adb_port", 0);
+        }
+        else if (jadb.contains(i.index)) {
+            auto& v = jadb[i.index];
+            if (v.is<MumuAdbInfo>()) {
+                auto a = v.as<MumuAdbInfo>();
+                adb_host = a.adb_host;
+                adb_port = a.adb_port;
+            }
+            else if (v.contains("adb_host_ip")) {
+                adb_host = v.get("adb_host_ip", std::string {});
+                adb_port = v.get("adb_port", 0);
+            }
+            else {
+                LogDebug << "No adb info for index" << VAR(i.index);
+                continue;
+            }
         }
         else {
             LogDebug << "No adb info for index" << VAR(i.index);

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -107,7 +107,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         std::string index;
         std::string name;
         std::string adb_host_ip;
-        int adb_port;
+        int adb_port = 0; // sentinel for absent JSON field, port 0 is reserved
 
         MEO_JSONIZATION(index, name, MEO_OPT adb_host_ip, MEO_OPT adb_port);
     };
@@ -173,7 +173,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     for (const MumuInfo& i : info) {
         std::string adb_host;
         int adb_port;
-        if (!i.adb_host_ip.empty()) {
+        if (!i.adb_host_ip.empty() && i.adb_port > 0) {
             adb_host = i.adb_host_ip;
             adb_port = i.adb_port;
         }

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -186,12 +186,12 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         int adb_port;
         if (jadb.is<MumuAdbInfo>()) {
             auto a = jadb.as<MumuAdbInfo>();
-            adb_host = std::move(a.adb_host);
+            adb_host = a.adb_host;
             adb_port = a.adb_port;
         }
         else if (jadb.contains(i.index) && jadb[i.index].is<MumuAdbInfo>()) {
             auto a = jadb[i.index].as<MumuAdbInfo>();
-            adb_host = std::move(a.adb_host);
+            adb_host = a.adb_host;
             adb_port = a.adb_port;
         }
         else {

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -195,6 +195,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
             adb_port = a.adb_port;
         }
         else {
+            LogDebug << "No adb info for index" << VAR(i.index);
             continue;
         }
 

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -106,8 +106,10 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     {
         std::string index;
         std::string name;
+        std::string adb_host_ip;
+        int adb_port = 0;
 
-        MEO_JSONIZATION(index, name);
+        MEO_JSONIZATION(index, name, MEO_OPT adb_host_ip, MEO_OPT adb_port);
     };
 
     json::value& jinfo = *jopt;
@@ -129,8 +131,10 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     }
     else {
         LogError << "Invalid MuMuManager info format" << VAR(output);
-        return { };
+        return {};
     }
+
+    bool need_adb = info.empty() || std::ranges::all_of(info, [](const MumuInfo& i) { return i.adb_host_ip.empty(); });
 
     struct MumuAdbInfo
     {
@@ -141,33 +145,18 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     };
 
     json::value jadb;
-    {
-        bool need_adb = !jinfo.is<MumuAdbInfo>() && !jinfo.contains("adb_host_ip");
-        if (need_adb && jinfo.is_object()) {
-            for (auto& v : jinfo.as_object() | std::views::values) {
-                if (v.is<MumuAdbInfo>() || (v.contains("adb_host_ip") && v.contains("adb_port"))) {
-                    need_adb = false;
-                    break;
-                }
-            }
-        }
+    if (need_adb) {
+        static const std::vector<std::string> mumu_adb_args = { "adb", "--vmindex", "all" };
+        ChildPipeIOStream adb_ios(mumu_mgr_path, mumu_adb_args);
+        std::string adb_output = adb_ios.read();
+        LogDebug << VAR(mumu_mgr_path) << VAR(mumu_adb_args) << VAR(adb_output);
 
-        if (need_adb) {
-            static const std::vector<std::string> mumu_adb_args = { "adb", "--vmindex", "all" };
-            ChildPipeIOStream adb_ios(mumu_mgr_path, mumu_adb_args);
-            std::string adb_output = adb_ios.read();
-            LogDebug << VAR(mumu_mgr_path) << VAR(mumu_adb_args) << VAR(adb_output);
-
-            auto adb_jopt = json::parse(adb_output);
-            if (!adb_jopt || !adb_jopt->is_object()) {
-                LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
-                return {};
-            }
-            jadb = std::move(*adb_jopt);
+        auto adb_jopt = json::parse(adb_output);
+        if (!adb_jopt || !adb_jopt->is_object()) {
+            LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
+            return {};
         }
-        else {
-            jadb = jinfo;
-        }
+        jadb = std::move(*adb_jopt);
     }
 
     std::filesystem::path dir;
@@ -184,30 +173,19 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     for (const MumuInfo& i : info) {
         std::string adb_host;
         int adb_port;
-        if (jadb.is<MumuAdbInfo>()) {
+        if (!need_adb) {
+            adb_host = i.adb_host_ip;
+            adb_port = i.adb_port;
+        }
+        else if (jadb.is<MumuAdbInfo>()) {
             auto a = jadb.as<MumuAdbInfo>();
             adb_host = a.adb_host;
             adb_port = a.adb_port;
         }
-        else if (jadb.contains("adb_host_ip")) {
-            adb_host = jadb.get("adb_host_ip", std::string {});
-            adb_port = jadb.get("adb_port", 0);
-        }
-        else if (jadb.contains(i.index)) {
-            auto& v = jadb[i.index];
-            if (v.is<MumuAdbInfo>()) {
-                auto a = v.as<MumuAdbInfo>();
-                adb_host = a.adb_host;
-                adb_port = a.adb_port;
-            }
-            else if (v.contains("adb_host_ip")) {
-                adb_host = v.get("adb_host_ip", std::string {});
-                adb_port = v.get("adb_port", 0);
-            }
-            else {
-                LogDebug << "No adb info for index" << VAR(i.index);
-                continue;
-            }
+        else if (jadb.contains(i.index) && jadb[i.index].is<MumuAdbInfo>()) {
+            auto a = jadb[i.index].as<MumuAdbInfo>();
+            adb_host = a.adb_host;
+            adb_port = a.adb_port;
         }
         else {
             LogDebug << "No adb info for index" << VAR(i.index);

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -132,19 +132,6 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         return { };
     }
 
-    static const std::vector<std::string> mumu_adb_args = { "adb", "--vmindex", "all" };
-    ChildPipeIOStream adb_ios(mumu_mgr_path, mumu_adb_args);
-    std::string adb_output = adb_ios.read();
-    LogDebug << VAR(mumu_mgr_path) << VAR(mumu_adb_args) << VAR(adb_output);
-
-    auto adb_jopt = json::parse(adb_output);
-    if (!adb_jopt || !adb_jopt->is_object()) {
-        LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
-        return {};
-    }
-
-    json::value& jadb = *adb_jopt;
-
     struct MumuAdbInfo
     {
         std::string adb_host;
@@ -152,6 +139,36 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
 
         MEO_JSONIZATION(adb_host, adb_port);
     };
+
+    json::value jadb;
+    {
+        bool need_adb = !jinfo.is<MumuAdbInfo>();
+        if (need_adb && jinfo.is_object()) {
+            for (auto& v : jinfo.as_object() | std::views::values) {
+                if (v.is<MumuAdbInfo>()) {
+                    need_adb = false;
+                    break;
+                }
+            }
+        }
+
+        if (need_adb) {
+            static const std::vector<std::string> mumu_adb_args = { "adb", "--vmindex", "all" };
+            ChildPipeIOStream adb_ios(mumu_mgr_path, mumu_adb_args);
+            std::string adb_output = adb_ios.read();
+            LogDebug << VAR(mumu_mgr_path) << VAR(mumu_adb_args) << VAR(adb_output);
+
+            auto adb_jopt = json::parse(adb_output);
+            if (!adb_jopt || !adb_jopt->is_object()) {
+                LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
+                return {};
+            }
+            jadb = std::move(*adb_jopt);
+        }
+        else {
+            jadb = jinfo;
+        }
+    }
 
     std::filesystem::path dir;
     if (emulator.name == "MuMuPlayer12 v5") {

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -131,7 +131,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     }
     else {
         LogError << "Invalid MuMuManager info format" << VAR(output);
-        return {};
+        return { };
     }
 
     bool need_adb = info.empty() || std::ranges::any_of(info, [](const MumuInfo& i) { return i.adb_host_ip.empty(); });
@@ -154,7 +154,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         auto adb_jopt = json::parse(adb_output);
         if (!adb_jopt || !adb_jopt->is_object()) {
             LogError << "Parse MuMuManager adb failed" << VAR(adb_output);
-            return {};
+            return { };
         }
         jadb = std::move(*adb_jopt);
     }

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -134,7 +134,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         return {};
     }
 
-    bool need_adb = info.empty() || std::ranges::all_of(info, [](const MumuInfo& i) { return i.adb_host_ip.empty(); });
+    bool need_adb = info.empty() || std::ranges::any_of(info, [](const MumuInfo& i) { return i.adb_host_ip.empty(); });
 
     struct MumuAdbInfo
     {
@@ -173,7 +173,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     for (const MumuInfo& i : info) {
         std::string adb_host;
         int adb_port;
-        if (!need_adb) {
+        if (!i.adb_host_ip.empty()) {
             adb_host = i.adb_host_ip;
             adb_port = i.adb_port;
         }

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -107,7 +107,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
         std::string index;
         std::string name;
         std::string adb_host_ip;
-        int adb_port = 0;
+        int adb_port;
 
         MEO_JSONIZATION(index, name, MEO_OPT adb_host_ip, MEO_OPT adb_port);
     };


### PR DESCRIPTION
## Summary by Sourcery

更新 MuMu 模拟器设备发现逻辑，以支持更新的 MuMu v6 adb 配置格式，并在缺失每个虚拟机的 adb 主机/端口信息时进行优雅处理。

新特性：
- 当主要管理器信息中缺少 adb 主机/端口信息时，增加通过 MuMuManager 的 `adb --vmindex all` 命令获取 MuMu 模拟器 adb 主机/端口信息的支持。

错误修复：
- 确保在 MuMu v6 管理器输出中 adb 主机 IP 或端口字段缺失，或结构发生变化时，依然可以正确发现 MuMu 模拟器设备。
- 通过单独校验和解析 adb 元数据，并跳过没有可用 adb 信息的条目，来防止 MuMu 设备发现过程中的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MuMu emulator device discovery to support newer MuMu v6 adb configuration formats and gracefully handle missing per-VM adb host/port information.

New Features:
- Add support for retrieving MuMu emulator adb host/port information via MuMuManager's `adb --vmindex all` command when it is not available in the primary manager info.

Bug Fixes:
- Ensure MuMu emulator devices are correctly discovered when adb host IP or port fields are absent or structured differently in MuMu v6 manager output.
- Prevent failures in MuMu device discovery by validating and parsing adb metadata separately and skipping entries without usable adb information.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 MuMu 模拟器设备发现逻辑，以支持更新的 MuMu v6 adb 配置格式，并在缺失每个虚拟机的 adb 主机/端口信息时进行优雅处理。

新特性：
- 当主要管理器信息中缺少 adb 主机/端口信息时，增加通过 MuMuManager 的 `adb --vmindex all` 命令获取 MuMu 模拟器 adb 主机/端口信息的支持。

错误修复：
- 确保在 MuMu v6 管理器输出中 adb 主机 IP 或端口字段缺失，或结构发生变化时，依然可以正确发现 MuMu 模拟器设备。
- 通过单独校验和解析 adb 元数据，并跳过没有可用 adb 信息的条目，来防止 MuMu 设备发现过程中的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MuMu emulator device discovery to support newer MuMu v6 adb configuration formats and gracefully handle missing per-VM adb host/port information.

New Features:
- Add support for retrieving MuMu emulator adb host/port information via MuMuManager's `adb --vmindex all` command when it is not available in the primary manager info.

Bug Fixes:
- Ensure MuMu emulator devices are correctly discovered when adb host IP or port fields are absent or structured differently in MuMu v6 manager output.
- Prevent failures in MuMu device discovery by validating and parsing adb metadata separately and skipping entries without usable adb information.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 MuMu 模拟器设备发现逻辑，以支持更新的 MuMu v6 adb 配置格式，并在缺失每个虚拟机的 adb 主机/端口信息时进行优雅处理。

新特性：
- 当主要管理器信息中缺少 adb 主机/端口信息时，增加通过 MuMuManager 的 `adb --vmindex all` 命令获取 MuMu 模拟器 adb 主机/端口信息的支持。

错误修复：
- 确保在 MuMu v6 管理器输出中 adb 主机 IP 或端口字段缺失，或结构发生变化时，依然可以正确发现 MuMu 模拟器设备。
- 通过单独校验和解析 adb 元数据，并跳过没有可用 adb 信息的条目，来防止 MuMu 设备发现过程中的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MuMu emulator device discovery to support newer MuMu v6 adb configuration formats and gracefully handle missing per-VM adb host/port information.

New Features:
- Add support for retrieving MuMu emulator adb host/port information via MuMuManager's `adb --vmindex all` command when it is not available in the primary manager info.

Bug Fixes:
- Ensure MuMu emulator devices are correctly discovered when adb host IP or port fields are absent or structured differently in MuMu v6 manager output.
- Prevent failures in MuMu device discovery by validating and parsing adb metadata separately and skipping entries without usable adb information.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新 MuMu 模拟器设备发现逻辑，以支持更新的 MuMu v6 adb 配置格式，并在缺失每个虚拟机的 adb 主机/端口信息时进行优雅处理。

新特性：
- 当主要管理器信息中缺少 adb 主机/端口信息时，增加通过 MuMuManager 的 `adb --vmindex all` 命令获取 MuMu 模拟器 adb 主机/端口信息的支持。

错误修复：
- 确保在 MuMu v6 管理器输出中 adb 主机 IP 或端口字段缺失，或结构发生变化时，依然可以正确发现 MuMu 模拟器设备。
- 通过单独校验和解析 adb 元数据，并跳过没有可用 adb 信息的条目，来防止 MuMu 设备发现过程中的失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update MuMu emulator device discovery to support newer MuMu v6 adb configuration formats and gracefully handle missing per-VM adb host/port information.

New Features:
- Add support for retrieving MuMu emulator adb host/port information via MuMuManager's `adb --vmindex all` command when it is not available in the primary manager info.

Bug Fixes:
- Ensure MuMu emulator devices are correctly discovered when adb host IP or port fields are absent or structured differently in MuMu v6 manager output.
- Prevent failures in MuMu device discovery by validating and parsing adb metadata separately and skipping entries without usable adb information.

</details>

</details>

</details>