### PR TITLE
停止任务时自动释放仍按下的按键

### DIFF
--- a/source/MaaFramework/Controller/ControllerAgent.cpp
+++ b/source/MaaFramework/Controller/ControllerAgent.cpp
@@ -261,9 +261,13 @@ void ControllerAgent::post_stop()
     LogFunc;
 
     need_to_stop_ = true;
+    release_keys_requested_ = true;
 
     if (action_runner_ && action_runner_->running()) {
         action_runner_->clear();
+    }
+    else {
+        release_pressed_keys_if_requested();
     }
 }
 
@@ -737,9 +741,17 @@ bool ControllerAgent::handle_click_key(const ClickKeyParam& param)
 
     for (const auto& keycode : param.keycode) {
         if (use_key_down_up) {
-            ret &= control_unit_->key_down(keycode);
+            bool key_down = control_unit_->key_down(keycode);
+            if (key_down) {
+                remember_key_down(keycode);
+            }
+            ret &= key_down;
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
-            ret &= control_unit_->key_up(keycode);
+            bool key_up = control_unit_->key_up(keycode);
+            if (key_up) {
+                forget_key_up(keycode);
+            }
+            ret &= key_up;
         }
         else {
             ret &= control_unit_->click_key(keycode);
@@ -762,9 +774,17 @@ bool ControllerAgent::handle_long_press_key(const LongPressKeyParam& param)
 
     for (const auto& keycode : param.keycode) {
         if (use_key_down_up) {
-            ret &= control_unit_->key_down(keycode);
+            bool key_down = control_unit_->key_down(keycode);
+            if (key_down) {
+                remember_key_down(keycode);
+            }
+            ret &= key_down;
             std::this_thread::sleep_for(std::chrono::milliseconds(param.duration));
-            ret &= control_unit_->key_up(keycode);
+            bool key_up = control_unit_->key_up(keycode);
+            if (key_up) {
+                forget_key_up(keycode);
+            }
+            ret &= key_up;
         }
         else {
             LogWarn << "long press key not supported, use click instead";
@@ -840,7 +860,11 @@ bool ControllerAgent::handle_key_down(const ClickKeyParam& param)
     bool ret = !param.keycode.empty();
 
     for (const auto& keycode : param.keycode) {
-        ret &= control_unit_->key_down(keycode);
+        bool key_down = control_unit_->key_down(keycode);
+        if (key_down) {
+            remember_key_down(keycode);
+        }
+        ret &= key_down;
     }
 
     return ret;
@@ -856,7 +880,11 @@ bool ControllerAgent::handle_key_up(const ClickKeyParam& param)
     bool ret = !param.keycode.empty();
 
     for (const auto& keycode : param.keycode) {
-        ret &= control_unit_->key_up(keycode);
+        bool key_up = control_unit_->key_up(keycode);
+        if (key_up) {
+            forget_key_up(keycode);
+        }
+        ret &= key_up;
     }
 
     return ret;
@@ -1025,6 +1053,8 @@ bool ControllerAgent::run_action(typename AsyncRunner<Action>::Id id, Action act
         ret = false;
     }
 
+    release_pressed_keys_if_requested();
+
     if (ret && notify) {
         notifier_.notify(this, MaaMsg_Controller_Action_Succeeded, cb_detail);
     }
@@ -1033,6 +1063,51 @@ bool ControllerAgent::run_action(typename AsyncRunner<Action>::Id id, Action act
     }
 
     return ret;
+}
+
+void ControllerAgent::remember_key_down(int keycode)
+{
+    std::unique_lock lock { pressed_keys_mutex_ };
+    pressed_keys_.insert(keycode);
+}
+
+void ControllerAgent::forget_key_up(int keycode)
+{
+    std::unique_lock lock { pressed_keys_mutex_ };
+    pressed_keys_.erase(keycode);
+}
+
+void ControllerAgent::release_pressed_keys()
+{
+    if (!control_unit_) {
+        LogError << "control_unit_ is nullptr";
+        return;
+    }
+
+    std::set<int> pressed_keys;
+    {
+        std::unique_lock lock { pressed_keys_mutex_ };
+        pressed_keys.swap(pressed_keys_);
+    }
+
+    for (int keycode : pressed_keys) {
+        if (control_unit_->key_up(keycode)) {
+            continue;
+        }
+
+        LogError << "Failed to release pressed key" << VAR(keycode);
+        std::unique_lock lock { pressed_keys_mutex_ };
+        pressed_keys_.insert(keycode);
+    }
+}
+
+void ControllerAgent::release_pressed_keys_if_requested()
+{
+    if (!release_keys_requested_.exchange(false)) {
+        return;
+    }
+
+    release_pressed_keys();
 }
 
 cv::Point ControllerAgent::preproc_touch_point(const cv::Point& p)

--- a/source/MaaFramework/Controller/ControllerAgent.h
+++ b/source/MaaFramework/Controller/ControllerAgent.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -271,6 +272,11 @@ private:
     bool handle_shell(const ShellParam& param);
     bool handle_inactive();
 
+    void remember_key_down(int keycode);
+    void forget_key_up(int keycode);
+    void release_pressed_keys();
+    void release_pressed_keys_if_requested();
+
     MaaCtrlId post(Action action);
     MaaCtrlId focus_id(MaaCtrlId id);
     bool check_stop();
@@ -294,6 +300,9 @@ private: // options
 
 private:
     bool need_to_stop_ = false;
+    std::atomic_bool release_keys_requested_ = false;
+    std::set<int> pressed_keys_;
+    std::mutex pressed_keys_mutex_;
 
 private:
     const std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> control_unit_ = nullptr;


### PR DESCRIPTION
你好，

## 这次主要改了什么

这次主要是修了任务停止后可能残留按键状态的问题呢。

简单来说的话，如果 Pipeline 通过 `key_down` 按住按键，用户在对应的 `key_up` 执行前手动停止任务，原来的 `ControllerAgent` 会清空待执行动作，但不会补发 `key_up`，按键就可能一直保持按下状态。

## 修改内容

- 记录 `ControllerAgent` 成功发出的 `key_down`；
- 正常收到 `key_up` 时移除对应记录；
- 停止任务时清空待执行动作，并在当前动作结束后释放仍记录的按键；
- 释放失败时保留记录并输出错误日志。

这样的话，任务被手动停止后，框架会尽量把自己按下的按键恢复到抬起状态啊。

## 检查

- 已通过 `git diff --check`；
- 改动仅涉及 `ControllerAgent` 的按键状态记录和停止清理逻辑；
- GitHub Actions 会在 PR 中运行完整编译和测试。

Fixes #1394 — whning#0513 官服

## Summary by Sourcery

确保控制器在任务停止或动作结束时释放其已按下的按键，防止按键卡在“按下”状态。

Bug 修复：
- 修复在对应的 `key_up` 动作尚未执行前任务就被停止时，按键在逻辑上仍保持按下状态的问题。

增强功能：
- 在 `ControllerAgent` 内跟踪已按下的按键，并在请求时自动释放它们；如果释放失败则记录错误日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure controller releases keys it has pressed when a task is stopped or an action finishes, preventing stuck key states.

Bug Fixes:
- Fix keys remaining logically pressed when a task is stopped before corresponding key_up actions are executed.

Enhancements:
- Track pressed keys within ControllerAgent and automatically release them once requested, with error logging if release fails.

</details>