### PR TITLE
fix(PipelineTask): 移除 Batch OCR 收集时的名称去重，修复内联子识别缓存冲突

### DIFF
--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -397,9 +397,8 @@ void PipelineTask::try_add_ocr_node(OCRCollectContext& ctx, const std::string& n
         return;
     }
 
-    if (ctx.plan.node_names.emplace(name).second) {
-        ctx.plan.entries.emplace_back(BatchOCREntry { .name = name, .param = param });
-    }
+    ctx.plan.node_names.emplace(name);
+    ctx.plan.entries.emplace_back(BatchOCREntry { .name = name, .param = param });
 }
 
 void PipelineTask::collect_ocr_from_reco(


### PR DESCRIPTION
去重逻辑由 PR #1280 引入，是为防止 pipeline node 与 inline sub 同名时 通过 get_pipeline_data 回查崩溃。但该崩溃已被 #1280 改用直接传参修复，去重本身多余。

移除去重后，同名 entry 的 ROI 在 prefetch_batch_ocr 的 node_rois 中 自然合并，handle_cached() 通过各自的 ROI 过滤保证结果正确，防止内联子识别缓存冲突。

closes: #1384
closes: https://github.com/MaaEnd/MaaEnd/issues/4191

## Summary by Sourcery

Bug Fixes:
- 修复由于批量 OCR 名称去重破坏了 ROI 合并和缓存行为而导致的内联子识别缓存冲突问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix inline sub-recognition cache conflicts caused by Batch OCR name deduplication disrupting ROI merging and caching behavior.

</details>