### PR TITLE
feat: 日志文件支持设置等级与清理时间

### DIFF
--- a/docs/en_us/1.1-QuickStarted.md
+++ b/docs/en_us/1.1-QuickStarted.md
@@ -195,6 +195,8 @@ Most tools will generate a `config/maa_option.json` file in the same directory, 
 - `logging`: Save the log and generate `debug/maafw.log`. Default true.
 - `save_draw`: Save visualized image-recognition results during runtime. Default false.
 - `stdout_level`: Console log level. Default 2 (Error); set 0 to silence logs, or 7 to show all logs.
+- `log_level`: Log file (`debug/maafw.log`) level. Default 7 (All); set 0 to write nothing to the file, or 2 to keep Error and above.
+- `log_cleanup_days`: Retention days for log and debug files. Default 7; `.log` / `.jpg` / `.png` older than this are deleted on startup. Set 0 to disable cleanup.
 - `save_on_error`: Save the current screenshot when a task fails. Default true.
 - `draw_quality`: JPEG quality for visualized image-recognition results (0-100). Default 85.
 

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -34,6 +34,12 @@ Set global options. Will be split into specific options in bindings.
 - StdoutLevel  
     Set the log output level to stdout.
 
+- LogLevel  
+    Set the log output level to the log file (maafw.log). Default value is All.
+
+- LogCleanupDays  
+    Set the retention days for log and debug files. Default value is 7; 0 disables cleanup.
+
 - DebugMode  
     Set whether to enable debug mode. In debug mode, RecoDetail can retrieve raw/draws; all tasks are treated as focus and produce callbacks.
 

--- a/docs/zh_cn/1.1-快速开始.md
+++ b/docs/zh_cn/1.1-快速开始.md
@@ -196,6 +196,8 @@ my_resource/
 - `logging`: 保存日志，会生成 `debug/maafw.log`。默认 true 。
 - `save_draw`: 保存图像识别可视化结果，会保存运行期间所有图像识别可视化结果绘制图。默认 false 。
 - `stdout_level`: 控制台显示日志等级。默认 2（Error），可设为 0 关闭全部控制台日志，或设为 7 打开全部控制台日志。
+- `log_level`: 日志文件（`debug/maafw.log`）写入等级。默认 7（All），可设为 0 关闭文件日志内容，或设为 2 仅写入 Error 及以上。
+- `log_cleanup_days`: 日志与调试文件保留天数。默认 7，超过该天数的 `.log` / `.jpg` / `.png` 会在启动时删除；设为 0 关闭清理。
 - `save_on_error`: 任务失败时保存当前截图。默认 true 。
 - `draw_quality`: 图像识别可视化结果的 JPEG 质量（0-100）。默认 85 。
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -34,6 +34,12 @@
 - StdoutLevel  
     设置日志输出到 stdout 中的级别
 
+- LogLevel  
+    设置日志输出到日志文件（maafw.log）中的级别，默认值为 All
+
+- LogCleanupDays  
+    设置日志与调试文件的保留天数，默认值为 7；0 表示不清理
+
 - DebugMode  
     设置是否启用调试模式。调试模式下，RecoDetail 将可以获取到 raw/draws；所有任务都会被视为 focus 而产生回调
 

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -126,6 +126,18 @@ enum MaaGlobalOptionEnum
     /// value: size_t, eg: 4096; val_size: sizeof(size_t)
     /// default value is 4096
     MaaGlobalOption_RecoImageCacheLimit = 9,
+
+    /// The level of log output to log file (maafw.log)
+    ///
+    /// value: MaaLoggingLevel, val_size: sizeof(MaaLoggingLevel)
+    /// default value is MaaLoggingLevel_All
+    MaaGlobalOption_LogLevel = 10,
+
+    /// Max age in days before log/debug files are deleted
+    ///
+    /// value: int32_t, eg: 7; val_size: sizeof(int32_t)
+    /// default value is 7, 0 to disable cleanup
+    MaaGlobalOption_LogCleanupDays = 11,
 };
 
 typedef MaaOption MaaResOption;

