### PR TITLE
fix: 修复 Batch OCR 下同名内联 OCR 误用缓存的问题

### DIFF
--- a/source/MaaFramework/Task/Component/Recognizer.cpp
+++ b/source/MaaFramework/Task/Component/Recognizer.cpp
@@ -262,8 +262,11 @@ RecoResult Recognizer::ocr(const MAA_VISION_NS::OCRerParam& param, const std::st
         return { };
     }
 
-    if (ocr_batch_cache_ && ocr_batch_cache_->contains(name)) {
-        const auto& cached = ocr_batch_cache_->at(name);
+    // Keep the read-side eligibility in sync with PipelineTask::try_add_ocr_node.
+    const bool can_use_batch_cache = ocr_batch_cache_ && !param.only_rec && param.color_filter.empty()
+                                     && param.roi_target.type != TargetType::PreTask && param.model == ocr_batch_cache_->model;
+    if (can_use_batch_cache && ocr_batch_cache_->results.contains(name)) {
+        const auto& cached = ocr_batch_cache_->results.at(name);
         LogDebug << "OCR using batch cache" << VAR(name) << VAR(cached);
         return build_result(name, "OCR", OCRer(image_, rois, param, cached, resource()->ocr_res().recer(param.model), name));
     }
@@ -696,7 +699,7 @@ void Recognizer::prefetch_batch_ocr(const std::vector<BatchOCREntry>& entries)
     };
 
     for (const auto& [node, rois] : node_rois) {
-        auto& cache = (*ocr_batch_cache_)[node];
+        auto& cache = ocr_batch_cache_->results[node];
         for (const MAA_VISION_NS::OCRerResult& res : ocrer.all_results()) {
             for (const auto& r : rois) {
                 if (!intersect(r, res.box)) {
@@ -707,7 +710,7 @@ void Recognizer::prefetch_batch_ocr(const std::vector<BatchOCREntry>& entries)
         }
     }
 
-    LogInfo << "prefetch_batch_ocr completed" << VAR(entries) << VAR(*ocr_batch_cache_);
+    LogInfo << "prefetch_batch_ocr completed" << VAR(entries) << VAR(ocr_batch_cache_->results);
 }
 
 MAA_TASK_NS_END

--- a/source/MaaFramework/Task/PipelineTask.cpp
+++ b/source/MaaFramework/Task/PipelineTask.cpp
@@ -272,7 +272,8 @@ RecoResult PipelineTask::recognize_list(const cv::Mat& image, const std::vector<
     notify(MaaMsg_Node_NextList_Starting, reco_list_cb_detail);
 
     auto batch_plan = prepare_batch_ocr(list);
-    auto ocr_cache = batch_plan ? std::make_shared<MAA_VISION_NS::OCRCache>() : nullptr;
+    auto ocr_cache =
+        batch_plan ? std::make_shared<MAA_VISION_NS::OCRCache>(MAA_VISION_NS::OCRCache { .model = batch_plan->model }) : nullptr;
     bool batch_triggered = false;
 
     for (const auto& node : list) {

--- a/source/MaaFramework/Vision/OCRer.h
+++ b/source/MaaFramework/Vision/OCRer.h
@@ -2,6 +2,7 @@
 
 #include <mutex>
 #include <ostream>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -106,6 +107,11 @@ private:
     inline static std::mutex s_predict_mutex_;
 };
 
-using OCRCache = std::unordered_map<std::string, OCRer::ResultsVec>;
+struct OCRCache
+{
+    // Batch results are only valid for OCR requests compatible with this model.
+    std::string model;
+    std::unordered_map<std::string, OCRer::ResultsVec> results;
+};
 
 MAA_VISION_NS_END


### PR DESCRIPTION
你好，

## 这次主要改了什么

这次主要是修了一个 Batch OCR 下的 OCR 识别失败问题。

简单来说，如果同一个 `next` 列表里的两个内联 OCR 使用了相同的 `sub_name`（比如默认名称 `OCR`），其中一个普通 OCR 写入批量缓存后，另一个 `only_rec: true` 的 OCR 也可能读到这份缓存。

后者本来没有参与 Batch OCR，却被当成批量结果处理了，最后就会识别失败。

## 问题原因

写入缓存时，`only_rec`、`color_filter` 等情况会被排除；但读取缓存时只检查了识别名称，没有再确认当前 OCR 是否属于这次 Batch OCR。

所以，同名的内联 OCR 可能会互相读到对方的缓存。

## 修改内容

- 为 Batch OCR 缓存记录本次批量识别使用的模型；
- 读取缓存前检查当前 OCR 是否适合复用批量结果；
- `only_rec`、`color_filter`、`PreTask ROI` 或模型不一致时，继续使用普通 OCR；
- 保留原有的 ROI 过滤逻辑。

## 检查

- 已通过 clang-format 检查；
- 已通过 `git diff --check`；
- 已针对同名 `sub_name` 和上述几种不兼容情况做源码级回归检查；
- GitHub Actions 会在新的 PR 中重新运行。

Fixes #1418 — whning#0513 官服

## Summary by Sourcery

通过在请求兼容且使用相同模型的前提下才复用缓存，修复了当多个内联 OCR 节点共享相同 sub_name 时批量 OCR 缓存被误用的问题。

Bug 修复：
- 防止 `only_rec`、颜色过滤（color-filtered）或 PreTask ROI OCR 节点在与其他具有相同 sub_name 的节点一起使用时，错误复用这些节点的批量 OCR 结果。
- 确保批量 OCR 缓存条目按所使用的 OCR 模型进行作用域隔离，从而避免不同模型之间共享结果。

增强功能：
- 引入结构化的 OCR 缓存类型，用于同时存储 OCR 模型和每个节点的批量结果，以保持在流水线设置和识别器读取之间的缓存使用一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix batch OCR cache misuse when multiple inline OCR nodes share the same sub_name by making cache reuse conditional on request compatibility and associated model.

Bug Fixes:
- Prevent only_rec, color-filtered, or PreTask ROI OCR nodes from incorrectly reusing batch OCR results from other nodes with the same sub_name.
- Ensure batch OCR cache entries are scoped to the OCR model used for the batch so results are not shared across different models.

Enhancements:
- Introduce a structured OCR cache type that stores both the OCR model and per-node batch results to keep cache usage consistent between pipeline setup and recognizer reads.

</details>