### PR TITLE
fix(win32): 截图前让 WithWindowPos 窗口避开物理鼠标

### DIFF
--- a/source/MaaWin32ControlUnit/Base/UnitBase.h
+++ b/source/MaaWin32ControlUnit/Base/UnitBase.h
@@ -15,6 +15,8 @@ public:
     virtual ~ScreencapBase() = default;
 
 public:
+    virtual void prepare_screencap() { }
+
     virtual std::optional<cv::Mat> screencap() = 0;
 
     virtual void inactive() { }

--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -10,12 +10,79 @@
 #include "InputUtils.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <mmsystem.h>
+#include <optional>
 
 MAA_CTRL_UNIT_NS_BEGIN
 
 namespace
 {
+
+constexpr LONG CursorParkingMargin = 8;
+
+struct WindowParkingCandidate
+{
+    LONG left = 0;
+    LONG top = 0;
+    long long overflow = 0;
+    long long movement = 0;
+    bool preferred = false;
+};
+
+LONG fit_window_axis(LONG current, LONG bound_begin, LONG bound_end, LONG size)
+{
+    const LONG available = bound_end - bound_begin;
+    if (size >= available) {
+        return bound_begin;
+    }
+    return std::clamp(current, bound_begin, bound_end - size);
+}
+
+long long rect_overflow(const RECT& rect, const RECT& bounds)
+{
+    return static_cast<long long>(std::max(bounds.left - rect.left, 0L)) + static_cast<long long>(std::max(bounds.top - rect.top, 0L))
+           + static_cast<long long>(std::max(rect.right - bounds.right, 0L))
+           + static_cast<long long>(std::max(rect.bottom - bounds.bottom, 0L));
+}
+
+std::optional<WindowParkingCandidate> make_parking_candidate(
+    LONG left,
+    LONG top,
+    bool preferred,
+    const POINT& cursor,
+    const RECT& window_rect,
+    const RECT& client_rect,
+    const RECT& monitor_rect)
+{
+    RECT predicted_window = window_rect;
+    OffsetRect(&predicted_window, left - window_rect.left, top - window_rect.top);
+
+    RECT predicted_client = client_rect;
+    OffsetRect(&predicted_client, left - window_rect.left, top - window_rect.top);
+    if (PtInRect(&predicted_client, cursor)) {
+        return std::nullopt;
+    }
+
+    return WindowParkingCandidate {
+        .left = left,
+        .top = top,
+        .overflow = rect_overflow(predicted_window, monitor_rect),
+        .movement = std::abs(static_cast<long long>(left) - window_rect.left) + std::abs(static_cast<long long>(top) - window_rect.top),
+        .preferred = preferred,
+    };
+}
+
+void select_parking_candidate(std::optional<WindowParkingCandidate>& best, std::optional<WindowParkingCandidate> candidate)
+{
+    if (!candidate) {
+        return;
+    }
+    if (!best || candidate->overflow < best->overflow || (candidate->overflow == best->overflow && candidate->preferred && !best->preferred)
+        || (candidate->overflow == best->overflow && candidate->preferred == best->preferred && candidate->movement < best->movement)) {
+        best = candidate;
+    }
+}
 
 struct NtDllHolder : public LibraryHolder<NtDllHolder>
 {
@@ -203,6 +270,8 @@ void MessageInput::restore_window_pos()
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
+    std::scoped_lock lock(window_move_mutex_);
+
     LONG left = saved_window_rect_.left;
     LONG top = saved_window_rect_.top;
 
@@ -352,6 +421,8 @@ bool MessageInput::move_window_to_align_cursor(int x, int y)
         return false;
     }
 
+    std::scoped_lock lock(window_move_mutex_);
+
     POINT cursor_pos;
     if (!GetCursorPos(&cursor_pos)) {
         LogError << "GetCursorPos failed" << VAR(GetLastError());
@@ -389,6 +460,244 @@ bool MessageInput::move_window_to_align_cursor(int x, int y)
     }
 
     return true;
+}
+
+bool MessageInput::get_client_screen_rect(RECT& rect) const
+{
+    RECT client_rect = { };
+    if (!GetClientRect(hwnd_, &client_rect)) {
+        LogError << "GetClientRect failed" << VAR(hwnd_) << VAR(GetLastError());
+        return false;
+    }
+
+    POINT top_left = { client_rect.left, client_rect.top };
+    POINT bottom_right = { client_rect.right, client_rect.bottom };
+    if (!ClientToScreen(hwnd_, &top_left) || !ClientToScreen(hwnd_, &bottom_right)) {
+        LogError << "ClientToScreen failed while getting client rect" << VAR(hwnd_) << VAR(GetLastError());
+        return false;
+    }
+
+    rect = { top_left.x, top_left.y, bottom_right.x, bottom_right.y };
+    return true;
+}
+
+bool MessageInput::find_window_parking_position(
+    const POINT& cursor,
+    const RECT& window_rect,
+    const RECT& client_rect,
+    LONG& out_left,
+    LONG& out_top) const
+{
+    RECT anchor_rect = window_pos_saved_ ? saved_window_rect_ : window_rect;
+    HMONITOR monitor = MonitorFromRect(&anchor_rect, MONITOR_DEFAULTTONEAREST);
+    if (!monitor) {
+        LogError << "MonitorFromRect failed while parking window";
+        return false;
+    }
+
+    MONITORINFO monitor_info { sizeof(MONITORINFO) };
+    if (!GetMonitorInfoW(monitor, &monitor_info)) {
+        LogError << "GetMonitorInfoW failed while parking window" << VAR(GetLastError());
+        return false;
+    }
+
+    const LONG window_width = window_rect.right - window_rect.left;
+    const LONG window_height = window_rect.bottom - window_rect.top;
+    const LONG client_width = client_rect.right - client_rect.left;
+    const LONG client_height = client_rect.bottom - client_rect.top;
+    const LONG client_offset_x = client_rect.left - window_rect.left;
+    const LONG client_offset_y = client_rect.top - window_rect.top;
+    const RECT& monitor_rect = monitor_info.rcMonitor;
+
+    const LONG fitted_left = fit_window_axis(window_rect.left, monitor_rect.left, monitor_rect.right, window_width);
+    const LONG fitted_top = fit_window_axis(window_rect.top, monitor_rect.top, monitor_rect.bottom, window_height);
+
+    std::optional<WindowParkingCandidate> best;
+    if (window_pos_saved_) {
+        select_parking_candidate(
+            best,
+            make_parking_candidate(saved_window_rect_.left, saved_window_rect_.top, true, cursor, window_rect, client_rect, monitor_rect));
+    }
+    select_parking_candidate(
+        best,
+        make_parking_candidate(window_rect.left, window_rect.top, false, cursor, window_rect, client_rect, monitor_rect));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            cursor.x + CursorParkingMargin - client_offset_x,
+            fitted_top,
+            false,
+            cursor,
+            window_rect,
+            client_rect,
+            monitor_rect));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            cursor.x - CursorParkingMargin - client_width - client_offset_x,
+            fitted_top,
+            false,
+            cursor,
+            window_rect,
+            client_rect,
+            monitor_rect));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            cursor.y + CursorParkingMargin - client_offset_y,
+            false,
+            cursor,
+            window_rect,
+            client_rect,
+            monitor_rect));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            cursor.y - CursorParkingMargin - client_height - client_offset_y,
+            false,
+            cursor,
+            window_rect,
+            client_rect,
+            monitor_rect));
+
+    if (!best) {
+        LogError << "Failed to find a cursor-free window position" << VAR(cursor.x) << VAR(cursor.y);
+        return false;
+    }
+
+    out_left = best->left;
+    out_top = best->top;
+    return true;
+}
+
+void MessageInput::send_mouse_leave()
+{
+    HWND target = get_active_hwnd();
+    if (!send_or_post_w(target, WM_MOUSELEAVE, 0, 0)) {
+        LogWarn << "Failed to send WM_MOUSELEAVE while parking window" << VAR(target);
+    }
+    if (target != hwnd_ && !send_or_post_w(hwnd_, WM_MOUSELEAVE, 0, 0)) {
+        LogWarn << "Failed to send WM_MOUSELEAVE to root window while parking" << VAR(hwnd_);
+    }
+}
+
+void MessageInput::wait_for_window_tracking_to_stop()
+{
+    if (!tracking_active_.load()) {
+        return;
+    }
+
+    request_stop_window_tracking();
+    const auto deadline = TrackingClock::now() + std::chrono::milliseconds(40);
+    while (tracking_active_.load() && TrackingClock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    if (!tracking_active_.load()) {
+        return;
+    }
+
+    LogWarn << "Window tracking did not stop within grace period, forcing stop";
+    if (has_pending_mouse_.load()) {
+        process_pending_mouse_frame();
+    }
+    stop_window_tracking();
+}
+
+bool MessageInput::park_window_away_from_cursor()
+{
+    if (!config_.with_window_pos || mouse_lock_follow_active_.load()) {
+        return true;
+    }
+    if (!hwnd_ || !IsWindow(hwnd_)) {
+        LogError << "Cannot park invalid window" << VAR(hwnd_);
+        return false;
+    }
+    if (mouse_down_sent_.load()) {
+        LogWarn << "Skip parking window while a mouse contact is active";
+        return false;
+    }
+
+    wait_for_window_tracking_to_stop();
+
+    auto prev_dpi_ctx = SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    OnScopeLeave([&]() {
+        if (prev_dpi_ctx) {
+            SetThreadDpiAwarenessContext(prev_dpi_ctx);
+        }
+    });
+
+    std::scoped_lock lock(window_move_mutex_);
+    save_window_pos();
+
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        POINT cursor = { };
+        RECT window_rect = { };
+        RECT client_rect = { };
+        if (!GetCursorPos(&cursor)) {
+            LogError << "GetCursorPos failed while parking window" << VAR(GetLastError());
+            return false;
+        }
+        if (!GetWindowRect(hwnd_, &window_rect)) {
+            LogError << "GetWindowRect failed while parking window" << VAR(hwnd_) << VAR(GetLastError());
+            return false;
+        }
+        if (!get_client_screen_rect(client_rect)) {
+            return false;
+        }
+
+        LONG new_left = 0;
+        LONG new_top = 0;
+        if (!find_window_parking_position(cursor, window_rect, client_rect, new_left, new_top)) {
+            return false;
+        }
+
+        const bool needs_move = std::abs(new_left - window_rect.left) > 1 || std::abs(new_top - window_rect.top) > 1;
+        if (needs_move
+            && !SetWindowPos(
+                hwnd_,
+                nullptr,
+                new_left,
+                new_top,
+                0,
+                0,
+                SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
+            LogError << "SetWindowPos failed while parking window" << VAR(hwnd_) << VAR(new_left) << VAR(new_top) << VAR(GetLastError());
+            return false;
+        }
+
+        if (needs_move) {
+            for (int settle_attempt = 0; settle_attempt < 10; ++settle_attempt) {
+                RECT settled_rect = { };
+                if (GetWindowRect(hwnd_, &settled_rect) && std::abs(settled_rect.left - new_left) <= 1
+                    && std::abs(settled_rect.top - new_top) <= 1) {
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            }
+        }
+
+        send_mouse_leave();
+        if (needs_move) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(17));
+        }
+
+        POINT current_cursor = { };
+        RECT current_client_rect = { };
+        if (GetCursorPos(&current_cursor) && get_client_screen_rect(current_client_rect)
+            && !PtInRect(&current_client_rect, current_cursor)) {
+            if (needs_move) {
+                LogInfo << "Parked window away from cursor" << VAR(new_left) << VAR(new_top) << VAR(current_cursor.x)
+                        << VAR(current_cursor.y);
+            }
+            return true;
+        }
+    }
+
+    LogWarn << "Cursor re-entered target window while parking";
+    return false;
 }
 
 bool MessageInput::is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason)
