### PR TITLE
fix(ci): 修复跟随大版本时损坏的 workflow YAML

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
                   cd .
 
             - name: Windows runner hack (2)
-              uses: al-cheb/configure-pagefile-action@v1
+              uses: al-cheb/configure-pagefile-action@v1.5
               with:
                   minimum-size: 16GB
                   maximum-size: 16GB

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -49,7 +49,8 @@ jobs:
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
-                  # 如果�?inputs.run_id �?run_id 获取 meta 的输�?                  run_id="${{ inputs.reuse-from-run-id }}"
+                  # 如果有 inputs.run_id 从 run_id 获取 meta 的输出
+                  run_id="${{ inputs.reuse-from-run-id }}"
                   if [[ -n "$run_id" ]] && gh run download $run_id --repo ${{ github.repository }} --name meta; then
                     if [[ -f "$META_OUTPUT" ]]; then
                         echo "Reusing meta outputs from run ID: $run_id"
@@ -109,7 +110,8 @@ jobs:
             is-release: ${{ steps.set.outputs.is-release }}
             is-prerelease: ${{ steps.set.outputs.is-prerelease }}
             tag: ${{ steps.set.outputs.tag }} # v<release version> | v<ci version>
-            version: ${{ steps.set.outputs.version }} # <release version> | <ci version>+<build> e.g �?            build-config: ${{ steps.set.outputs.build-config }} # Release | RelWithDebInfo | Debug
+            version: ${{ steps.set.outputs.version }} # <release version> | <ci version>+<build> e.g ↓
+            build-config: ${{ steps.set.outputs.build-config }} # Release | RelWithDebInfo | Debug
             latest-plugin: ${{ steps.set.outputs.latest-plugin }}
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ concurrency:
     group: ${{ github.workflow }}-${{ inputs.run-id }}
     cancel-in-progress: false
 
-# 注意：如�?only-publish-to �?All，则所�?jobs 的状态都必须是成功，All 的状态由 create_issue 判断
+# 注意：如果 only-publish-to 是 All，则所有 jobs 的状态都必须是成功，All 的状态由 create_issue 判断
 jobs:
     meta:
         uses: ./.github/workflows/meta.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
                   cd .
 
             - name: Windows runner hack (2)
-              uses: al-cheb/configure-pagefile-action@v1
+              uses: al-cheb/configure-pagefile-action@v1.5
               with:
                   minimum-size: 16GB
                   maximum-size: 16GB


### PR DESCRIPTION
PowerShell 重写文件时吞掉了含中文注释的换行，导致 meta/release 工作流语法错误。

## Summary by Sourcery

修复由损坏的注释导致的 GitHub 工作流故障，并更新一个 CI 动作依赖版本。

错误修复：
- 更正 meta 工作流脚本中的注释和 `run_id` 处理方式，避免出现 YAML 语法错误。
- 修复发布工作流中针对 `only-publish-to=All` 的注释，使 CI 中的 `jobs` 部分能够被正确解析。

改进：
- 在构建和测试工作流中，将 Windows runner 的页面文件配置动作更新到 `v1.5` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix broken GitHub workflows caused by corrupted comments and update a CI action dependency version.

Bug Fixes:
- Correct meta workflow script comments and run_id handling to avoid YAML syntax errors.
- Fix release workflow comment for only-publish-to=All so the jobs section parses correctly in CI.

Enhancements:
- Update Windows runner pagefile configuration action to version v1.5 in build and test workflows.

</details>

错误修复：
- 更正 meta 工作流脚本代码块，以便设置 `run_id`，并避免注释破坏 YAML 语法。
- 修复 release 工作流中关于 `only-publish-to=All` 的注释，使 `jobs` 部分在 CI 中能够被正确解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复由损坏的注释导致的 GitHub 工作流故障，并更新一个 CI 动作依赖版本。

错误修复：
- 更正 meta 工作流脚本中的注释和 `run_id` 处理方式，避免出现 YAML 语法错误。
- 修复发布工作流中针对 `only-publish-to=All` 的注释，使 CI 中的 `jobs` 部分能够被正确解析。

改进：
- 在构建和测试工作流中，将 Windows runner 的页面文件配置动作更新到 `v1.5` 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix broken GitHub workflows caused by corrupted comments and update a CI action dependency version.

Bug Fixes:
- Correct meta workflow script comments and run_id handling to avoid YAML syntax errors.
- Fix release workflow comment for only-publish-to=All so the jobs section parses correctly in CI.

Enhancements:
- Update Windows runner pagefile configuration action to version v1.5 in build and test workflows.

</details>

</details>