### PR TITLE
docs: pi 2.9.1 focus.trace 字段

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -31,7 +31,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-06-30 | v2.8.0  | Added `setting` task settings page UI declaration field; `import` supports importing `global_option` and `setting` fields; added `hotkey` option type |
 | 2026-07-01 | v2.8.1  | Added `controller` / `resource` filters for `pretask`, with the same semantics as `task.controller` / `task.resource` |
 | 2026-07-22 | v2.9.0  | Added the `telemetry` anonymous telemetry (data reporting) configuration field |
-| 2026-08-05 | v2.9.1  | Added Pipeline node `trace` field semantics for controlling whether node results are uploaded to telemetry by callback message type |
+| 2026-08-05 | v2.9.1  | Added the `trace` field on `focus` message template objects for controlling whether node results are uploaded to telemetry by callback message type |
 
 ## `interface.json`
 
@@ -1168,11 +1168,11 @@ typedef void(MAA_CALL* MaaEventCallback)(
 
 #### Message Template Mechanism
 
-Resource authors can configure message templates in the Pipeline using the `focus` field. The `focus` field is a dictionary where keys are message types and values are template strings or template objects. Template strings support file paths, URLs, or direct text, content supports Markdown format, and support internationalization (starting with `$`). When the Client receives a callback, it should perform placeholder replacement based on the template and display the result to users via the specified channel.
+Resource authors can configure message templates in the Pipeline using the `focus` field. The `focus` field is a dictionary where keys are message types and values are template strings or template objects. Template strings support file paths, URLs, or direct text, content supports Markdown format, and support internationalization (starting with `$`). When the Client receives a callback, it should perform placeholder replacement based on the template and display the result to users via the specified channel; the object form can also control whether the current node result is uploaded to the telemetry platform.
 
 ##### Two Forms of `focus` Values
 
-**Shorthand (plain string):** Equivalent to `display: "log"` — content is only shown in the run log.
+**Shorthand (plain string):** Equivalent to `display: "log"` — content is only shown in the run log; `trace` uses the default value.
 
 ```jsonc
 "focus": {
@@ -1180,16 +1180,26 @@ Resource authors can configure message templates in the Pipeline using the `focu
 }
 ```
 
-**Full form (object):** Use the `display` field to specify the display channel. **💡 v2.3.0**
+**Full form (object):** Use `display` to specify the display channel and `trace` to control telemetry upload. **💡 v2.3.0** (`trace` is **💡 v2.9.1**)
 
 ```jsonc
 "focus": {
     "Node.Action.Starting": {
         "content": "{name} starts execution",
-        "display": "toast"
+        "display": "toast",
+        "trace": false
     }
 }
 ```
+
+- `content` `string`  
+  Template content shown to the user. Optional; if omitted, no message is displayed.
+
+- `display` `string` | `string[]` **💡 v2.3.0**  
+  Display channel(s); see the table below. Optional, default `"log"`.
+
+- `trace` `boolean` **💡 v2.9.1**  
+  Whether to upload the current node result to the telemetry platform. Optional; if omitted, use the defaults in the table below.
 
 ##### `display` Values **💡 v2.3.0**
 
@@ -1216,6 +1226,15 @@ Resource authors can configure message templates in the Pipeline using the `focu
 }
 ```
 
+##### `trace` Defaults **💡 v2.9.1**
+
+When `telemetry.sentry` is configured and `tracing` is enabled (or not explicitly disabled):
+
+| Message type | Default | Notes |
+| ------------ | ------- | ----- |
+| `Node.PipelineNode.Failed` | `true` | Aligns with common Client default reporting of pipeline node failures |
+| Other `Node.xxx` messages | `false` | Upload only if the corresponding template object explicitly sets `"trace": true` |
+
 **Complete Pipeline Configuration Example:**
 
 ```jsonc
@@ -1229,7 +1248,11 @@ Resource authors can configure message templates in the Pipeline using the `focu
       },
       "Node.Action.Failed": {
         "content": "{name} execution failed",
-        "display": "modal"
+        "display": "modal",
+        "trace": true
+      },
+      "Node.PipelineNode.Succeeded": {
+        "trace": true
       }
     }
   }
@@ -1255,7 +1278,11 @@ Resource authors can configure message templates in the Pipeline using the `focu
         },
         "Node.Action.Failed": {
             "content": "{name} execution failed",
-            "display": "modal"
+            "display": "modal",
+            "trace": true
+        },
+        "Node.PipelineNode.Succeeded": {
+            "trace": true
         }
     }
 }