@@ -617,6 +926,11 @@ void MessageInput::resume_target_process()
 
 void MessageInput::process_pending_mouse_frame()
 {
+    std::scoped_lock lock(window_move_mutex_);
+    if (!tracking_active_.load()) {
+        return;
+    }
+
     has_pending_mouse_ = false;
 
     // 原子读取并清零累积的 delta（exchange 保证不丢失并发写入）
@@ -1051,9 +1365,12 @@ bool MessageInput::touch_up(int contact)
         return false;
     }
 
-    // touch_up 后继续黏住窗口一小段时间，再由 tracking 线程自行结束。
+    mouse_down_sent_ = false;
+
     if (config_.with_window_pos) {
-        request_stop_window_tracking();
+        if (!park_window_away_from_cursor()) {
+            LogWarn << "Failed to park target window after touch up";
+        }
     }
     else {
         finish_pos();
@@ -1171,7 +1488,9 @@ bool MessageInput::scroll(int dx, int dy)
     }
 
     if (config_.with_window_pos) {
-        request_stop_window_tracking();
+        if (!park_window_away_from_cursor()) {
+            LogWarn << "Failed to park target window after scroll";
+        }
     }
     else {
         finish_pos();
@@ -1442,6 +1761,11 @@ void MessageInput::deactivate_mouse_lock_follow()
 
 void MessageInput::process_mouse_lock_follow_frame()
 {
+    std::scoped_lock lock(window_move_mutex_);
+    if (!tracking_active_.load() || !mouse_lock_follow_active_.load()) {
+        return;
+    }
+
     has_pending_mouse_ = false;
 
     int dx = pending_mouse_x_.exchange(0);

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -60,6 +60,9 @@ public: // from InputBase
 public: // mouse lock follow
     bool set_mouse_lock_follow(bool enabled);
 
+    // WithWindowPos 模式下让目标窗口避开当前物理鼠标，避免目标应用自绘光标进入截图。
+    bool park_window_away_from_cursor();
+
     // WithWindowPos 模式下默认禁用显示器保护，因为后台控制器需要自由移动窗口。
     // 如需恢复保护，调用 set_window_pos_guard_enabled(true)。
     void set_window_pos_guard_enabled(bool enabled) { window_pos_guard_enabled_ = enabled; }
@@ -79,6 +82,11 @@ private:
 
     // WithWindowPos 模式：移动窗口使客户区坐标 (x,y) 与当前鼠标位置重合
     bool move_window_to_align_cursor(int x, int y);
+    bool get_client_screen_rect(RECT& rect) const;
+    bool find_window_parking_position(const POINT& cursor, const RECT& window_rect, const RECT& client_rect, LONG& out_left, LONG& out_top)
+        const;
+    void send_mouse_leave();
+    void wait_for_window_tracking_to_stop();
     bool is_window_move_allowed(int new_left, int new_top, const RECT& current_rect, const char* reason);
     void abort_windowpos_operation(const char* reason);
     void reset_windowpos_guard_state();
@@ -171,6 +179,7 @@ private:
     HWND rawinput_hwnd_ = nullptr;
     std::atomic_int counter_pending_ = 0;
     std::mutex tracking_state_mutex_;
+    std::mutex window_move_mutex_;
     std::condition_variable tracking_state_cv_;
     bool tracking_thread_init_done_ = false;
     bool tracking_thread_init_ok_ = false;

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -189,12 +189,14 @@ std::shared_ptr<ScreencapBase>
 
     for (auto& [method, unit] : units) {
         LogInfo << "Warming up" << method;
+        unit->prepare_screencap();
         if (!unit->screencap()) {
             LogWarn << "failed to warm up" << method;
         }
 
         LogInfo << "Testing" << method;
         auto now = std::chrono::steady_clock::now();
+        unit->prepare_screencap();
         if (!unit->screencap()) {
             LogWarn << "failed to test" << method;
             continue;
@@ -271,6 +273,13 @@ bool Win32ControlUnitMgr::screencap(cv::Mat& image)
     if (!screencap_) {
         LogError << "screencap_ is null";
         return false;
+    }
+
+    screencap_->prepare_screencap();
+
+    auto message_input = std::dynamic_pointer_cast<MessageInput>(mouse_);
+    if (message_input && !message_input->park_window_away_from_cursor()) {
+        LogWarn << "Failed to park target window away from cursor before screencap";
     }
 
     auto opt = screencap_->screencap();

--- a/source/MaaWin32ControlUnit/Screencap/FramePoolWithPseudoMinimizeScreencap.h
+++ b/source/MaaWin32ControlUnit/Screencap/FramePoolWithPseudoMinimizeScreencap.h
@@ -20,11 +20,9 @@ public:
     virtual ~FramePoolWithPseudoMinimizeScreencap() override = default;
 
 public: // from ScreencapBase
-    virtual std::optional<cv::Mat> screencap() override
-    {
-        helper_.ensure_not_minimized();
-        return inner_.screencap();
-    }
+    virtual void prepare_screencap() override { helper_.ensure_not_minimized(); }
+
+    virtual std::optional<cv::Mat> screencap() override { return inner_.screencap(); }
 
     virtual void inactive() override
     {

--- a/source/MaaWin32ControlUnit/Screencap/PrintWindowWithPseudoMinimizeScreencap.h
+++ b/source/MaaWin32ControlUnit/Screencap/PrintWindowWithPseudoMinimizeScreencap.h
@@ -20,11 +20,9 @@ public:
     virtual ~PrintWindowWithPseudoMinimizeScreencap() override = default;
 
 public: // from ScreencapBase
-    virtual std::optional<cv::Mat> screencap() override
-    {
-        helper_.ensure_not_minimized();
-        return inner_.screencap();
-    }
+    virtual void prepare_screencap() override { helper_.ensure_not_minimized(); }
+
+    virtual std::optional<cv::Mat> screencap() override { return inner_.screencap(); }
 
     virtual void inactive() override
     {


### PR DESCRIPTION
## 概述

- `SendMessageWithWindowPos` 完成点击或滚动后，将目标窗口停放到当前物理鼠标之外，并发送 `WM_MOUSELEAVE`，避免目标应用自绘光标或点击效果停留在刚点击的识别区域。
- 每次截图前再次检查物理鼠标位置；如果用户把鼠标移回目标窗口，则重新停放窗口后再截图。
- 控制器进入 inactive 状态时恢复原始窗口位置；伪最小化截图会先恢复到可操作状态，再执行截图前停放。

## 背景与根因

在 `SendMessageWithWindowPos` 模式下，框架会移动目标窗口，使目标客户区坐标与真实鼠标位置对齐后发送鼠标消息。部分 PC 应用会根据这些消息自行渲染光标或点击动画；这些内容已经成为应用画面的一部分，无法通过关闭截图会话的系统光标捕获来移除，并可能遮挡后续图像识别区域。

该问题最初在 MAA 任务层尝试规避，后续实机测试确认应在 Win32 输入层通用处理。本 PR 不再针对单个任务或模板做兼容。

## 实现范围

- 仅作用于 `WithWindowPos` 鼠标模式。
- 鼠标锁定跟随开启或仍有活动触点时不会停放窗口。
- 等待窗口跟踪线程结束后再移动，避免覆盖用户最后一段真实鼠标移动。
- 在当前显示器内优先选择避开鼠标的位置；用户移动鼠标时最多重新检查三次。
- 截图完成前只在确实移动窗口时等待一帧；断开时恢复已保存的位置。

## 验证

- [x] `git diff --check`
- [x] Windows x64 Release：`cmake --build build-local --config Release --target MaaWin32ControlUnit`
- [x] 独立 Win32 回归探针：点击后光标位于客户区外，应用自绘光标被清除
- [x] 用户把物理鼠标移回客户区后，下一次截图会再次停放并清除自绘光标
- [x] inactive 后恢复原始窗口位置
- [x] PC 客户端 1280×720、UI 100%、WGC + `SendMessageWithWindowPos` 实机连续任务验证稳定
- [ ] GitHub CI

## 相关内容

Follow-up to MaaAssistantArknights/MaaAssistantArknights#17620.

更正后的根因与现场证据：
https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17620#issuecomment-5228049504

## Summary by Sourcery

在 Win32 的 WithWindowPos 模式下，在输入之后、截图之前，将目标窗口“停放”到远离物理鼠标的位置，避免应用程序绘制的光标或点击效果出现在截图中，同时保留窗口原始位置，并与窗口跟踪和伪最小化行为进行协调。

New Features:
- 在 WithWindowPos 模式中添加窗口停放逻辑，将目标窗口移动到当前物理光标之外的位置，并在合成输入完成后发送 `WM_MOUSELEAVE`。
- 引入一个截图前的钩子，在抓取帧之前恢复伪最小化窗口并触发窗口停放。

Bug Fixes:
- 在使用 `SendMessageWithWindowPos` 输入时，防止应用程序渲染的光标和点击动画残留到后续截图中。
- 通过使用专用互斥量串行化窗口移动，并在重新定位之前等待跟踪停止，避免窗口跟踪、鼠标锁定跟随以及手动移动窗口之间的竞态条件。

Enhancements:
- 通过在当前显示器内选择无光标的停放位置，并基于溢出和移动成本进行评估，同时遵循之前保存的窗口位置，优化窗口定位。
- 确保窗口跟踪和鼠标锁定跟随的处理逻辑遵守新的窗口移动同步机制和提前退出条件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Park Win32 WithWindowPos target windows away from the physical mouse after input and before screenshots to prevent app-drawn cursors or click effects from appearing in captures, while preserving original window position and coordinating with tracking and pseudo-minimize behavior.

New Features:
- Add window parking logic in WithWindowPos mode to relocate the target window away from the current physical cursor and send WM_MOUSELEAVE after synthetic input.
- Introduce a pre-screencap hook that restores pseudo-minimized windows and triggers window parking before capturing frames.

Bug Fixes:
- Prevent application-rendered cursors and click animations from lingering in subsequent screenshots when using SendMessageWithWindowPos input.
- Avoid race conditions between window tracking, mouse lock follow, and manual window moves by serializing moves with a dedicated mutex and waiting for tracking to stop before repositioning.

Enhancements:
- Refine window positioning by selecting cursor-free parking positions within the current monitor based on overflow and movement cost while honoring any previously saved window position.
- Ensure window tracking and mouse lock follow processing respects the new window move synchronization and early-exit conditions.

</details>