### PR TITLE
fix:修复and识别器中的or识别器提前短路

### DIFF
--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -359,6 +359,177 @@ RecoResult Recognizer::custom_recognize(const MAA_VISION_NS::CustomRecognitionPa
         CustomRecognition(image_, rois.front(), param, resource()->custom_recognition(param.name), context_, name));
 }
 
+std::optional<Recognizer::ResolvedSubRecognition> Recognizer::resolve_sub_recognition(
+    const MAA_RES_NS::Recognition::SubRecognition& sub_reco,
+    std::string_view parent)
+{
+    using namespace MAA_RES_NS::Recognition;
+
+    if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
+        auto node_opt = context_.get_pipeline_data(*node_name);
+        if (!node_opt) {
+            LogError << parent << ": failed to get pipeline data for node" << VAR(*node_name);
+            return std::nullopt;
+        }
+        LogDebug << parent << ": resolve node reference" << VAR(*node_name);
+        return ResolvedSubRecognition {
+            .type = node_opt->reco_type,
+            .param = node_opt->reco_param,
+            .name = *node_name,
+        };
+    }
+
+    const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
+    LogDebug << parent << ": resolve inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
+    return ResolvedSubRecognition {
+        .type = inline_sub.type,
+        .param = inline_sub.param,
+        .name = inline_sub.sub_name,
+    };
+}
+
+RecoResult Recognizer::recognize_sub(const ResolvedSubRecognition& sub_reco)
+{
+    Recognizer sub_recognizer(*this);
+    return sub_recognizer.recognize(sub_reco.type, sub_reco.param, sub_reco.name);
+}
+
+RecoResult Recognizer::build_or_result(
+    const std::string& name,
+    const std::vector<RecoResult>& sub_results,
+    std::optional<cv::Rect> box)
+{
+    std::vector<ImageEncodedBuffer> all_draws;
+    for (const auto& sub : sub_results) {
+        all_draws.insert(all_draws.end(), sub.draws.begin(), sub.draws.end());
+    }
+
+    RecoResult result {
+        .reco_id = generate_reco_id(),
+        .name = name,
+        .algorithm = "Or",
+        .box = std::move(box),
+        .detail = sub_results,
+        .draws = std::move(all_draws),
+    };
+    tasker_->runtime_cache().set_reco_detail(result.reco_id, result);
+    save_draws(name, result);
+    return result;
+}
+
+void Recognizer::inherit_sub_boxes(const std::string& name, const RecoResult& sub_result)
+{
+    auto filtered_it = sub_filtered_boxes_->find(sub_result.name);
+    if (filtered_it != sub_filtered_boxes_->end()) {
+        sub_filtered_boxes_->insert_or_assign(name, filtered_it->second);
+    }
+    else {
+        sub_filtered_boxes_->insert_or_assign(
+            name,
+            sub_result.box ? std::vector<cv::Rect> { *sub_result.box } : std::vector<cv::Rect> { });
+    }
+    sub_best_box_->insert_or_assign(name, sub_result.box.value_or(cv::Rect { }));
+}
+
+bool Recognizer::recognize_and_from(
+    const MAA_RES_NS::Recognition::AndParam& param,
+    size_t index,
+    std::vector<RecoResult>& sub_results)
+{
+    using namespace MAA_RES_NS::Recognition;
+
+    if (index >= param.all_of.size()) {
+        return true;
+    }
+
+    auto resolved = resolve_sub_recognition(param.all_of[index], "And");
+    if (!resolved) {
+        return false;
+    }
+
+    if (resolved->type == Type::Or) {
+        return recognize_or_in_and(
+            std::get<std::shared_ptr<OrParam>>(resolved->param),
+            resolved->name,
+            param,
+            index + 1,
+            sub_results);
+    }
+
+    auto res = recognize_sub(*resolved);
+    register_sub_result_in_cache(res);
+    bool hit = res.box.has_value();
+    sub_results.emplace_back(std::move(res));
+    if (!hit) {
+        LogDebug << "And: sub recognition failed";
+        return false;
+    }
+
+    return recognize_and_from(param, index + 1, sub_results);
+}
+
+bool Recognizer::recognize_or_in_and(
+    const std::shared_ptr<MAA_RES_NS::Recognition::OrParam>& param,
+    const std::string& name,
+    const MAA_RES_NS::Recognition::AndParam& and_param,
+    size_t next_index,
+    std::vector<RecoResult>& sub_results)
+{
+    if (!param) {
+        LogError << "And: nested OrParam is null";
+        return false;
+    }
+
+    const auto filtered_snapshot = *sub_filtered_boxes_;
+    const auto best_snapshot = *sub_best_box_;
+    const size_t result_prefix_size = sub_results.size();
+    std::vector<RecoResult> or_sub_results;
+    std::vector<RecoResult> last_failed_path;
+
+    for (const auto& candidate : param->any_of) {
+        *sub_filtered_boxes_ = filtered_snapshot;
+        *sub_best_box_ = best_snapshot;
+        sub_results.resize(result_prefix_size);
+
+        auto resolved = resolve_sub_recognition(candidate, "And/Or");
+        if (!resolved) {
+            continue;
+        }
+
+        auto candidate_result = recognize_sub(*resolved);
+        register_sub_result_in_cache(candidate_result);
+        bool hit = candidate_result.box.has_value();
+        or_sub_results.emplace_back(std::move(candidate_result));
+        if (!hit) {
+            continue;
+        }
+
+        inherit_sub_boxes(name, or_sub_results.back());
+        auto or_result = build_or_result(name, or_sub_results, or_sub_results.back().box);
+        register_sub_result_in_cache(or_result);
+        sub_results.emplace_back(std::move(or_result));
+
+        if (recognize_and_from(and_param, next_index, sub_results)) {
+            LogDebug << "And: nested Or candidate succeeded";
+            return true;
+        }
+
+        last_failed_path = sub_results;
+        LogDebug << "And: nested Or candidate did not satisfy remaining recognitions";
+    }
+
+    *sub_filtered_boxes_ = filtered_snapshot;
+    *sub_best_box_ = best_snapshot;
+    if (!last_failed_path.empty()) {
+        sub_results = std::move(last_failed_path);
+    }
+    else {
+        sub_results.resize(result_prefix_size);
+        sub_results.emplace_back(build_or_result(name, or_sub_results, std::nullopt));
+    }
+    return false;
+}
+
 RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndParam>& param, const std::string& name)
 {
     using namespace MAA_RES_NS::Recognition;
@@ -371,39 +542,7 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
     LogDebug << "And recognition" << VAR(name) << VAR(param->all_of.size()) << VAR(param->box_index);
 
     std::vector<RecoResult> sub_results;
-    bool all_hit = true;
-
-    for (const auto& sub_reco : param->all_of) {
-        Recognizer sub_recognizer(*this);
-        RecoResult res;
-
-        if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
-            // Resolve node name to get recognition params
-            auto node_opt = context_.get_pipeline_data(*node_name);
-            if (!node_opt) {
-                LogError << "And: failed to get pipeline data for node" << VAR(*node_name);
-                all_hit = false;
-                break;
-            }
-            LogDebug << "And: run node reference" << VAR(*node_name);
-            res = sub_recognizer.recognize(node_opt->reco_type, node_opt->reco_param, *node_name);
-        }
-        else {
-            const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
-            LogDebug << "And: run inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
-            res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
-        }
-
-        register_sub_result_in_cache(res);
-
-        all_hit &= res.box.has_value();
-        sub_results.emplace_back(std::move(res));
-
-        if (!all_hit) {
-            LogDebug << "And: sub recognition failed";
-            break;
-        }
-    }
+    bool all_hit = recognize_and_from(*param, 0, sub_results);
 
     std::vector<ImageEncodedBuffer> all_draws;
     for (auto& sub : sub_results) {
@@ -459,24 +598,11 @@ RecoResult Recognizer::or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrPara
     bool has_hit = false;
 
     for (const auto& sub_reco : param->any_of) {
-        Recognizer sub_recognizer(*this);
-        RecoResult res;
-
-        if (auto* node_name = std::get_if<std::string>(&sub_reco)) {
-            // Resolve node name to get recognition params
-            auto node_opt = context_.get_pipeline_data(*node_name);
-            if (!node_opt) {
-                LogError << "Or: failed to get pipeline data for node" << VAR(*node_name);
-                continue;
-            }
-            LogDebug << "Or: run node reference" << VAR(*node_name);
-            res = sub_recognizer.recognize(node_opt->reco_type, node_opt->reco_param, *node_name);
+        auto resolved = resolve_sub_recognition(sub_reco, "Or");
+        if (!resolved) {
+            continue;
         }
-        else {
-            const auto& inline_sub = std::get<InlineSubRecognition>(sub_reco);
-            LogDebug << "Or: run inline sub recognition" << VAR(inline_sub.type) << VAR(inline_sub.sub_name);
-            res = sub_recognizer.recognize(inline_sub.type, inline_sub.param, inline_sub.sub_name);
-        }
+        auto res = recognize_sub(*resolved);
 
         has_hit = res.box.has_value();
         register_sub_result_in_cache(res);
@@ -516,10 +642,7 @@ RecoResult Recognizer::or_(const std::shared_ptr<MAA_RES_NS::Recognition::OrPara
 
     result.box = std::move(sub_results.back().box);
 
-    cv::Rect final_box = result.box.value_or(cv::Rect { });
-    // 按理说这里要从 sub 取的，但是太麻烦而且是 corner case，先不管了，后面有需要再加
-    sub_filtered_boxes_->insert_or_assign(name, std::vector<cv::Rect> { final_box });
-    sub_best_box_->insert_or_assign(name, final_box);
+    inherit_sub_boxes(name, sub_results.back());
 
     return result;
 }

--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -434,7 +434,8 @@ void Recognizer::inherit_sub_boxes(const std::string& name, const RecoResult& su
 bool Recognizer::recognize_and_from(
     const MAA_RES_NS::Recognition::AndParam& param,
     size_t index,
-    std::vector<RecoResult>& sub_results)
+    std::vector<RecoResult>& sub_results,
+    PendingSubRegistry& pending_regs)
 {
     using namespace MAA_RES_NS::Recognition;
 
@@ -453,19 +454,22 @@ bool Recognizer::recognize_and_from(
             resolved->name,
             param,
             index + 1,
-            sub_results);
+            sub_results,
+            pending_regs);
     }
 
     auto res = recognize_sub(*resolved);
-    register_sub_result_in_cache(res);
     bool hit = res.box.has_value();
+    if (hit && !res.name.empty()) {
+        pending_regs.emplace_back(res.name, res.reco_id);
+    }
     sub_results.emplace_back(std::move(res));
     if (!hit) {
         LogDebug << "And: sub recognition failed";
         return false;
     }
 
-    return recognize_and_from(param, index + 1, sub_results);
+    return recognize_and_from(param, index + 1, sub_results, pending_regs);
 }
 
 bool Recognizer::recognize_or_in_and(
@@ -473,7 +477,8 @@ bool Recognizer::recognize_or_in_and(
     const std::string& name,
     const MAA_RES_NS::Recognition::AndParam& and_param,
     size_t next_index,
-    std::vector<RecoResult>& sub_results)
+    std::vector<RecoResult>& sub_results,
+    PendingSubRegistry& pending_regs)
 {
     if (!param) {
         LogError << "And: nested OrParam is null";
@@ -483,6 +488,7 @@ bool Recognizer::recognize_or_in_and(
     const auto filtered_snapshot = *sub_filtered_boxes_;
     const auto best_snapshot = *sub_best_box_;
     const size_t result_prefix_size = sub_results.size();
+    const size_t pending_prefix_size = pending_regs.size();
     std::vector<RecoResult> or_sub_results;
     std::vector<RecoResult> last_failed_path;
 
@@ -490,6 +496,7 @@ bool Recognizer::recognize_or_in_and(
         *sub_filtered_boxes_ = filtered_snapshot;
         *sub_best_box_ = best_snapshot;
         sub_results.resize(result_prefix_size);
+        pending_regs.resize(pending_prefix_size);
 
         auto resolved = resolve_sub_recognition(candidate, "And/Or");
         if (!resolved) {
@@ -497,8 +504,10 @@ bool Recognizer::recognize_or_in_and(
         }
 
         auto candidate_result = recognize_sub(*resolved);
-        register_sub_result_in_cache(candidate_result);
         bool hit = candidate_result.box.has_value();
+        if (hit && !candidate_result.name.empty()) {
+            pending_regs.emplace_back(candidate_result.name, candidate_result.reco_id);
+        }
         or_sub_results.emplace_back(std::move(candidate_result));
         if (!hit) {
             continue;
@@ -506,10 +515,12 @@ bool Recognizer::recognize_or_in_and(
 
         inherit_sub_boxes(name, or_sub_results.back());
         auto or_result = build_or_result(name, or_sub_results, or_sub_results.back().box);
-        register_sub_result_in_cache(or_result);
+        if (!name.empty()) {
+            pending_regs.emplace_back(name, or_result.reco_id);
+        }
         sub_results.emplace_back(std::move(or_result));
 
-        if (recognize_and_from(and_param, next_index, sub_results)) {
+        if (recognize_and_from(and_param, next_index, sub_results, pending_regs)) {
             LogDebug << "And: nested Or candidate succeeded";
             return true;
         }
@@ -520,6 +531,7 @@ bool Recognizer::recognize_or_in_and(
 
     *sub_filtered_boxes_ = filtered_snapshot;
     *sub_best_box_ = best_snapshot;
+    pending_regs.resize(pending_prefix_size);
     if (!last_failed_path.empty()) {
         sub_results = std::move(last_failed_path);
     }
@@ -542,7 +554,15 @@ RecoResult Recognizer::and_(const std::shared_ptr<MAA_RES_NS::Recognition::AndPa
     LogDebug << "And recognition" << VAR(name) << VAR(param->all_of.size()) << VAR(param->box_index);
 
     std::vector<RecoResult> sub_results;
-    bool all_hit = recognize_and_from(*param, 0, sub_results);
+    PendingSubRegistry pending_regs;
+    bool all_hit = recognize_and_from(*param, 0, sub_results, pending_regs);
+
+    // 推迟到整条 And 路径确认成功后再注册，避免回溯放弃的分支污染 runtime cache
+    if (all_hit) {
+        for (const auto& [sub_name, sub_reco_id] : pending_regs) {
+            register_sub_result_in_cache(sub_name, sub_reco_id);
+        }
+    }
 
     std::vector<ImageEncodedBuffer> all_draws;
     for (auto& sub : sub_results) {
@@ -743,10 +763,19 @@ void Recognizer::register_sub_result_in_cache(const RecoResult& res)
         return;
     }
 
+    register_sub_result_in_cache(res.name, res.reco_id);
+}
+
+void Recognizer::register_sub_result_in_cache(const std::string& name, MaaRecoId reco_id)
+{
+    if (name.empty() || reco_id == MaaInvalidId) {
+        return;
+    }
+
     auto& cache = tasker_->runtime_cache();
     auto sub_node_id = TaskBase::generate_node_id();
-    cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = res.name, .reco_id = res.reco_id, .completed = true });
-    cache.set_latest_node(res.name, sub_node_id);
+    cache.set_node_detail(sub_node_id, NodeDetail { .node_id = sub_node_id, .name = name, .reco_id = reco_id, .completed = true });
+    cache.set_latest_node(name, sub_node_id);
 }
 
 bool Recognizer::debug_mode() const

--- a/source/MaaFramework/Task/Component/Recognizer.h
+++ b/source/MaaFramework/Task/Component/Recognizer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <string_view>
 #include <meojson/json.hpp>
 
 #include "Common/Conf.h"
@@ -30,6 +31,13 @@ public:
     MaaRecoId get_id() const { return reco_id_; }
 
 private:
+    struct ResolvedSubRecognition
+    {
+        MAA_RES_NS::Recognition::Type type;
+        MAA_RES_NS::Recognition::Param param;
+        std::string name;
+    };
+
     RecoResult direct_hit(const MAA_VISION_NS::DirectHitParam& param, const std::string& name);
     RecoResult template_match(const MAA_VISION_NS::TemplateMatcherParam& param, const std::string& name);
     RecoResult feature_match(const MAA_VISION_NS::FeatureMatcherParam& param, const std::string& name);
@@ -43,6 +51,23 @@ private:
 
     template <typename Analyzer>
     RecoResult build_result(const std::string& name, const std::string& algorithm, Analyzer&& analyzer);
+
+    std::optional<ResolvedSubRecognition> resolve_sub_recognition(
+        const MAA_RES_NS::Recognition::SubRecognition& sub_reco,
+        std::string_view parent);
+    RecoResult recognize_sub(const ResolvedSubRecognition& sub_reco);
+    bool recognize_and_from(
+        const MAA_RES_NS::Recognition::AndParam& param,
+        size_t index,
+        std::vector<RecoResult>& sub_results);
+    bool recognize_or_in_and(
+        const std::shared_ptr<MAA_RES_NS::Recognition::OrParam>& param,
+        const std::string& name,
+        const MAA_RES_NS::Recognition::AndParam& and_param,
+        size_t next_index,
+        std::vector<RecoResult>& sub_results);
+    RecoResult build_or_result(const std::string& name, const std::vector<RecoResult>& sub_results, std::optional<cv::Rect> box);
+    void inherit_sub_boxes(const std::string& name, const RecoResult& sub_result);
 
     std::vector<cv::Rect> get_rois(const MAA_VISION_NS::Target& roi, bool use_best = false);
     std::vector<cv::Rect> get_rois_from_pretask(const std::string& name, bool use_best);

--- a/source/MaaFramework/Task/Component/Recognizer.h
+++ b/source/MaaFramework/Task/Component/Recognizer.h
@@ -38,6 +38,9 @@ private:
         std::string name;
     };
 
+    // 回溯期间暂存的子识别注册项（name + reco_id），整条 And 路径确认成功后再统一写入 runtime cache
+    using PendingSubRegistry = std::vector<std::pair<std::string, MaaRecoId>>;
+
     RecoResult direct_hit(const MAA_VISION_NS::DirectHitParam& param, const std::string& name);
     RecoResult template_match(const MAA_VISION_NS::TemplateMatcherParam& param, const std::string& name);
     RecoResult feature_match(const MAA_VISION_NS::FeatureMatcherParam& param, const std::string& name);
@@ -59,13 +62,15 @@ private:
     bool recognize_and_from(
         const MAA_RES_NS::Recognition::AndParam& param,
         size_t index,
-        std::vector<RecoResult>& sub_results);
+        std::vector<RecoResult>& sub_results,
+        PendingSubRegistry& pending_regs);
     bool recognize_or_in_and(
         const std::shared_ptr<MAA_RES_NS::Recognition::OrParam>& param,
         const std::string& name,
         const MAA_RES_NS::Recognition::AndParam& and_param,
         size_t next_index,
-        std::vector<RecoResult>& sub_results);
+        std::vector<RecoResult>& sub_results,
+        PendingSubRegistry& pending_regs);
     RecoResult build_or_result(const std::string& name, const std::vector<RecoResult>& sub_results, std::optional<cv::Rect> box);
     void inherit_sub_boxes(const std::string& name, const RecoResult& sub_result);
 
@@ -73,6 +78,7 @@ private:
     std::vector<cv::Rect> get_rois_from_pretask(const std::string& name, bool use_best);
     void save_draws(const std::string& node_name, const RecoResult& result) const;
     void register_sub_result_in_cache(const RecoResult& res);
+    void register_sub_result_in_cache(const std::string& name, MaaRecoId reco_id);
 
 private:
     bool debug_mode() const;

--- a/test/pipeline/module/RunWithoutFile.cpp
+++ b/test/pipeline/module/RunWithoutFile.cpp
@@ -53,11 +53,18 @@ bool run_without_file(const std::filesystem::path& testset_dir)
     MaaTaskerBindResource(tasker_handle, resource_handle);
     MaaTaskerBindController(tasker_handle, controller_handle);
 
+    auto cleanup = [&]() {
+        MaaTaskerDestroy(tasker_handle);
+        MaaResourceDestroy(resource_handle);
+        MaaControllerDestroy(controller_handle);
+    };
+
     {
         auto failed_id = MaaTaskerPostTask(tasker_handle, "_NotExists_", "{}");
         auto failed_status = MaaTaskerWait(tasker_handle, failed_id);
         if (failed_id == MaaInvalidId || failed_status != MaaStatus_Failed) {
             std::cout << "Failed to detect invalid task" << std::endl;
+            cleanup();
             return false;
         }
     }
@@ -118,6 +125,19 @@ bool run_without_file(const std::filesystem::path& testset_dir)
     MaaRectDestroy(backtracking_box);
     if (!backtracking_succeeded) {
         std::cout << "Failed to backtrack nested Or recognition" << std::endl;
+        cleanup();
+        return false;
+    }
+
+    MaaNodeId latest_node_id = MaaInvalidId;
+    if (MaaTaskerGetLatestNode(tasker_handle, "A", &latest_node_id)) {
+        std::cout << "Abandoned Or candidate A should not be registered in runtime cache" << std::endl;
+        cleanup();
+        return false;
+    }
+    if (!MaaTaskerGetLatestNode(tasker_handle, "B", &latest_node_id) || !MaaTaskerGetLatestNode(tasker_handle, "candidate", &latest_node_id)) {
+        std::cout << "Selected Or candidate B / alias candidate should be registered in runtime cache" << std::endl;
+        cleanup();
         return false;
     }
 
@@ -129,9 +149,7 @@ bool run_without_file(const std::filesystem::path& testset_dir)
     auto task_id = MaaTaskerPostTask(tasker_handle, "MyTask", task_param_str.c_str());
     auto status = MaaTaskerWait(tasker_handle, task_id);
 
-    MaaTaskerDestroy(tasker_handle);
-    MaaResourceDestroy(resource_handle);
-    MaaControllerDestroy(controller_handle);
+    cleanup();
 
     return status == MaaStatus_Succeeded;
 }

--- a/test/pipeline/module/RunWithoutFile.cpp
+++ b/test/pipeline/module/RunWithoutFile.cpp
@@ -27,6 +27,18 @@ MaaBool my_action(
     const MaaRect* box,
     void* trans_arg);
 
+MaaBool match_second_candidate(
+    MaaContext* context,
+    MaaTaskId task_id,
+    const char* node_name,
+    const char* custom_recognition_name,
+    const char* custom_recognition_param,
+    const MaaImageBuffer* image,
+    const MaaRect* roi,
+    void* trans_arg,
+    MaaRect* out_box,
+    MaaStringBuffer* out_detail);
+
 bool run_without_file(const std::filesystem::path& testset_dir)
 {
     auto screenshot_path = testset_dir / "PipelineSmoking" / "Screenshot";
@@ -51,6 +63,63 @@ bool run_without_file(const std::filesystem::path& testset_dir)
     }
 
     MaaResourceRegisterCustomAction(resource_handle, "MyAct", &my_action, nullptr);
+    int recognition_attempts = 0;
+    MaaResourceRegisterCustomRecognition(resource_handle, "MatchSecondCandidate", &match_second_candidate, &recognition_attempts);
+
+    json::value backtracking_param {
+        { "Backtracking",
+          json::object {
+              { "recognition", "And" },
+              { "all_of",
+                json::array {
+                    json::object {
+                        { "sub_name", "candidate" },
+                        { "recognition", "Or" },
+                        { "any_of",
+                          json::array {
+                              json::object {
+                                  { "sub_name", "A" },
+                                  { "recognition", "DirectHit" },
+                                  { "roi", json::array { 10, 10, 20, 20 } },
+                              },
+                              json::object {
+                                  { "sub_name", "B" },
+                                  { "recognition", "DirectHit" },
+                                  { "roi", json::array { 200, 10, 20, 20 } },
+                              },
+                          } },
+                    },
+                    json::object {
+                        { "recognition", "Custom" },
+                        { "custom_recognition", "MatchSecondCandidate" },
+                        { "roi", "candidate" },
+                    },
+                } },
+          } },
+    };
+    std::string backtracking_param_str = backtracking_param.to_string();
+    auto backtracking_id = MaaTaskerPostTask(tasker_handle, "Backtracking", backtracking_param_str.c_str());
+    auto backtracking_status = MaaTaskerWait(tasker_handle, backtracking_id);
+    MaaNodeId backtracking_node_id = MaaInvalidId;
+    MaaSize node_id_list_size = 1;
+    MaaTaskerGetTaskDetail(
+        tasker_handle,
+        backtracking_id,
+        nullptr,
+        &backtracking_node_id,
+        &node_id_list_size,
+        nullptr);
+    MaaRecoId backtracking_reco_id = MaaInvalidId;
+    MaaTaskerGetNodeDetail(tasker_handle, backtracking_node_id, nullptr, &backtracking_reco_id, nullptr, nullptr);
+    auto backtracking_box = MaaRectCreate();
+    MaaTaskerGetRecognitionDetail(tasker_handle, backtracking_reco_id, nullptr, nullptr, nullptr, backtracking_box, nullptr, nullptr, nullptr);
+    bool backtracking_succeeded =
+        backtracking_status == MaaStatus_Succeeded && recognition_attempts == 2 && MaaRectGetX(backtracking_box) == 200;
+    MaaRectDestroy(backtracking_box);
+    if (!backtracking_succeeded) {
+        std::cout << "Failed to backtrack nested Or recognition" << std::endl;
+        return false;
+    }
 
     json::value task_param {
         { "MyTask", json::object { { "action", "Custom" }, { "custom_action", "MyAct" }, { "custom_action_param", "abcdefg" } } }
@@ -65,6 +134,28 @@ bool run_without_file(const std::filesystem::path& testset_dir)
     MaaControllerDestroy(controller_handle);
 
     return status == MaaStatus_Succeeded;
+}
+
+MaaBool match_second_candidate(
+    MaaContext* context,
+    MaaTaskId task_id,
+    const char* node_name,
+    const char* custom_recognition_name,
+    const char* custom_recognition_param,
+    const MaaImageBuffer* image,
+    const MaaRect* roi,
+    void* trans_arg,
+    MaaRect* out_box,
+    MaaStringBuffer* out_detail)
+{
+    ++*static_cast<int*>(trans_arg);
+    if (MaaRectGetX(roi) != 200) {
+        return false;
+    }
+
+    MaaRectSet(out_box, MaaRectGetX(roi), MaaRectGetY(roi), MaaRectGetW(roi), MaaRectGetH(roi));
+    MaaStringBufferSet(out_detail, "{}");
+    return true;
 }
 
 MaaBool my_action(


### PR DESCRIPTION
## Summary by Sourcery

改进复合识别处理，以便在 `And` 流水线中正确回溯嵌套的 `Or` 识别，并共享子识别解析逻辑。

Bug Fixes:
- 修复在评估嵌套 `Or` 时，`And` 识别器中过早短路的问题，以便后续识别可以基于成功的 `Or` 候选继续运行。

Enhancements:
- 引入用于解析和执行子识别的工具，将其在 `And` 和 `Or` 识别器之间复用，并集中化 `Or` 结果构造和 box 继承逻辑。

Tests:
- 添加一个流水线测试场景，用于验证在 `And` 中嵌套 `Or` 并进行回溯时，第二个候选能够被匹配，且识别详情正确。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve composite recognition handling to correctly backtrack nested Or recognitions within And pipelines and share sub-recognition resolution logic.

Bug Fixes:
- Fix premature short-circuit in And recognizer when evaluating nested Or so later recognitions can run based on successful Or candidates.

Enhancements:
- Introduce utilities to resolve and execute sub-recognitions, reuse them across And and Or recognizers, and centralize Or result construction and box inheritance.

Tests:
- Add pipeline test scenario that exercises nested Or inside And with backtracking to ensure the second candidate is matched and recognition details are correct.

</details>