### PR TITLE
fix: 修复动作失败时 action_details 信息丢失的问题

### DIFF
--- a/source/MaaFramework/Task/Component/Actuator.cpp
+++ b/source/MaaFramework/Task/Component/Actuator.cpp
@@ -128,6 +128,13 @@ ActionResult Actuator::run(const cv::Rect& reco_hit, MaaRecoId reco_id, const Pi
         return { };
     }
 
+    if (result.action_id == MaaInvalidId) {
+        result.action_id = action_id_;
+        result.name = pipeline_data.name;
+        result.action = MAA_RES_NS::Action::kTypeNameMap.at(pipeline_data.action_type);
+        result.box = reco_hit;
+    }
+
     tasker_->runtime_cache().set_action_detail(result.action_id, result);
 
     return result;

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -131,6 +131,15 @@ class MyRecognition(CustomRecognition):
         )
         print(f"  action_direct_detail: {action_direct_detail}")
 
+        # 失败动作也应保留 action_id 和动作类型，便于关联失败事件
+        failed_action_detail = context.run_action_direct(
+            JActionType.Click, JClick(target=(0, 0, 0, 0)), (100, 100, 50, 50), ""
+        )
+        assert failed_action_detail is not None
+        assert failed_action_detail.action_id != 0
+        assert failed_action_detail.action == JActionType.Click
+        assert not failed_action_detail.success
+
         # 测试 clone 和 override
         new_ctx = context.clone()
         new_ctx.override_pipeline({"TaskA": {}, "TaskB": {}})

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -133,7 +133,10 @@ class MyRecognition(CustomRecognition):
 
         # 失败动作也应保留 action_id 和动作类型，便于关联失败事件
         failed_action_detail = context.run_action_direct(
-            JActionType.Click, JClick(target=(0, 0, 0, 0)), (100, 100, 50, 50), ""
+            JActionType.Click,
+            JClick(target="__missing_target__"),
+            (100, 100, 50, 50),
+            "",
         )
         assert failed_action_detail is not None
         assert failed_action_detail.action_id != 0


### PR DESCRIPTION
你好，

这次修的是动作失败时 `action_details` 丢失关键信息的问题。

当 Click 等动作因为目标框为空而提前返回时，原来的代码会直接返回空的 `ActionResult`。外层事件有正确的 `action_id`，但 `action_details` 里的 `action_id`、`name` 和 `action` 都变成默认值，`RuntimeCache` 还会打印 `uid is invalid`。排查日志时，两边的信息就对不上了。

## 修改内容

在 `Actuator::run` 的统一出口补齐失败结果的基础信息：

- 保留当前 Actuator 的 `action_id`；
- 写入当前节点名和动作类型；
- 保留本次识别框；
- 保持 `success: false`；
- 增加回归测试，覆盖目标框为空的 Click 失败场景。

## 检查

- Python 语法检查通过；
- `git diff --check` 通过；
- 回归测试覆盖目标框为空的失败路径；
- GitHub Actions 会在 PR 中运行完整编译和测试。

Fixes #1258 — whning#0513 官服

## Summary by Sourcery

补全动作失败时的 action_details 基础信息并覆盖相关回归场景。

Bug Fixes:
- 保留动作失败结果中的 action_id、节点名称、动作类型和识别框信息，避免失败事件与 action_details 无法关联。

Tests:
- 增加目标框为空时 Click 动作失败的回归测试，验证失败结果仍包含有效动作标识和类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

补全动作失败时的 action_details 基础信息并覆盖相关回归场景。

Bug Fixes:
- 保留动作失败结果中的 action_id、节点名称、动作类型和识别框信息，避免失败事件与 action_details 无法关联。

Tests:
- 增加目标框为空时 Click 动作失败的回归测试，验证失败结果仍包含有效动作标识和类型。

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

补全动作失败时的 action_details 基础信息并覆盖相关回归场景。

Bug Fixes:
- 保留动作失败结果中的 action_id、节点名称、动作类型和识别框信息，避免失败事件与 action_details 无法关联。

Tests:
- 增加目标框为空时 Click 动作失败的回归测试，验证失败结果仍包含有效动作标识和类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

补全动作失败时的 action_details 基础信息并覆盖相关回归场景。

Bug Fixes:
- 保留动作失败结果中的 action_id、节点名称、动作类型和识别框信息，避免失败事件与 action_details 无法关联。

Tests:
- 增加目标框为空时 Click 动作失败的回归测试，验证失败结果仍包含有效动作标识和类型。

</details>

</details>