### PR TITLE
fix(PipelineTask): Batch OCR 对 AND/OR 组合识别节点触发失效

### DIFF
--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -288,7 +288,7 @@ RecoResult PipelineTask::recognize_list(const cv::Mat& image, const std::vector<
         }
         const auto& pipeline_data = *node_opt;
 
-        if (batch_plan && !batch_triggered && batch_plan->node_names.contains(pipeline_data.name)) {
+        if (batch_plan && !batch_triggered && batch_plan->owner_node_names.contains(pipeline_data.name)) {
             batch_triggered = true;
 
             Recognizer recognizer(tasker_, *context_, image, ocr_cache);
@@ -355,7 +355,11 @@ std::optional<PipelineTask::BatchOCRPlan> PipelineTask::prepare_batch_ocr(const 
             continue;
         }
 
+        const auto old_size = ctx.plan.entries.size();
         collect_ocr_from_reco(ctx, data.name, data.reco_type, data.reco_param);
+        if (ctx.plan.entries.size() > old_size) {
+            ctx.plan.owner_node_names.emplace(data.name);
+        }
     }
 
     if (ctx.plan.entries.size() < 2) {

--- a/source/MaaFramework/Task/PipelineTask.h
+++ b/source/MaaFramework/Task/PipelineTask.h
@@ -37,6 +37,7 @@ private:
     {
         std::string model;
         std::set<std::string> node_names;
+        std::set<std::string> owner_node_names;
         std::vector<BatchOCREntry> entries;
     };
 


### PR DESCRIPTION
## Summary by Sourcery

修复批量 OCR 流水线在处理组合 AND/OR 识别节点时的触发逻辑。

Bug 修复：
- 确保批量 OCR 的触发是基于实际贡献条目的节点，从而恢复 AND/OR 组合识别节点的正确行为。

增强功能：
- 在批量 OCR 计划中跟踪所属节点名称，以便将条目正确关联到其来源的流水线节点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix batch OCR pipeline trigger handling for combined AND/OR recognition nodes.

Bug Fixes:
- Ensure batch OCR is triggered based on the nodes that actually contribute entries, restoring correct behavior for AND/OR combined recognition nodes.

Enhancements:
- Track owner node names in batch OCR plans to correctly associate entries with their originating pipeline nodes.

</details>