### PR TITLE
docs: 修复 ProjectInterface V2 文档构建

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -722,7 +722,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
 
     > [!NOTE]
     >
-    > In the Pipeline protocol, [`ClickKey`](3.1-PipelineProtocol.md#clickkey) also accepts `key` as *list<int>* (press multiple keys in one action, e.g. `[17, 65]` for Ctrl+A). `hotkey` placeholders are replaced with a single integer only and do **not** expand into an array automatically. For typical single-key rebinding (e.g. combat keys `E`, `1`, `F1`), `{name}.primary` is sufficient. If an Integrator truly needs a one-shot `ClickKey` array form for a combo, they must design it separately in the pipeline (e.g. hard-code the key code array, or split into multiple `KeyDown`/`KeyUp` nodes).
+    > In the Pipeline protocol, [`ClickKey`](3.1-PipelineProtocol.md#clickkey) also accepts `key` as `list<int>` (press multiple keys in one action, e.g. `[17, 65]` for Ctrl+A). `hotkey` placeholders are replaced with a single integer only and do **not** expand into an array automatically. For typical single-key rebinding (e.g. combat keys `E`, `1`, `F1`), `{name}.primary` is sufficient. If an Integrator truly needs a one-shot `ClickKey` array form for a combo, they must design it separately in the pipeline (e.g. hard-code the key code array, or split into multiple `KeyDown`/`KeyUp` nodes).
 
   - **default_case** `string` | `string[]`  
     Default option name. _Optional._

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -720,7 +720,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
 
     > [!NOTE]
     >
-    > Pipeline 协议中 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `key` 字段还支持 *list<int>*（一次动作依次按下多个键，如 `[17, 65]` 表示 Ctrl+A）。`hotkey` 占位符**仅**替换为单个整数，不会自动展开为数组。一般单键改绑（如战斗技能 `E`、`1`、`F1`）使用 `{名称}.primary` 即可；若确需组合键的一次性 `ClickKey` 数组形式，Integrator 需在 pipeline 中另行设计（例如直接写键码数组，或拆成多个 `KeyDown`/`KeyUp` 节点）。
+    > Pipeline 协议中 [`ClickKey`](3.1-任务流水线协议.md#clickkey) 的 `key` 字段还支持 `list<int>`（一次动作依次按下多个键，如 `[17, 65]` 表示 Ctrl+A）。`hotkey` 占位符**仅**替换为单个整数，不会自动展开为数组。一般单键改绑（如战斗技能 `E`、`1`、`F1`）使用 `{名称}.primary` 即可；若确需组合键的一次性 `ClickKey` 数组形式，Integrator 需在 pipeline 中另行设计（例如直接写键码数组，或拆成多个 `KeyDown`/`KeyUp` 节点）。
 
   - default_case `string` | `string[]`  
     默认选项名称。可选。


### PR DESCRIPTION
## Summary

- 将中英文 ProjectInterface V2 文档中的 list&lt;int&gt; 类型标记改为行内代码
- 避免 Markdown 强调语法生成嵌套的 int 元素并被 Vue 误解析为未闭合标签
- 修复 MaaFrameworkWebsite Deploy job 的 VitePress 构建失败：https://github.com/MaaXYZ/MaaFrameworkWebsite/actions/runs/29691820364/job/88205793101

## Verification

- 在 MaaFrameworkWebsite 中按 Deploy workflow 同步 MaaFramework 文档
- 修复前 yarn build 可复现 Element is missing end tag
- 修复后 yarn build 完整通过

## Summary by Sourcery

Documentation:
- 更新英文和中文的 ProjectInterface V2 文档，将 `list<int>` 类型从强调文本改为内联代码，以防止在站点生成过程中被错误解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the English and Chinese ProjectInterface V2 docs to mark the list<int> type as inline code instead of emphasized text to prevent mis-parsing during site generation.

</details>