### PR TITLE
fix: throttle minicap stream failures

### DIFF
--- a/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
+++ b/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
@@ -76,6 +76,8 @@ std::optional<std::string> MinicapStream::read_exact(size_t count)
 
 std::optional<cv::Mat> MinicapStream::read_frame()
 {
+    constexpr uint64_t kBytesPerPixel = 4;
+
     auto size_data = read_exact(sizeof(uint32_t));
     if (!size_data) {
         return std::nullopt;
@@ -83,6 +85,13 @@ std::optional<cv::Mat> MinicapStream::read_frame()
 
     uint32_t size = 0;
     std::memcpy(&size, size_data->data(), sizeof(size));
+
+    const auto max_size = static_cast<uint64_t>(display_width_) * static_cast<uint64_t>(display_height_) * kBytesPerPixel;
+    if (size == 0 || size > max_size) {
+        LogError << "invalid minicap frame size" << VAR(size) << VAR(max_size);
+        quit_ = true;
+        return std::nullopt;
+    }
 
     auto data = read_exact(size);
     if (!data) {
@@ -198,11 +207,19 @@ void MinicapStream::pulling()
             consecutive_failures = 0;
             backoff = kBackoffBase;
 
-            std::unique_lock locker(mutex_);
-            image_ = std::move(*image);
+            {
+                std::unique_lock locker(mutex_);
+                image_ = std::move(*image);
+            }
             cond_.notify_all();
             continue;
         }
+
+        {
+            std::unique_lock locker(mutex_);
+            image_.release();
+        }
+        cond_.notify_all();
 
         if (quit_) {
             break;
@@ -220,8 +237,6 @@ void MinicapStream::pulling()
         }
 
         std::unique_lock locker(mutex_);
-        image_.release();
-        cond_.notify_all();
         cond_.wait_for(locker, backoff, [this]() { return quit_.load(); });
         backoff = std::min(backoff * 2, kBackoffMax);
     }

--- a/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
+++ b/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
@@ -185,7 +185,7 @@ void MinicapStream::pulling()
     using namespace std::chrono_literals;
 
     constexpr auto kBackoffBase = 10ms;
-    constexpr auto kBackoffMax = 1s;
+    constexpr auto kBackoffMax = 1000ms;
     constexpr auto kLogInterval = 1min;
 
     size_t consecutive_failures = 0;

--- a/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
+++ b/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.cpp
@@ -1,5 +1,7 @@
 #include "MinicapStream.h"
 
+#include <algorithm>
+#include <cstring>
 #include <format>
 
 #include "MaaUtils/Logger.h"
@@ -60,7 +62,7 @@ std::optional<cv::Mat> MinicapStream::screencap()
     return image_.empty() ? std::nullopt : std::make_optional(image_.clone());
 }
 
-std::optional<std::string> MinicapStream::read(size_t count)
+std::optional<std::string> MinicapStream::read_exact(size_t count)
 {
     if (!sock_ios_) {
         LogError << "sock_ios_ is nullptr";
@@ -68,7 +70,26 @@ std::optional<std::string> MinicapStream::read(size_t count)
     }
 
     using namespace std::chrono_literals;
-    return sock_ios_->read_some(count, 1s);
+    auto data = sock_ios_->read_some(count, 1s);
+    return data.size() == count ? std::make_optional(std::move(data)) : std::nullopt;
+}
+
+std::optional<cv::Mat> MinicapStream::read_frame()
+{
+    auto size_data = read_exact(sizeof(uint32_t));
+    if (!size_data) {
+        return std::nullopt;
+    }
+
+    uint32_t size = 0;
+    std::memcpy(&size, size_data->data(), sizeof(size));
+
+    auto data = read_exact(size);
+    if (!data) {
+        return std::nullopt;
+    }
+
+    return screencap_helper_.decode_jpg(*data, false);
 }
 
 void MinicapStream::create_thread()
@@ -80,6 +101,7 @@ void MinicapStream::create_thread()
 void MinicapStream::release_thread()
 {
     quit_ = true;
+    cond_.notify_all();
     if (pull_thread_.joinable()) {
         pull_thread_.join();
     }
@@ -134,12 +156,12 @@ bool MinicapStream::connect_and_check()
     // TODO: 解决大端底的情况
     MinicapHeader header;
 
-    auto data = read(sizeof(header));
+    auto data = read_exact(sizeof(header));
     if (!data) {
         LogError << "read header failed";
         return false;
     }
-    header = *reinterpret_cast<const MinicapHeader*>(data->data());
+    std::memcpy(&header, data->data(), sizeof(header));
 
     LogInfo << VAR(header.version) << VAR(header.size) << VAR(header.pid) << VAR(header.real_width) << VAR(header.real_height)
             << VAR(header.virt_width) << VAR(header.virt_height) << VAR(header.orientation) << VAR(header.flags);
@@ -148,7 +170,7 @@ bool MinicapStream::connect_and_check()
         return false;
     }
 
