### PR TITLE
fix(agent): 避免套接字析构无限等待

### DIFF
--- a/source/AgentCommon/Transceiver.cpp
+++ b/source/AgentCommon/Transceiver.cpp
@@ -236,6 +236,11 @@ void Transceiver::uninit_socket()
     //     }
     // }
 
+    // AgentClient owns the bound socket and may be destroyed without a disconnect handshake.
+    if (is_bound_) {
+        zmq_sock_.set(zmq::sockopt::linger, 0);
+    }
+
     zmq_sock_.close();
     zmq_ctx_.close();
 


### PR DESCRIPTION
为 IPC 和 TCP ZeroMQ 套接字设置零 linger，避免直接销毁 AgentClient 时因积压消息长期阻塞。

## Summary by Sourcery

Bug Fixes:
- 确保在销毁 `AgentClient` 时，不会因 IPC 和 TCP 套接字上残留的 ZeroMQ 消息而导致进程挂起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure AgentClient destruction no longer hangs due to lingering ZeroMQ messages on IPC and TCP sockets.

</details>