### PR TITLE
fix(messageinput):touchup在窗口没有变化时不多发送send_activate_message

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -1037,10 +1037,6 @@ bool MessageInput::touch_up(int contact)
 
     OnScopeLeave([this]() { unblock_input(); });
 
-    if (reuse_gesture) {
-        bool use_post = (config_.mode == Mode::PostMessage);
-        ::MaaNS::CtrlUnitNs::send_activate_message(target, use_post);
-    }
 
     MouseMessageInfo msg_info;
     if (!contact_to_mouse_up_message(contact, msg_info)) {


### PR DESCRIPTION
fix #1408 
fix #1328 
检测窗口活跃相关代码已经完整，删去多余send_activate_message
详细内容在 #1408

## Summary by Sourcery

错误修复：
- 当窗口状态未发生变化时，在触摸抬起事件中停止发送不必要的窗口激活消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop dispatching unnecessary window activation messages on touch-up when the window state has not changed.

</details>