### PR TITLE
chore(linux): Linux 控制器简单清理

### DIFF
--- a/source/MaaLinuxControlUnit/Input/NoneInput.cpp
+++ b/source/MaaLinuxControlUnit/Input/NoneInput.cpp
@@ -1,0 +1,84 @@
+#include "NoneInput.h"
+
+#include "MaaUtils/Logger.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+MaaControllerFeature NoneInput::get_features() const
+{
+    return MaaControllerFeature_UseMouseDownAndUpInsteadOfClick | MaaControllerFeature_UseKeyboardDownAndUpInsteadOfClick;
+}
+
+bool NoneInput::click(int x, int y)
+{
+    LogError << "deprecated: get_features() returns MaaControllerFeature_UseMouseDownAndUpInsteadOfClick, "
+                "use touch_down/touch_up instead"
+             << VAR(x) << VAR(y);
+    return false;
+}
+
+bool NoneInput::swipe(int x1, int y1, int x2, int y2, int duration)
+{
+    LogError << "deprecated: get_features() returns MaaControllerFeature_UseMouseDownAndUpInsteadOfClick, "
+                "use touch_down/touch_move/touch_up instead"
+             << VAR(x1) << VAR(y1) << VAR(x2) << VAR(y2) << VAR(duration);
+    return false;
+}
+
+bool NoneInput::touch_down(int contact, int x, int y, int pressure)
+{
+    std::ignore = contact;
+    std::ignore = x;
+    std::ignore = y;
+    std::ignore = pressure;
+
+    return true;
+}
+
+bool NoneInput::touch_move(int contact, int x, int y, int pressure)
+{
+    std::ignore = contact;
+    std::ignore = x;
+    std::ignore = y;
+    std::ignore = pressure;
+
+    return true;
+}
+
+bool NoneInput::touch_up(int contact)
+{
+    std::ignore = contact;
+    return true;
+}
+
+bool NoneInput::click_key(int key)
+{
+    std::ignore = key;
+    return true;
+}
+
+bool NoneInput::input_text(const std::string& text)
+{
+    std::ignore = text;
+    return true;
+}
+
+bool NoneInput::key_down(int key)
+{
+    std::ignore = key;
+    return true;
+}
+
+bool NoneInput::key_up(int key)
+{
+    std::ignore = key;
+    return true;
+}
+
+bool NoneInput::scroll(int dx, int dy)
+{
+    std::ignore = dx;
+    std::ignore = dy;
+    return true;
+}
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaLinuxControlUnit/Input/NoneInput.h
+++ b/source/MaaLinuxControlUnit/Input/NoneInput.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Base/UnitBase.h"
+#include "Common/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+class NoneInput : public InputBase
+{
+public:
+    explicit NoneInput() = default;
+
+    virtual ~NoneInput() override = default;
+
+    MaaControllerFeature get_features() const override;
+    bool click(int x, int y) override;
+    bool swipe(int x1, int y1, int x2, int y2, int duration) override;
+    bool touch_down(int contact, int x, int y, int pressure) override;
+    bool touch_move(int contact, int x, int y, int pressure) override;
+    bool touch_up(int contact) override;
+    bool click_key(int key) override;
+    bool input_text(const std::string& text) override;
+    bool key_down(int key) override;
+    bool key_up(int key) override;
+    bool scroll(int dx, int dy) override;
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaLinuxControlUnit/Input/UInput.cpp
+++ b/source/MaaLinuxControlUnit/Input/UInput.cpp
@@ -403,7 +403,7 @@ bool UInput::create_device()
 
     // Configure the uinput device using the traditional uinput_user_dev struct.
     uinput_user_dev udev = { };
-    std::strncpy(udev.name, "MaaFramework KWin Virtual Input", sizeof(udev.name) - 1);
+    std::strncpy(udev.name, "MaaFramework Virtual Input", sizeof(udev.name) - 1);
     udev.id.bustype = BUS_VIRTUAL;
     udev.id.vendor = 0x3255;
     udev.id.product = 0x7999;

--- a/source/MaaLinuxControlUnit/Manager/LinuxControlUnitMgr.cpp
+++ b/source/MaaLinuxControlUnit/Manager/LinuxControlUnitMgr.cpp
@@ -1,8 +1,10 @@
 #include "LinuxControlUnitMgr.h"
 
+#include "Input/NoneInput.h"
 #include "Input/UInput.h"
 #include "Input/VkToEvdev.h"
 #include "Input/WlrInput.h"
+#include "Screencap/NoneScreencap.h"
 #include "Screencap/PipeWireScreencap.h"
 #include "Screencap/WlrScreencap.h"
 
@@ -266,6 +268,9 @@ json::object LinuxControlUnitMgr::get_info() const
 bool LinuxControlUnitMgr::init_screencap()
 {
     switch (config_.screencap_method) {
+    case MaaLinuxScreencapMethod_None:
+        screencap_ = std::make_shared<NoneScreencap>();
+        return true;
     case MaaLinuxScreencapMethod_Wlr:
         screencap_ = std::make_shared<WlrScreencap>(wl_client_);
         return true;
@@ -285,6 +290,9 @@ bool LinuxControlUnitMgr::init_screencap()
 bool LinuxControlUnitMgr::init_input()
 {
     switch (config_.input_method) {
+    case MaaLinuxInputMethod_None:
+        input_ = std::make_shared<NoneInput>();
+        return true;
     case MaaLinuxInputMethod_Wlr:
         input_ = std::make_shared<WlrInput>(wl_client_);
         return true;

--- a/source/MaaLinuxControlUnit/Screencap/NoneScreencap.h
+++ b/source/MaaLinuxControlUnit/Screencap/NoneScreencap.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Base/UnitBase.h"
+#include "Common/Conf.h"
+
+MAA_CTRL_UNIT_NS_BEGIN
+
+class NoneScreencap : public ScreencapBase
+{
+public:
+    explicit NoneScreencap() = default;
+
+    virtual ~NoneScreencap() override = default;
+
+    std::optional<cv::Mat> screencap() override { return cv::Mat(); }
+};
+
+MAA_CTRL_UNIT_NS_END

--- a/source/MaaLinuxControlUnit/Screencap/NoneScreencap.h
+++ b/source/MaaLinuxControlUnit/Screencap/NoneScreencap.h
@@ -12,7 +12,7 @@ public:
 
     virtual ~NoneScreencap() override = default;
 
-    std::optional<cv::Mat> screencap() override { return cv::Mat(); }
+    std::optional<cv::Mat> screencap() override { return std::nullopt; }
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.cpp
+++ b/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.cpp
@@ -157,6 +157,13 @@ std::optional<cv::Mat> PipeWireScreencap::screencap()
         return std::nullopt;
     }
 
+    if (!stream_active_) {
+        pw_thread_loop_lock(pw_thread_loop_);
+        pw_stream_set_active(pw_stream_, true);
+        pw_thread_loop_unlock(pw_thread_loop_);
+        stream_active_ = true;
+    }
+
     // Wait for the first frame with a timeout.
     // Subsequent calls return the cached frame immediately without waiting.
     std::unique_lock<std::mutex> lock(frame_mutex_);
@@ -171,6 +178,23 @@ std::optional<cv::Mat> PipeWireScreencap::screencap()
     latest_frame_.copyTo(target);
     std::optional ret(target);
     return ret;
+}
+
+void PipeWireScreencap::inactive()
+{
+    ScreencapBase::inactive();
+    if (!pw_stream_ || !pw_thread_loop_ || !stream_active_) {
+        return;
+    }
+    {
+        std::lock_guard lock(frame_mutex_);
+        latest_frame_ = cv::Mat();
+        frame_available_ = false;
+    }
+    pw_thread_loop_lock(pw_thread_loop_);
+    pw_stream_set_active(pw_stream_, false);
+    pw_thread_loop_unlock(pw_thread_loop_);
+    stream_active_ = false;
 }
 
 // ===========================================================================

--- a/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.h
+++ b/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.h
@@ -45,7 +45,7 @@ class PipeWireScreencap : public ScreencapBase
 {
 public:
     explicit PipeWireScreencap(int pipewire_fd, uint32_t pipewire_node_id, int screen_width, int screen_height);
-    ~PipeWireScreencap();
+    ~PipeWireScreencap() override;
 
     PipeWireScreencap(const PipeWireScreencap&) = delete;
     PipeWireScreencap& operator=(const PipeWireScreencap&) = delete;

--- a/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.h
+++ b/source/MaaLinuxControlUnit/Screencap/PipeWireScreencap.h
@@ -56,6 +56,8 @@ public:
 
     std::optional<cv::Mat> screencap() override;
 
+    void inactive() override;
+
 private:
     /* ---- Internal cleanup ---- */
     void close_internal();
@@ -114,6 +116,7 @@ private:
     cv::Mat latest_frame_;
     bool frame_available_ = false;
     std::condition_variable frame_cv_;
+    bool stream_active_ = true;
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaLinuxControlUnit/Wayland/WaylandHelper.cpp
+++ b/source/MaaLinuxControlUnit/Wayland/WaylandHelper.cpp
@@ -9,7 +9,7 @@
     {                                                        \
     void default_delete<TypeName>::operator()(TypeName* ptr) \
     {                                                        \
-        LogDebug << "Delete protocol";                       \
+        LogDebug << "Delete protocol " #TypeName;            \
         DeleteFunction(ptr);                                 \
     }                                                        \
     }

--- a/source/MaaLinuxControlUnit/Wayland/WaylandHelper.cpp
+++ b/source/MaaLinuxControlUnit/Wayland/WaylandHelper.cpp
@@ -4,12 +4,12 @@
 
 #include <linux/input-event-codes.h>
 
-#define DEFAULT_DELETER(TypeName, DeleteFunction)            \
-    namespace std                                            \
-    {                                                        \
-    void default_delete<TypeName>::operator()(TypeName* ptr) \
-    {                                                        \
-        LogDebug << "Delete protocol " #TypeName;            \
+#define DEFAULT_DELETER(TypeName, DeleteFunction)                   \
+    namespace std                                                   \
+    {                                                               \
+    void default_delete<TypeName>::operator()(TypeName* ptr)        \
+    {                                                               \
+        LogDebug << "Delete protocol " #TypeName << VAR_VOIDP(ptr); \
         DeleteFunction(ptr);                                 \
     }                                                        \
     }

--- a/test/linux_test/CMakeLists.txt
+++ b/test/linux_test/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_executable(portal_test portal_test.cpp)
+add_executable(pw_screencap_test pw_screencap_test.cpp)
 
 target_link_libraries(portal_test MaaFramework MaaToolkit)
+target_link_libraries(pw_screencap_test MaaFramework MaaToolkit)

--- a/test/linux_test/pw_screencap_test.cpp
+++ b/test/linux_test/pw_screencap_test.cpp
@@ -1,8 +1,7 @@
-#include "MaaFramework/Instance/MaaController.h"
-#include "MaaFramework/Utility/MaaBuffer.h"
-
 #include <iostream>
+#include <thread>
 
+#include "MaaFramework/MaaAPI.h"
 #include "MaaToolkit/MaaToolkitAPI.h"
 
 //
@@ -44,9 +43,11 @@ int main()
     MaaControllerWait(ctrl, ctrl_id);
     ctrl_id = MaaControllerPostScreencap(ctrl);
     MaaControllerWait(ctrl, ctrl_id);
-    auto imgbuf = MaaImageBufferCreate(); // Add breakpoint at here to view image
-    auto img = MaaControllerCachedImage(ctrl, imgbuf);
-    if (!img) {
+    MaaControllerPostInactive(ctrl);
+    std::this_thread::sleep_for(std::chrono::seconds(5)); // test inactive
+    auto image_buffer = MaaImageBufferCreate();           // Add breakpoint at here to view image
+    auto image_result = MaaControllerCachedImage(ctrl, image_buffer);
+    if (!image_result) {
         destroy();
         return -1;
     }

--- a/test/linux_test/pw_screencap_test.cpp
+++ b/test/linux_test/pw_screencap_test.cpp
@@ -1,0 +1,55 @@
+#include "MaaFramework/Instance/MaaController.h"
+#include "MaaFramework/Utility/MaaBuffer.h"
+
+#include <iostream>
+
+#include "MaaToolkit/MaaToolkitAPI.h"
+
+//
+// Created by free on 8/8/26.
+//
+int main()
+{
+    const auto helper = MaaToolkitPortalHelperCreate();
+    std::string restore_token;
+    std::cout << "Input Restore Token, press Enter to skip: ";
+    getline(std::cin, restore_token);
+    if (!restore_token.empty()) {
+        MaaToolkitPortalHelperSetRestoreToken(helper, restore_token.c_str());
+    }
+    MaaToolkitPortalHelperSetPersist(helper, true);
+    if (!MaaToolkitPortalHelperOpenStream(helper)) {
+        std::cerr << "Failed to open PipeWire Stream" << std::endl;
+        return -1;
+    }
+    auto pw_socket_fd = MaaToolkitPortalHelperGetPipeWireFD(helper);
+    auto pw_node_id = MaaToolkitPortalHelperGetPipeWireNodeID(helper);
+    auto restore = MaaToolkitPortalHelperGetRestoreToken(helper);
+    std::cout << "Socket FD: " << pw_socket_fd << std::endl;
+    std::cout << "Node ID: " << pw_node_id << std::endl;
+    if (restore != nullptr) {
+        std::cout << "Restore Token: " << restore << std::endl;
+    }
+    auto ctrl = MaaLinuxControllerCreate(
+        std::format(
+            R"({{"screencap_method":4,"input_method":0, "pw_socket_fd":{}, "pw_node_id":{}, "pw_screen_width":1920, "pw_screen_height":1080}})",
+            pw_socket_fd,
+            pw_node_id)
+            .c_str());
+    auto destroy = [&]() {
+        MaaControllerDestroy(ctrl);
+        MaaToolkitPortalHelperDestroy(helper);
+    };
+    auto ctrl_id = MaaControllerPostConnection(ctrl);
+    MaaControllerWait(ctrl, ctrl_id);
+    ctrl_id = MaaControllerPostScreencap(ctrl);
+    MaaControllerWait(ctrl, ctrl_id);
+    auto imgbuf = MaaImageBufferCreate(); // Add breakpoint at here to view image
+    auto img = MaaControllerCachedImage(ctrl, imgbuf);
+    if (!img) {
+        destroy();
+        return -1;
+    }
+    destroy();
+    return 0;
+}


### PR DESCRIPTION
* 在协议析构时增加名称和指针
* 修改 uinput 虚拟设备名称
* 增加 None 采集/输入实现方便测试
* 增加 pw_screencap_test 用于测试 PipeWire 采集
* PipeWire 支持暂停采集，节省资源

## Summary by Sourcery

在 Linux 端新增测试工具和空操作（no-op）控制器实现，并改进 PipeWire 和 Wayland 的处理。

New Features:
- 引入 `NoneInput` 和 `NoneScreencap` 实现，以便在测试中提供空操作输入与空操作屏幕捕获。
- 添加 `pw_screencap_test` 可执行文件，用于通过 portal helper 运行 PipeWire 屏幕捕获测试。

Enhancements:
- 允许 PipeWire 屏幕捕获通过“非活动（inactive）”状态进行暂停和恢复，以释放资源并清理缓存帧。
- 在 Wayland 协议对象删除时记录类型名和指针，便于调试。
- 将 uinput 虚拟设备名称更新为通用的 `MaaFramework Virtual Input` 标签。

Build:
- 扩展 `linux_test` 的 CMake 配置，以构建并链接新的 `pw_screencap_test` 目标。

Tests:
- 添加一个 Linux PipeWire 屏幕捕获测试程序，用于驱动控制器并验证非活动行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Linux-side test utilities and no-op controller implementations, and improve PipeWire and Wayland handling.

New Features:
- Introduce NoneInput and NoneScreencap implementations to allow no-op input and capture for testing.
- Add a pw_screencap_test executable to exercise PipeWire screencap via the portal helper.

Enhancements:
- Allow PipeWire screencap to be paused and resumed via an inactive state to release resources and clear cached frames.
- Log Wayland protocol deletions with type name and pointer for easier debugging.
- Update the uinput virtual device name to a generic MaaFramework Virtual Input label.

Build:
- Extend linux_test CMake configuration to build and link the new pw_screencap_test target.

Tests:
- Add a Linux PipeWire screencap test program that drives the controller and validates inactive behavior.

</details>