### PR TITLE
docs: 新增 MaaFwApp Android 通用 GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ _✨ 基于图像识别的自动化黑盒测试框架 ✨_
 - [MWU](https://github.com/ravizhan/MWU) ![Vue](https://img.shields.io/badge/Vue-1867C0?logo=vuedotjs) ![Python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white) ![license](https://img.shields.io/github/license/ravizhan/MWU) ![activity](https://img.shields.io/github/commit-activity/m/ravizhan/MWU?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/ravizhan/MWU?style=social)  
     基于 Vue + FastAPI 的轻量级跨平台通用 WebUI。由 MaaFramework 强力驱动！
 
+- [MaaFwApp](https://github.com/Aliothmoon/MaaFwApp) ![kotlin](https://img.shields.io/badge/Kotlin-7F52FF?logo=kotlin&logoColor=white) ![android](https://img.shields.io/badge/Android-3DDC84?logo=android&logoColor=white) ![license](https://img.shields.io/github/license/Aliothmoon/MaaFwApp) ![activity](https://img.shields.io/github/commit-activity/m/Aliothmoon/MaaFwApp?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/Aliothmoon/MaaFwApp?style=social)  
+    基于 Kotlin + Jetpack Compose 的 Android 通用 GUI。由 MaaFramework 强力驱动！
+
 ### 开发工具
 
 - [MaaDebugger](https://github.com/MaaXYZ/MaaDebugger) ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white) ![license](https://img.shields.io/github/license/MaaXYZ/MaaDebugger) ![activity](https://img.shields.io/github/commit-activity/m/MaaXYZ/MaaDebugger?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/MaaXYZ/MaaDebugger?style=social) [![pypi](https://img.shields.io/badge/PyPI-3776AB?logo=pypi&logoColor=white)](https://pypi.org/project/MaaDebugger/)  

--- a/README_en.md
+++ b/README_en.md
@@ -75,6 +75,9 @@ It offers low-code simplicity while maintaining high extensibility. The framewor
 - [MWU](https://github.com/ravizhan/MWU) ![Vue](https://img.shields.io/badge/Vue-1867C0?logo=vuedotjs) ![Python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white) ![license](https://img.shields.io/github/license/ravizhan/MWU) ![activity](https://img.shields.io/github/commit-activity/m/ravizhan/MWU?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/ravizhan/MWU?style=social)  
      A lightweight cross-platform generic WebUI based on Vue + FastAPI. Powered by MaaFramework!
 
+- [MaaFwApp](https://github.com/Aliothmoon/MaaFwApp) ![kotlin](https://img.shields.io/badge/Kotlin-7F52FF?logo=kotlin&logoColor=white) ![android](https://img.shields.io/badge/Android-3DDC84?logo=android&logoColor=white) ![license](https://img.shields.io/github/license/Aliothmoon/MaaFwApp) ![activity](https://img.shields.io/github/commit-activity/m/Aliothmoon/MaaFwApp?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/Aliothmoon/MaaFwApp?style=social)  
+     An Android generic GUI based on Kotlin + Jetpack Compose. Powered by MaaFramework!
+
 ### Development Tool
 
 - [MaaDebugger](https://github.com/MaaXYZ/MaaDebugger) ![python](https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white) ![license](https://img.shields.io/github/license/MaaXYZ/MaaDebugger) ![activity](https://img.shields.io/github/commit-activity/m/MaaXYZ/MaaDebugger?color=%23ff69b4) ![stars](https://img.shields.io/github/stars/MaaXYZ/MaaDebugger?style=social) [![pypi](https://img.shields.io/badge/PyPI-3776AB?logo=pypi&logoColor=white)](https://pypi.org/project/MaaDebugger/)  


### PR DESCRIPTION
## Summary

Add [MaaFwApp](https://github.com/Aliothmoon/MaaFwApp) to the community **Generic UI** list in both `README.md` and `README_en.md`.

MaaFwApp is a Project Interface V2 client for Android (Kotlin + Jetpack Compose). MaaFramework runs in a privileged process via Shizuku or root, using the native Android controller.

## Notes

- No MirrorChyan badge: resource updates are not supported yet (PI is packaged at build time).
- Description follows the existing Generic UI wording.

## Summary by Sourcery

在中文和英文的 README 文件中，将 MaaFwApp 记录为社区通用 UI 客户端。

文档：
- 在 `README.md` 的社区通用 UI 列表中加入 MaaFwApp，附简要中文说明和技术徽章。
- 在 `README_en.md` 的社区通用 UI 列表中加入 MaaFwApp，附简要英文说明和技术徽章。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document MaaFwApp as a community generic UI client in both Chinese and English readme files.

Documentation:
- Add MaaFwApp to the community Generic UI list in README.md with a brief Chinese description and tech badges.
- Add MaaFwApp to the community Generic UI list in README_en.md with a brief English description and tech badges.

</details>