### PR TITLE
fix: 修复 ColorMatch 导出结果无法重新加载的问题

### DIFF
--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -122,7 +122,8 @@ bool get_multi_keys_and_check_value_or_array(
     return true;
 }
 
-template <typename OutT> bool get_and_check_array_or_2darray(
+template <typename OutT>
+bool get_and_check_array_or_2darray(
     const json::value& input,
     const std::string& key,
     std::vector<std::vector<OutT>>& output,

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -65,7 +65,7 @@ bool get_and_check_value_or_array(
     }
 
     if (opt->is_array()) {
-        for (const auto& item : array) {
+        for (const auto& item : opt->as_array()) {
             if (!item.is<OutT>()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;
@@ -99,7 +99,7 @@ bool get_multi_keys_and_check_value_or_array(
             continue;
         }
         else if (opt->is_array()) {
-            for (const auto& item : array) {
+            for (const auto& item : opt->as_array()) {
                 if (!item.is<OutT>()) {
                     LogError << "type error" << VAR(keys) << VAR(input);
                     return false;
@@ -122,8 +122,7 @@ bool get_multi_keys_and_check_value_or_array(
     return true;
 }
 
-template <typename OutT>
-bool get_and_check_array_or_2darray(
+templbool get_and_check_array_or_2darray(
     const json::value& input,
     const std::string& key,
     std::vector<std::vector<OutT>>& output,
@@ -187,6 +186,9 @@ bool get_and_check_array_or_2darray(
     }
 
     return !output.empty();
+}
+
+   return !output.empty();
 }
 
 bool PipelineParser::parse_node(
@@ -2013,7 +2015,7 @@ bool PipelineParser::parse_anchor(
         output[opt->as_string()] = node_name;
     }
     else if (opt->is_array()) {
-        for (const auto& item : array) {
+        for (const auto& item : opt->as_array()) {
             if (!item.is_string()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -122,7 +122,7 @@ bool get_multi_keys_and_check_value_or_array(
     return true;
 }
 
-templbool get_and_check_array_or_2darray(
+template <typename OutT> bool get_and_check_array_or_2darray(
     const json::value& input,
     const std::string& key,
     std::vector<std::vector<OutT>>& output,
@@ -188,8 +188,6 @@ templbool get_and_check_array_or_2darray(
     return !output.empty();
 }
 
-   return !output.empty();
-}
 
 bool PipelineParser::parse_node(
     const std::string& name,

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -134,9 +134,13 @@ bool get_and_check_array_or_2darray(
         output = default_value;
         return true;
     }
-    if (!opt->is_array() || opt->as_array().empty()) {
+    if (!opt->is_array()) {
         LogError << "type error" << VAR(key) << VAR(input);
         return false;
+    }
+    if (opt->as_array().empty()) {
+        output = default_value;
+        return true;
     }
 
     output.clear();

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -65,7 +65,7 @@ bool get_and_check_value_or_array(
     }
 
     if (opt->is_array()) {
-        for (const auto& item : opt->as_array()) {
+        for (const auto& item : array) {
             if (!item.is<OutT>()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;
@@ -99,7 +99,7 @@ bool get_multi_keys_and_check_value_or_array(
             continue;
         }
         else if (opt->is_array()) {
-            for (const auto& item : opt->as_array()) {
+            for (const auto& item : array) {
                 if (!item.is<OutT>()) {
                     LogError << "type error" << VAR(keys) << VAR(input);
                     return false;
@@ -127,7 +127,8 @@ bool get_and_check_array_or_2darray(
     const json::value& input,
     const std::string& key,
     std::vector<std::vector<OutT>>& output,
-    const std::vector<std::vector<OutT>>& default_value)
+    const std::vector<std::vector<OutT>>& default_value,
+    bool empty_as_default = false)
 {
     auto opt = input.find(key);
     if (!opt) {
@@ -138,16 +139,22 @@ bool get_and_check_array_or_2darray(
         LogError << "type error" << VAR(key) << VAR(input);
         return false;
     }
-    if (opt->as_array().empty()) {
-        output = default_value;
+    const auto& array = opt->as_array();
+    if (array.empty()) {
+        if (empty_as_default) {
+            output = default_value;
+        }
+        else {
+            output.clear();
+        }
         return true;
     }
 
     output.clear();
 
-    auto& front = opt->as_array()[0];
+    const auto& front = array[0];
     if (front.is_array()) {
-        for (const auto& arr : opt->as_array()) {
+        for (const auto& arr : array) {
             if (!arr.is_array()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;
@@ -165,7 +172,7 @@ bool get_and_check_array_or_2darray(
     }
     else if (front.is<OutT>()) {
         std::vector<OutT> row;
-        for (const auto& item : opt->as_array()) {
+        for (const auto& item : array) {
             if (!item.is<OutT>()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;
@@ -884,13 +891,13 @@ bool PipelineParser::parse_color_matcher_param(
     }
 
     std::vector<std::vector<int>> lower;
-    if (!get_and_check_array_or_2darray(input, "lower", lower, default_lower)) {
+    if (!get_and_check_array_or_2darray(input, "lower", lower, default_lower, true)) {
         LogError << "failed to get_and_check_array_or_2darray lower" << VAR(input);
         return false;
     }
 
     std::vector<std::vector<int>> upper;
-    if (!get_and_check_array_or_2darray(input, "upper", upper, default_upper)) {
+    if (!get_and_check_array_or_2darray(input, "upper", upper, default_upper, true)) {
         LogError << "failed to get_and_check_array_or_2darray lower" << VAR(input);
         return false;
     }
@@ -2006,7 +2013,7 @@ bool PipelineParser::parse_anchor(
         output[opt->as_string()] = node_name;
     }
     else if (opt->is_array()) {
-        for (const auto& item : opt->as_array()) {
+        for (const auto& item : array) {
             if (!item.is_string()) {
                 LogError << "type error" << VAR(key) << VAR(input);
                 return false;

--- a/test/python/pipeline_test.py
+++ b/test/python/pipeline_test.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import sys
 import json
 import io
+import tempfile
 
 # Fix encoding issues on Windows
 if sys.stdout.encoding != "utf-8":
@@ -143,6 +144,42 @@ def test_resource_node_list(resource: Resource):
 
     print(f"  Found {len(node_list)} nodes: {node_list[:5]}...")
     print("  PASS: resource.node_list")
+
+
+def test_color_match_dumper_roundtrip():
+    """空的 ColorMatch lower/upper 经过 dump 后仍然可以重新加载"""
+    print("\n=== test_color_match_dumper_roundtrip ===")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        source_dir = tmp_path / "source"
+        source_pipeline_dir = source_dir / "pipeline"
+        source_pipeline_dir.mkdir(parents=True)
+        with open(source_pipeline_dir / "source.json", "w", encoding="utf-8") as file:
+            json.dump(
+                {"ColorMatchDefault": {"recognition": "ColorMatch"}},
+                file,
+                indent=4,
+            )
+
+        resource = Resource()
+        resource.post_bundle(str(source_dir)).wait()
+        assert_true(resource.loaded, "source resource should load")
+
+        dumped = resource.get_node_data("ColorMatchDefault")
+        assert_not_none(dumped, "dumped ColorMatch node")
+
+        roundtrip_dir = tmp_path / "roundtrip"
+        roundtrip_pipeline_dir = roundtrip_dir / "pipeline"
+        roundtrip_pipeline_dir.mkdir(parents=True)
+        with open(roundtrip_pipeline_dir / "roundtrip.json", "w", encoding="utf-8") as file:
+            json.dump({"ColorMatchDefault": dumped}, file, indent=4)
+
+        roundtrip_resource = Resource()
+        roundtrip_resource.post_bundle(str(roundtrip_dir)).wait()
+        assert_true(roundtrip_resource.loaded, "dumped resource should load again")
+
+    print("  PASS: ColorMatch dumper/parser round-trip")
 
 
 # ============================================================================
@@ -1383,6 +1420,7 @@ def pipeline_node_test():
         test_resource_get_node_data(resource)
         test_resource_get_node_object(resource)
         test_resource_node_list(resource)
+        test_color_match_dumper_roundtrip()
 
         dbg_controller = DbgController(
             install_dir / "test" / "PipelineSmoking" / "Screenshot",


### PR DESCRIPTION
你好，

## 这次主要改了什么

这次主要是修了一个 ColorMatch 配置导出后无法重新加载的问题呢。

简单来说的话，当 ColorMatch 没有配置 `lower` 和 `upper` 时，PipelineDumper 会把它们导出成空数组。这个结果再次交给 PipelineParser 时，解析器会把空数组当成非法输入，导致同一份配置无法重新加载。

## 修改内容

然后，解析到空的 `lower` 或 `upper` 时，会和字段缺失一样使用默认值。这样一来，既能兼容现有的 dumper 输出，也能让手写的空数组配置正常处理。

## 检查

- 增加了 ColorMatch Parser/Dumper round-trip 测试；
- 已通过 clang-format、Python 语法和 `git diff --check` 检查；
- GitHub Actions 会在 PR 中重新运行。

Fixes #1315 — whning#0513 官服

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复已导出和已解析配置之间的兼容性。

测试：
- 添加一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复已导出和已解析配置之间的兼容性。

测试：
- 添加一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复已导出和已解析配置之间的兼容性。

测试：
- 添加一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复已导出和已解析配置之间的兼容性。

测试：
- 添加一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dumped）与解析（parsed）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略边界配置的场景。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

在导出的 bounds 为空数组时，恢复 ColorMatch 配置的往返（round-trip）兼容性。

Bug 修复：
- 允许空的 ColorMatch `lower` 和 `upper` 数组回退到其默认值，从而恢复导出（dump）与解析（parse）配置之间的兼容性。

测试：
- 新增一个 ColorMatch 解析器/导出器的往返测试，用于覆盖省略 bounds 的配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore ColorMatch configuration round-trip compatibility when bounds are exported as empty arrays.

Bug Fixes:
- Allow empty ColorMatch `lower` and `upper` arrays to fall back to their default values, restoring compatibility between dumped and parsed configurations.

Tests:
- Add a ColorMatch parser/dumper round-trip test covering configurations with omitted bounds.

</details>

</details>

</details>

</details>

</details>