### PR TITLE
fix: guard batch OCR cache by request compatibility

### DIFF
--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -262,8 +262,11 @@ RecoResult Recognizer::ocr(const MAA_VISION_NS::OCRerParam& param, const std::st
         return { };
     }
 
-    if (ocr_batch_cache_ && ocr_batch_cache_->contains(name)) {
-        const auto& cached = ocr_batch_cache_->at(name);
+    // Keep the read-side eligibility in sync with PipelineTask::try_add_ocr_node.
+    const bool can_use_batch_cache = ocr_batch_cache_ && !param.only_rec && param.color_filter.empty()
+                                     && param.roi_target.type != TargetType::PreTask && param.model == ocr_batch_cache_->model;
+    if (can_use_batch_cache && ocr_batch_cache_->results.contains(name)) {
+        const auto& cached = ocr_batch_cache_->results.at(name);
         LogDebug << "OCR using batch cache" << VAR(name) << VAR(cached);
         return build_result(name, "OCR", OCRer(image_, rois, param, cached, resource()->ocr_res().recer(param.model), name));
     }
@@ -696,7 +699,7 @@ void Recognizer::prefetch_batch_ocr(const std::vector<BatchOCREntry>& entries)
     };
 
     for (const auto& [node, rois] : node_rois) {
-        auto& cache = (*ocr_batch_cache_)[node];
+        auto& cache = ocr_batch_cache_->results[node];
         for (const MAA_VISION_NS::OCRerResult& res : ocrer.all_results()) {
             for (const auto& r : rois) {
                 if (!intersect(r, res.box)) {
@@ -707,7 +710,7 @@ void Recognizer::prefetch_batch_ocr(const std::vector<BatchOCREntry>& entries)
         }
     }
 
-    LogInfo << "prefetch_batch_ocr completed" << VAR(entries) << VAR(*ocr_batch_cache_);
+    LogInfo << "prefetch_batch_ocr completed" << VAR(entries) << VAR(ocr_batch_cache_->results);
 }
 
 MAA_TASK_NS_END

--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -272,7 +272,8 @@ RecoResult PipelineTask::recognize_list(const cv::Mat& image, const std::vector<
     notify(MaaMsg_Node_NextList_Starting, reco_list_cb_detail);
 
     auto batch_plan = prepare_batch_ocr(list);
-    auto ocr_cache = batch_plan ? std::make_shared<MAA_VISION_NS::OCRCache>() : nullptr;
+    auto ocr_cache =
+        batch_plan ? std::make_shared<MAA_VISION_NS::OCRCache>(MAA_VISION_NS::OCRCache { .model = batch_plan->model }) : nullptr;
     bool batch_triggered = false;
 
     for (const auto& node : list) {

--- a/source/MaaFramework/Vision/OCRer.h
+++ b/source/MaaFramework/Vision/OCRer.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <ostream>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -106,6 +107,11 @@ private:
     inline static std::mutex s_predict_mutex_;
 };
 
-using OCRCache = std::unordered_map<std::string, OCRer::ResultsVec>;
+struct OCRCache
+{
+    // Batch results are only valid for OCR requests compatible with this model.
+    std::string model;
+    std::unordered_map<std::string, OCRer::ResultsVec> results;
+};
 
 MAA_VISION_NS_END


### PR DESCRIPTION
## Summary

Fixes #1418.

Batch OCR cache entries were keyed only by recognition name. When two inline OCR sub-recognitions reused the same `sub_name`, a request excluded from the batch plan (for example `only_rec: true`) could read another request's cached result and fail deterministically.

## Changes

- Store the batch OCR model together with the cache entries.
- Reuse batch results only when the current request is compatible with the batch plan.
- Keep `only_rec`, `color_filter`, `PreTask` ROI, and model-mismatch requests on the normal OCR path.

## Verification

- `git diff --check` passed.
- clang-format check passed.
- Source-level regression assertions cover the name collision and all four compatibility guards.
- CMake configuration was attempted, but local MaaDeps download did not complete; the local GCC 8.1 toolchain also does not meet the project's C++20 requirement.

## Summary by Sourcery

通过按请求兼容性保护批量 OCR 缓存及复用，防止跨请求的缓存冲突。

Bug Fixes:
- 防止以共享名称为键的批量 OCR 缓存条目被不兼容的 OCR 请求复用。
- 确保仅识别（only-recognition）、颜色过滤、PreTask ROI 或模型不匹配的内联 OCR 请求绕过批量缓存。

Enhancements:
- 在批量缓存结果中包含 OCR 模型，并在读取缓存时强制进行兼容性检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard batch OCR caching and reuse by request compatibility to prevent cross-request cache collisions.

Bug Fixes:
- Prevent batch OCR cache entries keyed by shared names from being reused by incompatible OCR requests.
- Ensure inline OCR requests with only-recognition, color filters, PreTask ROIs, or mismatched models bypass the batch cache.

Enhancements:
- Include the OCR model alongside batch cache results and enforce compatibility checks when reading from the cache.

</details>