### PR TITLE
fix:修复MuMu模拟器搜索和连接错误

### DIFF
--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -66,7 +66,7 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_by_emulator_tool(const Emulato
 {
     LogFunc << VAR(emulator.name);
 
-    if (emulator.name == "MuMuPlayer12" || emulator.name == "MuMuPlayer12 v5") {
+    if (emulator.name == "MuMuPlayer v4" || emulator.name == "MuMuPlayer v5+") {
         return find_mumu_devices(emulator);
     }
     else if (emulator.name == "LDPlayer") {

--- a/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
+++ b/source/MaaToolkit/AdbDevice/AdbDeviceWin32Finder.cpp
@@ -160,12 +160,12 @@ std::vector<AdbDevice> AdbDeviceWin32Finder::find_mumu_devices(const Emulator& e
     }
 
     std::filesystem::path dir;
-    if (emulator.name == "MuMuPlayer12 v5") {
-        // MuMuPlayer12 v5: C:\Program Files\Netease\MuMuPlayer-12.0\nx_device\12.0\shell\MuMuNxDevice.exe
+    if (emulator.name == "MuMuPlayer v5+") {
+        // MuMuPlayer v5+: C:\Program Files\Netease\MuMuPlayer-12.0\nx_device\12.0\shell\MuMuNxDevice.exe
         dir = emulator.process_path.parent_path().parent_path().parent_path().parent_path();
     }
     else {
-        // MuMuPlayer12: C:\Program Files\Netease\MuMuPlayer-12.0\shell\MuMuPlayer.exe
+        // MuMuPlayer v4: C:\Program Files\Netease\MuMuPlayer-12.0\shell\MuMuPlayer.exe
         dir = emulator.process_path.parent_path().parent_path();
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 通过匹配更新后的 v4 和 v5+ 模拟器名称，修复 MuMuPlayer 模拟器的搜索和连接问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix MuMuPlayer emulator search and connection by matching the updated v4 and v5+ emulator names.

</details>