@@ -1266,46 +1293,11 @@ Resource authors can configure message templates in the Pipeline using the `focu
 1. Parse the `details_json` parameter in the callback function
 2. Check if the parsed object contains a `focus` field
 3. If present, find the corresponding template (string or object) in `focus` based on the `message` parameter
-4. If the template is a string, treat it as `content` and set `display` to `["log"]`; if it is an object, read `content` and `display` separately
-5. Replace placeholders in `content` (e.g., `{name}`, `{task_id}`) with data from `details_json`
-6. Display the processed text to the user via the channel(s) specified in `display` (may be multiple) **💡 v2.3.0**
+4. If the template is a string, treat it as `content`, set `display` to `["log"]`, and use the default `trace`; if it is an object, read `content`, `display`, and `trace` separately
+5. If `content` is present, replace placeholders (e.g., `{name}`, `{task_id}`) with data from `details_json`, then display via the channel(s) specified in `display` **💡 v2.3.0**
+6. Resolve the effective `trace`: use the explicit value from the object if present, otherwise use the default; when global telemetry is enabled, upload the current node result only if the effective value is `true` **💡 v2.9.1**
 
 Using the example above, upon receiving `Node.Action.Starting`, the Client should append to the log and show a toast: `NodeA starts execution, task ID: 12345`
-
-#### Node Telemetry Trace Mechanism **💡 v2.9.1**
-
-Resource authors can use the `trace` field on Pipeline nodes (at the same level as `focus`) to control, by callback message type, whether the current node result is uploaded to the telemetry platform. `trace` is a dictionary whose keys are message types (e.g. `Node.PipelineNode.Failed`) and whose values are `boolean`.
-
-##### Defaults
-
-When `telemetry.sentry` is configured and `tracing` is enabled (or not explicitly disabled):
-
-| Message type | Default | Notes |
-| ------------ | ------- | ----- |
-| `Node.PipelineNode.Failed` | `true` | Aligns with common Client default reporting of pipeline node failures |
-| Other `Node.xxx` messages | `false` | Upload only if the node `trace` explicitly sets `true` |
-
-##### Pipeline Configuration Example
-
-```jsonc
-{
-  "NodeA": {
-    "trace": {
-      "Node.PipelineNode.Failed": true,
-      "Node.PipelineNode.Succeeded": true,
-      "Node.Action.Failed": false
-    }
-  }
-}
-```
-
-##### Client Processing Flow
-
-1. Confirm that global telemetry is enabled (valid `telemetry.sentry.dsn`, user consent allowed, `tracing` not disabled, etc.)
-2. Parse the `details_json` parameter in the callback function
-3. Read the optional `trace` field (a dictionary; may be omitted)
-4. Resolve the effective boolean for `message`: use `trace[message]` if present, otherwise use the defaults in the previous section
-5. Upload the current node result to the telemetry platform only when the effective value is `true`
 
 #### More Message Types
 

--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -31,6 +31,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-06-30 | v2.8.0  | Added `setting` task settings page UI declaration field; `import` supports importing `global_option` and `setting` fields; added `hotkey` option type |
 | 2026-07-01 | v2.8.1  | Added `controller` / `resource` filters for `pretask`, with the same semantics as `task.controller` / `task.resource` |
 | 2026-07-22 | v2.9.0  | Added the `telemetry` anonymous telemetry (data reporting) configuration field |
+| 2026-08-05 | v2.9.1  | Added Pipeline node `trace` field semantics for controlling whether node results are uploaded to telemetry by callback message type |
 
 ## `interface.json`
 
@@ -1270,6 +1271,41 @@ Resource authors can configure message templates in the Pipeline using the `focu
 6. Display the processed text to the user via the channel(s) specified in `display` (may be multiple) **💡 v2.3.0**
 
 Using the example above, upon receiving `Node.Action.Starting`, the Client should append to the log and show a toast: `NodeA starts execution, task ID: 12345`