-    if (!read(header.size - sizeof(header))) {
+    if (!read_exact(header.size - sizeof(header))) {
         LogError << "read header failed";
         return false;
     }
@@ -160,36 +182,48 @@ void MinicapStream::pulling()
 {
     LogFunc;
 
+    using namespace std::chrono_literals;
+
+    constexpr auto kBackoffBase = 10ms;
+    constexpr auto kBackoffMax = 1s;
+    constexpr auto kLogInterval = 1min;
+
+    size_t consecutive_failures = 0;
+    auto backoff = kBackoffBase;
+    auto next_log_time = std::chrono::steady_clock::time_point::min();
+
     while (!quit_) {
-        auto size_opt = read(4);
-        if (!size_opt) {
-            LogError << "read size failed";
-            std::unique_lock locker(mutex_);
-            image_ = cv::Mat();
-            continue;
-        }
-        auto size = *reinterpret_cast<const uint32_t*>(size_opt->data());
+        auto image = read_frame();
+        if (image && !image->empty()) {
+            consecutive_failures = 0;
+            backoff = kBackoffBase;
 
-        auto data_opt = read(size);
-        if (!data_opt) {
-            LogError << "read data failed";
             std::unique_lock locker(mutex_);
-            image_ = cv::Mat();
+            image_ = std::move(*image);
+            cond_.notify_all();
             continue;
         }
 
-        auto img_opt = screencap_helper_.decode_jpg(*data_opt);
+        if (quit_) {
+            break;
+        }
 
-        if (!img_opt || img_opt->empty()) {
-            LogError << "decode jpg failed";
-            std::unique_lock locker(mutex_);
-            image_ = cv::Mat();
-            continue;
+        ++consecutive_failures;
+        auto now = std::chrono::steady_clock::now();
+        if (consecutive_failures == 1) {
+            LogError << "minicap stream read/decode failed, retrying with backoff";
+            next_log_time = now + kLogInterval;
+        }
+        else if (now >= next_log_time) {
+            LogError << "minicap stream still failing" << VAR(consecutive_failures);
+            next_log_time = now + kLogInterval;
         }
 
         std::unique_lock locker(mutex_);
-        image_ = std::move(*img_opt);
+        image_.release();
         cond_.notify_all();
+        cond_.wait_for(locker, backoff, [this]() { return quit_.load(); });
+        backoff = std::min(backoff * 2, kBackoffMax);
     }
 }
 

--- a/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.h
+++ b/source/MaaAdbControlUnit/Screencap/Minicap/MinicapStream.h
@@ -2,6 +2,7 @@
 
 #include "MinicapBase.h"
 
+#include <atomic>
 #include <condition_variable>
 #include <thread>
 
@@ -27,7 +28,8 @@ public: // from ScreencapBase
     virtual std::optional<cv::Mat> screencap() override;
 
 private:
-    std::optional<std::string> read(size_t count);
+    std::optional<std::string> read_exact(size_t count);
+    std::optional<cv::Mat> read_frame();
     void create_thread();
     void release_thread();
     bool connect_and_check();
@@ -37,7 +39,7 @@ private:
     ProcessArgvGenerator forward_argv_;
     int port_ = 0;
 
-    bool quit_ = true;
+    std::atomic_bool quit_ = true;
     std::mutex mutex_;
     cv::Mat image_;
     std::condition_variable cond_;

--- a/source/MaaAdbControlUnit/Screencap/ScreencapHelper.cpp
+++ b/source/MaaAdbControlUnit/Screencap/ScreencapHelper.cpp
@@ -139,9 +139,9 @@ std::optional<cv::Mat> ScreencapHelper::trunc_decode_jpg(const std::string& buff
     return decode_jpg(truncbuf);
 }
 
-std::optional<cv::Mat> ScreencapHelper::decode_jpg(const std::string& buffer)
+std::optional<cv::Mat> ScreencapHelper::decode_jpg(const std::string& buffer, bool log_error)
 {
-    if (!check_head_tail(buffer, "\xFF\xD8\xFF", "\xFF\xD9")) {
+    if (!check_head_tail(buffer, "\xFF\xD8\xFF", "\xFF\xD9", log_error)) {
         return std::nullopt;
     }
     return decode(buffer);
@@ -188,15 +188,19 @@ bool ScreencapHelper::clean_cr(std::string& buffer)
     return true;
 }
 
-bool ScreencapHelper::check_head_tail(std::string_view input, std::string_view head, std::string_view tail)
+bool ScreencapHelper::check_head_tail(std::string_view input, std::string_view head, std::string_view tail, bool log_error)
 {
     if (input.size() < head.size() || input.size() < tail.size()) {
-        LogError << "input too short" << VAR(input) << VAR(head) << VAR(tail);
+        if (log_error) {
+            LogError << "input too short" << VAR(input) << VAR(head) << VAR(tail);
+        }
         return false;
     }
 
     if (input.substr(0, head.size()) != head || input.substr(input.size() - tail.size(), tail.size()) != tail) {
-        LogError << "head or tail mismatch" << VAR(input) << VAR(head) << VAR(tail);
+        if (log_error) {
+            LogError << "head or tail mismatch" << VAR(input) << VAR(head) << VAR(tail);
+        }
         return false;
     }
 

--- a/source/MaaAdbControlUnit/Screencap/ScreencapHelper.h
+++ b/source/MaaAdbControlUnit/Screencap/ScreencapHelper.h
@@ -18,12 +18,12 @@ public:
     static std::optional<cv::Mat> decode_gzip(const std::string& buffer);
     static std::optional<cv::Mat> decode_png(const std::string& buffer);
     static std::optional<cv::Mat> trunc_decode_jpg(const std::string& buffer);
-    static std::optional<cv::Mat> decode_jpg(const std::string& buffer);
+    static std::optional<cv::Mat> decode_jpg(const std::string& buffer, bool log_error = true);
     static std::optional<cv::Mat> decode(const std::string& buffer);
 
 private:
     static bool clean_cr(std::string& buffer);
-    static bool check_head_tail(std::string_view input, std::string_view head, std::string_view tail);
+    static bool check_head_tail(std::string_view input, std::string_view head, std::string_view tail, bool log_error = true);
 
     enum class EndOfLine
     {


### PR DESCRIPTION
## Summary

- add exact-length reads and safe `memcpy` parsing for minicap frame metadata
- invalidate cached frames on stream failures and retry with capped exponential backoff
- suppress per-frame JPEG validation errors for minicap stream only, logging the first failure and periodic summaries instead
- make shutdown wake an active backoff wait

## Validation

- `git diff --check`
- local CMake configuration reached dependency discovery with MSVC 19.44; full build was skipped because MaaDeps/OpenCV was not available locally
- CI will cover Windows VS 2026, Linux, macOS, and Android builds

Closes #1440

## Summary by Sourcery

在出现读取和解码失败时，提高 minicap 屏幕捕获流的健壮性和日志记录能力。

New Features:
- 为 minicap 流引入精确长度的帧读取机制，并封装帧解析逻辑。

Bug Fixes:
- 确保来自 minicap 套接字的不完整头部和帧读取被视为失败，而不是被部分消费的数据。
- 通过安全拷贝 minicap 头部和帧大小元数据，而不是使用 reinterpret_cast，避免未定义行为。
- 在发生读取或解码失败时清除已缓存的 minicap 帧，并阻止使用方看到过期图像。
- 使关闭操作能够可靠地中断 minicap 拉取循环中任何正在进行的退避等待。

Enhancements:
- 为重复出现的 minicap 流读取/解码失败添加有上限的指数退避以及聚合错误日志记录。
- 允许在不记录逐帧错误的情况下执行 JPEG 校验，并在 minicap 帧上使用该模式以减少日志噪音。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness and logging of the minicap screencap stream under read and decode failures.

New Features:
- Introduce exact-length frame reads and encapsulated frame parsing for the minicap stream.

Bug Fixes:
- Ensure incomplete header and frame reads from the minicap socket are treated as failures rather than partially consumed data.
- Avoid undefined behavior by safely copying minicap header and frame size metadata instead of using reinterpret_cast.
- Clear cached minicap frames when read or decode failures occur and prevent consumers from seeing stale images.
- Make shutdown reliably interrupt any ongoing backoff wait in the minicap pulling loop.

Enhancements:
- Add capped exponential backoff and aggregated error logging for repeated minicap stream read/decode failures.
- Allow JPEG validation to be performed without logging per-frame errors, and use this mode for minicap frames to reduce log noise.

</details>