--- a/source/MaaAgentServer/Global/OptionMgr.cpp
+++ b/source/MaaAgentServer/Global/OptionMgr.cpp
@@ -14,6 +14,10 @@ bool OptionMgr::set_option(MaaGlobalOption key, MaaOptionValue value, MaaOptionV
         return set_log_dir(value, val_size);
     case MaaGlobalOption_StdoutLevel:
         return set_stdout_level(value, val_size);
+    case MaaGlobalOption_LogLevel:
+        return set_log_level(value, val_size);
+    case MaaGlobalOption_LogCleanupDays:
+        return set_log_cleanup_days(value, val_size);
     default:
         LogError << "MaaAgentServer does not support this option" << VAR(key);
         return false;
@@ -48,6 +52,46 @@ bool OptionMgr::set_stdout_level(MaaOptionValue value, MaaOptionValueSize val_si
     LogInfo << "Set log stdout level" << VAR(level);
 
     MAA_LOG_NS::Logger::get_instance().set_stdout_level(static_cast<MAA_LOG_NS::level>(level));
+
+    return true;
+}
+
+bool OptionMgr::set_log_level(MaaOptionValue value, MaaOptionValueSize val_size)
+{
+    LogFunc;
+
+    if (val_size != sizeof(MaaLoggingLevel)) {
+        LogError << "Invalid value size" << VAR(val_size);
+        return false;
+    }
+
+    MaaLoggingLevel level = *reinterpret_cast<const MaaLoggingLevel*>(value);
+
+    LogInfo << "Set log file level" << VAR(level);
+
+    MAA_LOG_NS::Logger::get_instance().set_log_level(static_cast<MAA_LOG_NS::level>(level));
+
+    return true;
+}
+
+bool OptionMgr::set_log_cleanup_days(MaaOptionValue value, MaaOptionValueSize val_size)
+{
+    LogFunc;
+
+    if (val_size != sizeof(int32_t)) {
+        LogError << "Invalid value size" << VAR(val_size);
+        return false;
+    }
+
+    int32_t days = *reinterpret_cast<const int32_t*>(value);
+    if (days < 0) {
+        LogError << "Invalid log cleanup days, should be >= 0" << VAR(days);
+        return false;
+    }
+
+    LogInfo << "Set log cleanup days" << VAR(days);
+
+    MAA_LOG_NS::Logger::get_instance().set_log_cleanup_days(days);
 
     return true;
 }

--- a/source/MaaAgentServer/Global/OptionMgr.h
+++ b/source/MaaAgentServer/Global/OptionMgr.h
@@ -21,6 +21,8 @@ private:
 private:
     bool set_log_dir(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_stdout_level(MaaOptionValue value, MaaOptionValueSize val_size);
+    bool set_log_level(MaaOptionValue value, MaaOptionValueSize val_size);
+    bool set_log_cleanup_days(MaaOptionValue value, MaaOptionValueSize val_size);
 };
 
 MAA_AGENT_SERVER_NS_END

--- a/source/MaaFramework/Global/OptionMgr.cpp
+++ b/source/MaaFramework/Global/OptionMgr.cpp
@@ -16,6 +16,10 @@ bool OptionMgr::set_option(MaaGlobalOption key, MaaOptionValue value, MaaOptionV
         return set_save_draw(value, val_size);
     case MaaGlobalOption_StdoutLevel:
         return set_stdout_level(value, val_size);
+    case MaaGlobalOption_LogLevel:
+        return set_log_level(value, val_size);
+    case MaaGlobalOption_LogCleanupDays:
+        return set_log_cleanup_days(value, val_size);
     case MaaGlobalOption_DebugMode:
         return set_debug_mode(value, val_size);
     case MaaGlobalOption_SaveOnError:
@@ -74,6 +78,46 @@ bool OptionMgr::set_stdout_level(MaaOptionValue value, MaaOptionValueSize val_si
     LogInfo << "Set log stdout level" << VAR(level);
 
     MAA_LOG_NS::Logger::get_instance().set_stdout_level(static_cast<MAA_LOG_NS::level>(level));
+
+    return true;
+}
+
+bool OptionMgr::set_log_level(MaaOptionValue value, MaaOptionValueSize val_size)
+{
+    LogFunc;
+
+    if (val_size != sizeof(MaaLoggingLevel)) {
+        LogError << "Invalid value size" << VAR(val_size);
+        return false;
+    }
+
+    MaaLoggingLevel level = *reinterpret_cast<const MaaLoggingLevel*>(value);
+
+    LogInfo << "Set log file level" << VAR(level);
+
+    MAA_LOG_NS::Logger::get_instance().set_log_level(static_cast<MAA_LOG_NS::level>(level));
+
+    return true;
+}
+
+bool OptionMgr::set_log_cleanup_days(MaaOptionValue value, MaaOptionValueSize val_size)
+{
+    LogFunc;
+
+    if (val_size != sizeof(int32_t)) {
+        LogError << "Invalid value size" << VAR(val_size);
+        return false;
+    }
+
+    int32_t days = *reinterpret_cast<const int32_t*>(value);
+    if (days < 0) {
+        LogError << "Invalid log cleanup days, should be >= 0" << VAR(days);
+        return false;
+    }
+
+    LogInfo << "Set log cleanup days" << VAR(days);
+
+    MAA_LOG_NS::Logger::get_instance().set_log_cleanup_days(days);
 
     return true;
 }

--- a/source/MaaFramework/Global/OptionMgr.h
+++ b/source/MaaFramework/Global/OptionMgr.h
@@ -39,6 +39,8 @@ private:
     bool set_log_dir(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_save_draw(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_stdout_level(MaaOptionValue value, MaaOptionValueSize val_size);
+    bool set_log_level(MaaOptionValue value, MaaOptionValueSize val_size);
+    bool set_log_cleanup_days(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_debug_mode(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_save_on_error(MaaOptionValue value, MaaOptionValueSize val_size);
     bool set_draw_quality(MaaOptionValue value, MaaOptionValueSize val_size);

--- a/source/MaaToolkit/Config/GlobalOptionConfig.cpp
+++ b/source/MaaToolkit/Config/GlobalOptionConfig.cpp
@@ -68,6 +68,8 @@ bool GlobalOptionConfig::apply_option()
 
     MaaBool ret = true;
 
+    ret &= MaaGlobalSetOption(MaaGlobalOption_LogCleanupDays, &option_.log_cleanup_days, sizeof(option_.log_cleanup_days));
+
     std::string logging_dir = option_.logging ? path_to_utf8_string(debug_dir_) : "";
     ret &= MaaGlobalSetOption(MaaGlobalOption_LogDir, static_cast<void*>(logging_dir.data()), logging_dir.size());
 
@@ -76,6 +78,8 @@ bool GlobalOptionConfig::apply_option()
     ret &= MaaGlobalSetOption(MaaGlobalOption_SaveOnError, &option_.save_on_error, sizeof(option_.save_on_error));
 
     ret &= MaaGlobalSetOption(MaaGlobalOption_StdoutLevel, &option_.stdout_level, sizeof(option_.stdout_level));
+
+    ret &= MaaGlobalSetOption(MaaGlobalOption_LogLevel, &option_.log_level, sizeof(option_.log_level));
 
     ret &= MaaGlobalSetOption(MaaGlobalOption_DrawQuality, &option_.draw_quality, sizeof(option_.draw_quality));
 

--- a/source/MaaToolkit/Config/GlobalOptionConfig.h
+++ b/source/MaaToolkit/Config/GlobalOptionConfig.h
@@ -29,9 +29,18 @@ public:
         bool save_draw = false;
         bool save_on_error = true;
         int32_t stdout_level = MaaLoggingLevel_Error;
+        int32_t log_level = MaaLoggingLevel_All;
+        int32_t log_cleanup_days = 7;
         int draw_quality = 85;
 
-        MEO_JSONIZATION(MEO_OPT logging, MEO_OPT save_draw, MEO_OPT save_on_error, MEO_OPT stdout_level, MEO_OPT draw_quality);
+        MEO_JSONIZATION(
+            MEO_OPT logging,
+            MEO_OPT save_draw,
+            MEO_OPT save_on_error,
+            MEO_OPT stdout_level,
+            MEO_OPT log_level,
+            MEO_OPT log_cleanup_days,
+            MEO_OPT draw_quality);
     };
 
 public:

--- a/source/binding/NodeJS/src/apis/global.cpp
+++ b/source/binding/NodeJS/src/apis/global.cpp
@@ -19,6 +19,36 @@ namespace
     throw maajs::MaaError { std::format("{} is not available in AgentServer builds", api) };
 }
 
+int32_t parse_logging_level(const std::string& level, const char* option)
+{
+    if (level == "Off") {
+        return MaaLoggingLevel_Off;
+    }
+    if (level == "Fatal") {
+        return MaaLoggingLevel_Fatal;
+    }
+    if (level == "Error") {
+        return MaaLoggingLevel_Error;
+    }
+    if (level == "Warn") {
+        return MaaLoggingLevel_Warn;
+    }
+    if (level == "Info") {
+        return MaaLoggingLevel_Info;
+    }
+    if (level == "Debug") {
+        return MaaLoggingLevel_Debug;
+    }
+    if (level == "Trace") {
+        return MaaLoggingLevel_Trace;
+    }
+    if (level == "All") {
+        return MaaLoggingLevel_All;
+    }
+
+    throw maajs::MaaError { std::format("Global set {} failed, invalid level {}", option, level) };
+}
+
 } // namespace
 
 std::string version_from_macro()
@@ -54,37 +84,26 @@ void set_save_on_error(bool value)
 
 void set_stdout_level(std::string level)
 {
-    int32_t value = 0;
-    if (level == "Off") {
-        value = MaaLoggingLevel_Off;
-    }
-    else if (level == "Fatal") {
-        value = MaaLoggingLevel_Fatal;
-    }
-    else if (level == "Error") {
-        value = MaaLoggingLevel_Error;
-    }
-    else if (level == "Warn") {
-        value = MaaLoggingLevel_Warn;
-    }
-    else if (level == "Info") {
-        value = MaaLoggingLevel_Info;
-    }
-    else if (level == "Debug") {
-        value = MaaLoggingLevel_Debug;
-    }
-    else if (level == "Trace") {
-        value = MaaLoggingLevel_Trace;
-    }
-    else if (level == "All") {
-        value = MaaLoggingLevel_All;
-    }
-    else {
-        throw maajs::MaaError { std::format("Global set stdout_level failed, invalid level {}", level) };
-    }
+    int32_t value = parse_logging_level(level, "stdout_level");
 
     if (!MaaGlobalSetOption(MaaGlobalOption_StdoutLevel, &value, sizeof(value))) {
         throw maajs::MaaError { "Global set stdout_level failed" };
+    }
+}
+
+void set_log_level(std::string level)
+{
+    int32_t value = parse_logging_level(level, "log_level");
+
+    if (!MaaGlobalSetOption(MaaGlobalOption_LogLevel, &value, sizeof(value))) {
+        throw maajs::MaaError { "Global set log_level failed" };
+    }
+}
+
+void set_log_cleanup_days(int value)
+{
+    if (!MaaGlobalSetOption(MaaGlobalOption_LogCleanupDays, &value, sizeof(value))) {
+        throw maajs::MaaError { "Global set log_cleanup_days failed" };
     }
 }
 
@@ -197,6 +216,8 @@ maajs::ObjectType load_global(maajs::EnvType env)
     MAA_BIND_SETTER(globalObject, "save_draw", set_save_draw);
     MAA_BIND_SETTER(globalObject, "save_on_error", set_save_on_error);
     MAA_BIND_SETTER(globalObject, "stdout_level", set_stdout_level);
+    MAA_BIND_SETTER(globalObject, "log_level", set_log_level);
+    MAA_BIND_SETTER(globalObject, "log_cleanup_days", set_log_cleanup_days);
     MAA_BIND_SETTER(globalObject, "debug_mode", set_debug_mode);
     MAA_BIND_SETTER(globalObject, "draw_quality", set_draw_quality);
     MAA_BIND_SETTER(globalObject, "reco_image_cache_limit", set_reco_image_cache_limit);

--- a/source/binding/NodeJS/src/apis/global.d.ts
+++ b/source/binding/NodeJS/src/apis/global.d.ts
@@ -10,6 +10,8 @@ declare global {
             set save_draw(value: boolean)
             set save_on_error(value: boolean)
             set stdout_level(value: StdoutLevel)
+            set log_level(value: StdoutLevel)
+            set log_cleanup_days(value: number)
             set debug_mode(value: boolean)
             set draw_quality(value: number)
             set reco_image_cache_limit(value: number)

--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -232,6 +232,18 @@ class MaaGlobalOptionEnum(IntEnum):
     # default value is 4096
     RecoImageCacheLimit = 9
 
+    # The level of log output to log file (maafw.log)
+    #
+    # value, val_size: sizeof(MaaLoggingLevel)
+    # default value is MaaLoggingLevel_All
+    LogLevel = 10
+
+    # Max age in days before log/debug files are deleted
+    #
+    # value: int, eg: 7; val_size: sizeof(int32)
+    # default value is 7, 0 to disable cleanup
+    LogCleanupDays = 11
+
 
 class MaaCtrlOptionEnum(IntEnum):
     Invalid = 0

--- a/source/binding/Python/maa/tasker.py
+++ b/source/binding/Python/maa/tasker.py
@@ -691,6 +691,48 @@ class Tasker:
         )
 
     @staticmethod
+    def set_log_level(level: LoggingLevelEnum) -> bool:
+        """设置日志输出到日志文件中的级别 / Set the log output level to log file
+
+        Args:
+            level: 日志级别 / Logging level
+
+        Returns:
+            bool: 是否成功 / Whether successful
+        """
+        clevel = MaaLoggingLevel(level)
+        return bool(
+            Library.framework().MaaGlobalSetOption(
+                MaaOption(MaaGlobalOptionEnum.LogLevel),
+                ctypes.pointer(clevel),
+                ctypes.sizeof(MaaLoggingLevel),
+            )
+        )
+
+    @staticmethod
+    def set_log_cleanup_days(days: int) -> bool:
+        """设置日志文件清理天数 / Set log file cleanup days
+
+        超过该天数的 .log/.jpg/.png 会在日志初始化时删除。0 表示不清理。默认 7 天。
+        Files older than this many days (.log/.jpg/.png) are deleted when logging starts.
+        0 disables cleanup. Default is 7.
+
+        Args:
+            days: 保留天数，0 表示不清理 / Retention days, 0 to disable cleanup
+
+        Returns:
+            bool: 是否成功 / Whether successful
+        """
+        cdays = ctypes.c_int32(days)
+        return bool(
+            Library.framework().MaaGlobalSetOption(
+                MaaOption(MaaGlobalOptionEnum.LogCleanupDays),
+                ctypes.pointer(cdays),
+                ctypes.sizeof(ctypes.c_int32),
+            )
+        )
+
+    @staticmethod
     def set_debug_mode(debug_mode: bool) -> bool:
         """设置是否启用调试模式 / Set whether to enable debug mode
 

--- a/test/nodejs/binding.ts
+++ b/test/nodejs/binding.ts
@@ -150,6 +150,8 @@ async function api_test() {
 
     maa.Global.save_draw = true
     maa.Global.stdout_level = 'All'
+    maa.Global.log_level = 'All'
+    maa.Global.log_cleanup_days = 7
     maa.Global.log_dir = '.'
 
     const devices = await maa.AdbController.find()

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -472,6 +472,8 @@ def test_tasker_api(resource: Resource, controller: DbgController):
     # 测试全局选项 (静态方法)
     Tasker.set_save_draw(True)
     Tasker.set_stdout_level(LoggingLevelEnum.All)
+    Tasker.set_log_level(LoggingLevelEnum.All)
+    Tasker.set_log_cleanup_days(7)
     log_dir = install_dir / "bin" / "debug" / "新建文件夹"
     assert Tasker.set_log_dir(log_dir)
     Tasker.set_debug_mode(True)


### PR DESCRIPTION
目的是减少日志体积：
1、可减少trace、debug日志量
2、自定义日志清除时间

## Summary by Sourcery

在框架、绑定和工具链中新增可配置的日志文件级别，以及自动清理日志/调试文件的天数。

新功能：
- 通过 C API、Python 和 NodeJS 绑定以及工具配置，提供一个全局选项，用于控制日志文件（`maafw.log`）的输出级别。
- 引入一个全局选项，用于配置日志/调试文件的保留天数，包括可禁用清理的能力，并贯穿于框架、代理服务器、绑定和工具配置中。

增强：
- 重构 NodeJS 全局 API 中的日志级别解析，将其抽取为可复用的辅助方法，在标准输出和日志文件级别之间共享。
- 扩展工具的全局选项配置和应用流程，将日志文件级别和日志清理天数纳入其中。
- 在英文和中文的快速入门文档以及集成接口概览文档中补充新的日志级别和日志保留选项说明。

测试：
- 更新 Python 和 NodeJS 绑定测试，以覆盖新的日志文件级别和日志清理天数选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable log file level and automatic log/debug file cleanup days across framework, bindings, and tooling.

New Features:
- Expose a global option to control the log file (maafw.log) output level via C API, Python and NodeJS bindings, and toolkit config.
- Introduce a global option to configure log/debug file retention days, including the ability to disable cleanup, wired through framework, agent server, bindings, and toolkit config.

Enhancements:
- Refactor logging level parsing in NodeJS global API into a reusable helper shared between stdout and log file levels.
- Extend toolkit global option configuration and application flow to include log file level and log cleanup days.
- Document the new log-level and log-retention options in both English and Chinese quick start and integrated interface overview docs.

Tests:
- Update Python and NodeJS binding tests to cover the new log file level and log cleanup day options.

</details>