### PR TITLE
fix(MaaPiCli): make task field optional in InterfaceData to support import-only interface.json

### DIFF
--- a/source/MaaPiCli/CLI/interactor.cpp
+++ b/source/MaaPiCli/CLI/interactor.cpp
@@ -1209,6 +1209,8 @@ void Interactor::add_task()
 
     if (all_data_tasks.empty()) {
         LogError << "Task is empty";
+        std::cout << "No tasks available.\n\n";
+        mpause();
         return;
     }
 

--- a/source/include/ProjectInterface/Types.h
+++ b/source/include/ProjectInterface/Types.h
@@ -302,7 +302,7 @@ struct InterfaceData
         MEO_OPT github,
         controller,
         resource,
-        task,
+        MEO_OPT task,
         MEO_OPT option,
         MEO_OPT agent,
         MEO_OPT global_option,


### PR DESCRIPTION
## Summary

When \interface.json\ uses the \import\ field to load tasks from another file, it does not have its own \	ask\ array. The C++ \InterfaceData\ struct's \MEO_JSONIZATION\ macro marked \	ask\ as required (without \MEO_OPT\), causing \check_json()\ to reject the file before the import merge logic could populate tasks from imported files.

## Changes

- **\source/include/ProjectInterface/Types.h\**: Changed \	ask,\ to \MEO_OPT task,\ in \InterfaceData::MEO_JSONIZATION\, making the field optional.

## Context

The JSON Schema (\interface.schema.json\) already listed \	ask\ as optional — the \equired\ array only contains \interface_version\, \
ame\, \controller\, and \esource\. This was a C++ validation mismatch that has now been corrected.

No schema files need changes.

## Summary by Sourcery

放宽对 InterfaceData 的验证，以允许依赖导入且没有任务的 `interface.json` 文件，并增强 CLI 交互器，在无可用任务时提供更清晰的反馈。

Bug Fixes:
- 将 InterfaceData 的 `task` 字段改为可选，以便从其他文件导入任务的 `interface.json` 文件能够正确通过验证。

Enhancements:
- 改进在无可用任务时的 CLI 反馈，通过打印提示信息并在返回前暂停片刻。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax InterfaceData validation to allow task-less interface.json files that rely on imports, and enhance the CLI interactor to provide clearer feedback when no tasks are available.

Bug Fixes:
- Make the InterfaceData task field optional so interface.json files that import tasks from other files validate correctly.

Enhancements:
- Improve CLI feedback when no tasks are available by printing a message and pausing before returning.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

放宽对 InterfaceData 的验证，以允许依赖导入且没有任务的 `interface.json` 文件，并增强 CLI 交互器，在无可用任务时提供更清晰的反馈。

Bug Fixes:
- 将 InterfaceData 的 `task` 字段改为可选，以便从其他文件导入任务的 `interface.json` 文件能够正确通过验证。

Enhancements:
- 改进在无可用任务时的 CLI 反馈，通过打印提示信息并在返回前暂停片刻。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax InterfaceData validation to allow task-less interface.json files that rely on imports, and enhance the CLI interactor to provide clearer feedback when no tasks are available.

Bug Fixes:
- Make the InterfaceData task field optional so interface.json files that import tasks from other files validate correctly.

Enhancements:
- Improve CLI feedback when no tasks are available by printing a message and pausing before returning.

</details>

</details>