+
+#### Node Telemetry Trace Mechanism **💡 v2.9.1**
+
+Resource authors can use the `trace` field on Pipeline nodes (at the same level as `focus`) to control, by callback message type, whether the current node result is uploaded to the telemetry platform. `trace` is a dictionary whose keys are message types (e.g. `Node.PipelineNode.Failed`) and whose values are `boolean`.
+
+##### Defaults
+
+When `telemetry.sentry` is configured and `tracing` is enabled (or not explicitly disabled):
+
+| Message type | Default | Notes |
+| ------------ | ------- | ----- |
+| `Node.PipelineNode.Failed` | `true` | Aligns with common Client default reporting of pipeline node failures |
+| Other `Node.xxx` messages | `false` | Upload only if the node `trace` explicitly sets `true` |
+
+##### Pipeline Configuration Example
+
+```jsonc
+{
+  "NodeA": {
+    "trace": {
+      "Node.PipelineNode.Failed": true,
+      "Node.PipelineNode.Succeeded": true,
+      "Node.Action.Failed": false
+    }
+  }
+}
+```
+
+##### Client Processing Flow
+
+1. Confirm that global telemetry is enabled (valid `telemetry.sentry.dsn`, user consent allowed, `tracing` not disabled, etc.)
+2. Parse the `details_json` parameter in the callback function
+3. Read the optional `trace` field (a dictionary; may be omitted)
+4. Resolve the effective boolean for `message`: use `trace[message]` if present, otherwise use the defaults in the previous section
+5. Upload the current node result to the telemetry platform only when the effective value is `true`
 
 #### More Message Types
 

--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -1192,15 +1192,6 @@ Resource authors can configure message templates in the Pipeline using the `focu
 }
 ```
 
-- `content` `string`  
-  Template content shown to the user. Optional; if omitted, no message is displayed.
-
-- `display` `string` | `string[]` **💡 v2.3.0**  
-  Display channel(s); see the table below. Optional, default `"log"`.
-
-- `trace` `boolean` **💡 v2.9.1**  
-  Whether to upload the current node result to the telemetry platform. Optional; if omitted, use the defaults in the table below.
-
 ##### `display` Values **💡 v2.3.0**
 
 | Value | Description | Behavior |

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -31,7 +31,7 @@
 | 2026-6-30 | v2.8.0 | 新增 `setting` 任务设置页 UI 声明字段；`import` 支持导入 `global_option` 与 `setting` 字段；新增 `hotkey` 配置项类型 |
 | 2026-7-1 | v2.8.1 | `pretask` 支持 `controller` / `resource` 过滤字段，与 `task.controller` / `task.resource` 语义一致 |
 | 2026-7-22 | v2.9.0 | 新增 `telemetry` 匿名遥测（数据埋点）配置字段 |
-| 2026-8-5 | v2.9.1 | 新增 Pipeline 节点 `trace` 字段语义，用于按回调消息类型控制遥测是否上传节点结果 |
+| 2026-8-5 | v2.9.1 | 新增 `focus` 消息模板对象的 `trace` 字段，用于按回调消息类型控制遥测是否上传节点结果 |
 
 ## `interface.json`
 
@@ -1166,11 +1166,11 @@ typedef void(MAA_CALL* MaaEventCallback)(
 
 #### 消息模板机制
 
-资源作者可以在 Pipeline 中通过 `focus` 字段配置消息模板。`focus` 是一个字典，键为消息类型，值为模板字符串或模板对象。模板字符串支持文件路径、URL 或直接文本，内容支持 Markdown 格式，支持国际化（以`$`开头）。Client 收到回调后，应根据模板进行占位符替换并按指定方式展示给用户。
+资源作者可以在 Pipeline 中通过 `focus` 字段配置消息模板。`focus` 是一个字典，键为消息类型，值为模板字符串或模板对象。模板字符串支持文件路径、URL 或直接文本，内容支持 Markdown 格式，支持国际化（以`$`开头）。Client 收到回调后，应根据模板进行占位符替换并按指定方式展示给用户；对象写法还可配置是否将本次节点结果上传到遥测平台。
 
 ##### `focus` 值的两种写法
 
-**简写（纯字符串）：** 等价于 `display: "log"`，内容仅展示在运行日志中。
+**简写（纯字符串）：** 等价于 `display: "log"`，内容仅展示在运行日志中；`trace` 使用默认值。
 
 ```jsonc
 "focus": {
@@ -1178,16 +1178,26 @@ typedef void(MAA_CALL* MaaEventCallback)(
 }
 ```
 
-**完整写法（对象）：** 可通过 `display` 字段指定展示渠道。 **💡 v2.3.0**
+**完整写法（对象）：** 可通过 `display` 指定展示渠道，通过 `trace` 控制是否上传遥测。 **💡 v2.3.0**（`trace` 为 **💡 v2.9.1**）
 
 ```jsonc
 "focus": {
     "Node.Action.Starting": {
         "content": "{name} 开始执行",
-        "display": "toast"
+        "display": "toast",
+        "trace": false
     }
 }
 ```
+
+- `content` `string`  
+  展示给用户的模板内容。可选；缺省时不进行消息展示。
+
+- `display` `string` | `string[]` **💡 v2.3.0**  
+  展示渠道，见下表。可选，默认 `"log"`。
+
+- `trace` `boolean` **💡 v2.9.1**  
+  是否将本次节点结果上传到遥测平台。可选；缺省时使用下表默认值。
 
 ##### `display` 可选值 **💡 v2.3.0**
 
@@ -1214,6 +1224,15 @@ typedef void(MAA_CALL* MaaEventCallback)(
 }
 ```
 
+##### `trace` 默认值 **💡 v2.9.1**
+
+在已配置 `telemetry.sentry` 且 `tracing` 启用（或未显式关闭）的前提下：
+
+| 消息类型 | 默认值 | 说明 |
+| -------- | ------ | ---- |
+| `Node.PipelineNode.Failed` | `true` | 与常见 Client 对流水线节点失败的默认上报行为对齐 |
+| 其他 `Node.xxx` 消息 | `false` | 需在对应消息的模板对象中显式写 `"trace": true` 才会上传 |
+
 **Pipeline 中的完整配置示例：**
 
 ```jsonc
@@ -1227,7 +1246,11 @@ typedef void(MAA_CALL* MaaEventCallback)(
       },
       "Node.Action.Failed": {
         "content": "{name} 执行失败",
-        "display": "modal"
+        "display": "modal",
+        "trace": true
+      },
+      "Node.PipelineNode.Succeeded": {
+        "trace": true
       }
     }
   }
