### PR TITLE
fix: 修复神经网络检测保持图像宽高比

### DIFF
--- a/source/MaaFramework/Vision/NeuralNetworkDetector.cpp
+++ b/source/MaaFramework/Vision/NeuralNetworkDetector.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cmath>
 #include <map>
 #include <ranges>
 #include <sstream>
@@ -72,7 +73,26 @@ NeuralNetworkDetector::ResultsVec NeuralNetworkDetector::detect(const std::vecto
     cv::Mat image = image_with_roi();
     cv::Size raw_roi_size(image.cols, image.rows);
     cv::Size input_image_size(static_cast<int>(input_shape[3]), static_cast<int>(input_shape[2]));
-    cv::resize(image, image, input_image_size, 0, 0, cv::INTER_AREA);
+    const double scale = std::min(
+        static_cast<double>(input_image_size.width) / raw_roi_size.width,
+        static_cast<double>(input_image_size.height) / raw_roi_size.height);
+    cv::Size resized_image_size(
+        static_cast<int>(std::round(raw_roi_size.width * scale)),
+        static_cast<int>(std::round(raw_roi_size.height * scale)));
+    cv::resize(image, image, resized_image_size, 0, 0, cv::INTER_AREA);
+    const int pad_width = input_image_size.width - resized_image_size.width;
+    const int pad_height = input_image_size.height - resized_image_size.height;
+    const int pad_left = pad_width / 2;
+    const int pad_top = pad_height / 2;
+    cv::copyMakeBorder(
+        image,
+        image,
+        pad_top,
+        pad_height - pad_top,
+        pad_left,
+        pad_width - pad_left,
+        cv::BORDER_CONSTANT,
+        cv::Scalar(114, 114, 114));
     std::vector<float> input = image_to_tensor(image);
 
     Ort::Value input_tensor =
@@ -109,9 +129,6 @@ NeuralNetworkDetector::ResultsVec NeuralNetworkDetector::detect(const std::vecto
 
     ResultsVec raw_results;
     const size_t output_size = output.back().size();
-    double width_ratio = 1.0 * raw_roi_size.width / input_image_size.width;
-    double height_ratio = 1.0 * raw_roi_size.height / input_image_size.height;
-
     for (size_t i = 0; i < output_size; ++i) {
         constexpr size_t kConfidenceIndex = 4;
         for (size_t j = kConfidenceIndex; j < output.size(); ++j) {
@@ -126,13 +143,13 @@ NeuralNetworkDetector::ResultsVec NeuralNetworkDetector::detect(const std::vecto
             int w = static_cast<int>(output[2][i]);
             int h = static_cast<int>(output[3][i]);
 
-            int x = center_x - w / 2;
-            int y = center_y - h / 2;
+            int x = static_cast<int>((center_x - w / 2 - pad_left) / scale);
+            int y = static_cast<int>((center_y - h / 2 - pad_top) / scale);
             cv::Rect box {
-                static_cast<int>(x * width_ratio) + roi_.x,
-                static_cast<int>(y * height_ratio) + roi_.y,
-                static_cast<int>(w * width_ratio),
-                static_cast<int>(h * height_ratio),
+                x + roi_.x,
+                y + roi_.y,
+                static_cast<int>(w / scale),
+                static_cast<int>(h / scale),
             };
 
             Result res;

--- a/source/MaaFramework/Vision/NeuralNetworkDetector.cpp
+++ b/source/MaaFramework/Vision/NeuralNetworkDetector.cpp
@@ -74,11 +74,13 @@ NeuralNetworkDetector::ResultsVec NeuralNetworkDetector::detect(const std::vecto
     cv::Size raw_roi_size(image.cols, image.rows);
     cv::Size input_image_size(static_cast<int>(input_shape[3]), static_cast<int>(input_shape[2]));
     const double scale = std::min(
-        static_cast<double>(input_image_size.width) / raw_roi_size.width,
-        static_cast<double>(input_image_size.height) / raw_roi_size.height);
+        std::min(
+            static_cast<double>(input_image_size.width) / raw_roi_size.width,
+            static_cast<double>(input_image_size.height) / raw_roi_size.height),
+        1.0);
     cv::Size resized_image_size(
-        static_cast<int>(std::round(raw_roi_size.width * scale)),
-        static_cast<int>(std::round(raw_roi_size.height * scale)));
+        static_cast<int>(std::floor(raw_roi_size.width * scale)),
+        static_cast<int>(std::floor(raw_roi_size.height * scale)));
     cv::resize(image, image, resized_image_size, 0, 0, cv::INTER_AREA);
     const int pad_width = input_image_size.width - resized_image_size.width;
     const int pad_height = input_image_size.height - resized_image_size.height;
@@ -138,10 +140,10 @@ NeuralNetworkDetector::ResultsVec NeuralNetworkDetector::detect(const std::vecto
                 continue;
             }
 
-            int center_x = static_cast<int>(output[0][i]);
-            int center_y = static_cast<int>(output[1][i]);
-            int w = static_cast<int>(output[2][i]);
-            int h = static_cast<int>(output[3][i]);
+            const double center_x = output[0][i];
+            const double center_y = output[1][i];
+            const double w = output[2][i];
+            const double h = output[3][i];
 
             int x = static_cast<int>((center_x - w / 2 - pad_left) / scale);
             int y = static_cast<int>((center_y - h / 2 - pad_top) / scale);


### PR DESCRIPTION
主要调整了在使用模型识别前的缩放方式,修改为yolo默认的颜色填充,再使用保持宽高比的 letterbox 缩放

## Summary by Sourcery

调整神经网络检测器的预处理方式，通过采用 letterbox 风格的缩放与填充来保持输入的纵横比，以实现与 YOLO 兼容的推理。

Bug Fixes:
- 通过按比例缩放并填充，而不是直接拉伸到网络输入尺寸，来保留原始 ROI 的纵横比。
- 在将边界框坐标映射回原始 ROI 时，考虑缩放比例和填充偏移，而不是仅使用宽度/高度比例进行换算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust neural network detector preprocessing to maintain input aspect ratio using letterbox-style resizing and padding for YOLO-compatible inference.

Bug Fixes:
- Preserve original ROI aspect ratio by resizing with scale factor and padding instead of stretching to the network input size.
- Correct bounding box coordinate mapping back to the original ROI by accounting for scale and padding rather than simple width/height ratios.

</details>