### PR TITLE
fix(agent): retry Transceiver::poll on EINTR

### DIFF
--- a/source/AgentCommon/Transceiver.cpp
+++ b/source/AgentCommon/Transceiver.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cerrno>
 #include <cstdlib>
 #include <format>
 #include <fstream>
@@ -272,8 +273,16 @@ bool Transceiver::poll(zmq::pollitem_t& pollitem)
         auto remaining_time = timeout_ > elapsed ? timeout_ - elapsed : std::chrono::milliseconds(0);
         auto interval = std::min(remaining_time, std::chrono::milliseconds(1000));
 
-        if (zmq::poll(&pollitem, 1, interval)) {
-            return true;
+        try {
+            if (zmq::poll(&pollitem, 1, interval)) {
+                return true;
+            }
+        }
+        catch (const zmq::error_t& e) {
+            // Android/Linux: signals may interrupt poll; retry with remaining timeout.
+            if (e.num() != EINTR) {
+                throw;
+            }
         }
 
         if (elapsed > timeout_) {


### PR DESCRIPTION
## Summary
- Catch `zmq::error_t` from `zmq::poll` in `Transceiver::poll`.
- On `EINTR`, continue the existing timeout loop with remaining time instead of aborting the process.

## Test plan
- [ ] Build AgentClient for Android
- [ ] Run custom actions that reverse-call context repeatedly; confirm no `zmq::error_t` / SIGABRT on signal interruption
- [ ] Non-EINTR ZMQ errors still propagate

Fixes #1442

## Summary by Sourcery

错误修复：
- 通过在 `zmq::poll` 被中断时，使用剩余的超时时间重试调用，而不是向上传播中断，防止 `Transceiver::poll` 在遇到 `EINTR` 时异常终止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent Transceiver::poll from aborting on EINTR by retrying zmq::poll with the remaining timeout instead of propagating the interruption.

</details>