@@ -1253,7 +1276,11 @@ typedef void(MAA_CALL* MaaEventCallback)(
         },
         "Node.Action.Failed": {
             "content": "{name} 执行失败",
-            "display": "modal"
+            "display": "modal",
+            "trace": true
+        },
+        "Node.PipelineNode.Succeeded": {
+            "trace": true
         }
     }
 }
@@ -1264,46 +1291,11 @@ typedef void(MAA_CALL* MaaEventCallback)(
 1. 在回调函数中解析 `details_json` 参数
 2. 检查解析后的对象中是否存在 `focus` 字段
 3. 若存在，根据 `message` 参数在 `focus` 中查找对应的模板（字符串或对象）
-4. 若模板为字符串，则 `content` 即为该字符串，`display` 视为 `["log"]`；若为对象，则分别读取 `content` 和 `display`
-5. 使用 `details_json` 中的数据替换 `content` 中的占位符（如 `{name}`、`{task_id}`）
-6. 根据 `display` 指定的渠道（可多个）将处理后的文本展示给用户 **💡 v2.3.0**
+4. 若模板为字符串，则 `content` 即为该字符串，`display` 视为 `["log"]`，`trace` 使用默认值；若为对象，则分别读取 `content`、`display`、`trace`
+5. 若存在 `content`，使用 `details_json` 中的数据替换占位符（如 `{name}`、`{task_id}`），再根据 `display` 指定的渠道展示给用户 **💡 v2.3.0**
+6. 解析有效 `trace`：对象中显式给出则用之，否则使用默认值；在全局遥测已启用时，仅当有效值为 `true` 才上传本次节点结果 **💡 v2.9.1**
 
 以上述示例为例，收到 `Node.Action.Starting` 时，应在日志中追加并弹出 toast：`NodeA 开始执行，任务 ID: 12345`
-
-#### 节点遥测追踪机制 **💡 v2.9.1**
-
-资源作者可以在 Pipeline 节点上通过 `trace` 字段（与 `focus` 同级）按回调消息类型控制是否将本次节点结果上传到遥测平台。`trace` 是一个字典，键为消息类型（如 `Node.PipelineNode.Failed`），值为 `boolean`。
-
-##### 默认值
-
-在已配置 `telemetry.sentry` 且 `tracing` 启用（或未显式关闭）的前提下：
-
-| 消息类型 | 默认值 | 说明 |
-| -------- | ------ | ---- |
-| `Node.PipelineNode.Failed` | `true` | 与常见 Client 对流水线节点失败的默认上报行为对齐 |
-| 其他 `Node.xxx` 消息 | `false` | 需在节点 `trace` 中显式写 `true` 才会上传 |
-
-##### Pipeline 配置示例
-
-```jsonc
-{
-  "NodeA": {
-    "trace": {
-      "Node.PipelineNode.Failed": true,
-      "Node.PipelineNode.Succeeded": true,
-      "Node.Action.Failed": false
-    }
-  }
-}
-```
-
-##### Client 处理流程
-
-1. 确认全局遥测已启用（存在有效 `telemetry.sentry.dsn`、用户授权允许、`tracing` 未关闭等）
-2. 在回调函数中解析 `details_json` 参数
-3. 读取可选的 `trace` 字段（字典；可缺省）
-4. 根据 `message` 解析有效布尔值：`trace[message]` 若存在则用之，否则使用上一节默认值
-5. 仅当有效值为 `true` 时，将本次节点结果上传到遥测平台
 
 #### 更多消息类型
 

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -1190,15 +1190,6 @@ typedef void(MAA_CALL* MaaEventCallback)(
 }
 ```
 
-- `content` `string`  
-  展示给用户的模板内容。可选；缺省时不进行消息展示。
-
-- `display` `string` | `string[]` **💡 v2.3.0**  
-  展示渠道，见下表。可选，默认 `"log"`。
-
-- `trace` `boolean` **💡 v2.9.1**  
-  是否将本次节点结果上传到遥测平台。可选；缺省时使用下表默认值。
-
 ##### `display` 可选值 **💡 v2.3.0**
 
 | 值 | 说明 | 行为特征 |

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -31,6 +31,7 @@
 | 2026-6-30 | v2.8.0 | 新增 `setting` 任务设置页 UI 声明字段；`import` 支持导入 `global_option` 与 `setting` 字段；新增 `hotkey` 配置项类型 |
 | 2026-7-1 | v2.8.1 | `pretask` 支持 `controller` / `resource` 过滤字段，与 `task.controller` / `task.resource` 语义一致 |
 | 2026-7-22 | v2.9.0 | 新增 `telemetry` 匿名遥测（数据埋点）配置字段 |
+| 2026-8-5 | v2.9.1 | 新增 Pipeline 节点 `trace` 字段语义，用于按回调消息类型控制遥测是否上传节点结果 |
 
 ## `interface.json`
 
@@ -1268,6 +1269,41 @@ typedef void(MAA_CALL* MaaEventCallback)(
 6. 根据 `display` 指定的渠道（可多个）将处理后的文本展示给用户 **💡 v2.3.0**
 
 以上述示例为例，收到 `Node.Action.Starting` 时，应在日志中追加并弹出 toast：`NodeA 开始执行，任务 ID: 12345`
+
+#### 节点遥测追踪机制 **💡 v2.9.1**
+
+资源作者可以在 Pipeline 节点上通过 `trace` 字段（与 `focus` 同级）按回调消息类型控制是否将本次节点结果上传到遥测平台。`trace` 是一个字典，键为消息类型（如 `Node.PipelineNode.Failed`），值为 `boolean`。
+
+##### 默认值
+
+在已配置 `telemetry.sentry` 且 `tracing` 启用（或未显式关闭）的前提下：
+
+| 消息类型 | 默认值 | 说明 |
+| -------- | ------ | ---- |
+| `Node.PipelineNode.Failed` | `true` | 与常见 Client 对流水线节点失败的默认上报行为对齐 |
+| 其他 `Node.xxx` 消息 | `false` | 需在节点 `trace` 中显式写 `true` 才会上传 |
+
+##### Pipeline 配置示例
+
+```jsonc
+{
+  "NodeA": {
+    "trace": {
+      "Node.PipelineNode.Failed": true,
+      "Node.PipelineNode.Succeeded": true,
+      "Node.Action.Failed": false
+    }
+  }
+}
+```
+
+##### Client 处理流程
+
+1. 确认全局遥测已启用（存在有效 `telemetry.sentry.dsn`、用户授权允许、`tracing` 未关闭等）
+2. 在回调函数中解析 `details_json` 参数
+3. 读取可选的 `trace` 字段（字典；可缺省）
+4. 根据 `message` 解析有效布尔值：`trace[message]` 若存在则用之，否则使用上一节默认值
+5. 仅当有效值为 `true` 时，将本次节点结果上传到遥测平台
 
 #### 更多消息类型
 


### PR DESCRIPTION
## Summary by Sourcery

记录新的 v2.9.1 Pipeline 节点 `trace` 字段，该字段用于按回调消息类型控制遥测（telemetry）上传。

Documentation:
- 新增 v2.9.1 更新日志条目，描述用于遥测控制的 Pipeline 节点 `trace` 字段。
- 在 Project Interface v2 文档中记录 Pipeline 节点 `trace` 遥测机制的语义、默认值、配置示例以及客户端处理流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the new v2.9.1 Pipeline node `trace` field used to control telemetry uploads per callback message type.

Documentation:
- Add v2.9.1 changelog entry describing the Pipeline node `trace` field for telemetry control.
- Document the semantics, defaults, configuration examples, and client processing flow for the Pipeline node `trace` telemetry mechanism in the Project Interface v2 docs.

</details>