### PR TITLE
fix(win32): avoid intercepting mouse in window-pos input

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -64,6 +64,8 @@ MessageInput::MessageInput(HWND hwnd, Config config)
 {
     if (config_.with_window_pos) {
         window_pos_guard_enabled_ = false;
+    }
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         tracking_thread_ = std::thread(&MessageInput::tracking_thread_func, this);
     }
 }
@@ -331,7 +333,14 @@ void MessageInput::finish_pos()
         restore_cursor_pos();
     }
     else if (config_.with_window_pos) {
-        stop_window_tracking();
+        if (config_.track_hardware_mouse) {
+            stop_window_tracking();
+        }
+        else {
+            // Without tracking there is no pending hardware delta, so every completion path can restore immediately.
+            restore_window_pos();
+            reset_windowpos_guard_state();
+        }
     }
 }
 
@@ -339,7 +348,8 @@ void MessageInput::restore_pos()
 {
     finish_pos();
 
-    if (config_.with_window_pos) {
+    // No-tracking mode has already restored in finish_pos(). Tracking mode still needs a forced restore here.
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         restore_window_pos();
         reset_windowpos_guard_state();
     }
@@ -524,7 +534,9 @@ bool MessageInput::prepare_mouse_position(int x, int y)
     }
 
     if (config_.with_window_pos) {
-        start_window_tracking(x, y);
+        if (config_.track_hardware_mouse) {
+            start_window_tracking(x, y);
+        }
 
         if (!move_window_to_align_cursor(x, y)) {
             return false;
@@ -1051,8 +1063,8 @@ bool MessageInput::touch_up(int contact)
         return false;
     }
 
-    // touch_up 后继续黏住窗口一小段时间，再由 tracking 线程自行结束。
-    if (config_.with_window_pos) {
+    // Tracking mode keeps the window aligned briefly after touch_up.
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         request_stop_window_tracking();
     }
     else {
@@ -1170,7 +1182,7 @@ bool MessageInput::scroll(int dx, int dy)
         success &= send_or_post_w(target, WM_MOUSEHWHEEL, wParam, lParam);
     }
 
-    if (config_.with_window_pos) {
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         request_stop_window_tracking();
     }
     else {

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -27,6 +27,7 @@ public:
         Mode mode = Mode::SendMessage;
         bool with_cursor_pos = false;
         bool with_window_pos = false;
+        bool track_hardware_mouse = true;
         bool block_input = false;
     };
 

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -157,11 +157,21 @@ std::shared_ptr<InputBase> Win32ControlUnitMgr::make_input(MaaWin32InputMethod m
     case MaaWin32InputMethod_SendMessageWithWindowPos:
         return std::make_shared<MessageInput>(
             hwnd_,
-            MessageInput::Config { .mode = MessageInput::Mode::SendMessage, .with_window_pos = true, .block_input = false });
+            MessageInput::Config {
+                .mode = MessageInput::Mode::SendMessage,
+                .with_window_pos = true,
+                .track_hardware_mouse = false,
+                .block_input = false,
+            });
     case MaaWin32InputMethod_PostMessageWithWindowPos:
         return std::make_shared<MessageInput>(
             hwnd_,
-            MessageInput::Config { .mode = MessageInput::Mode::PostMessage, .with_window_pos = true, .block_input = false });
+            MessageInput::Config {
+                .mode = MessageInput::Mode::PostMessage,
+                .with_window_pos = true,
+                .track_hardware_mouse = false,
+                .block_input = false,
+            });
     case MaaWin32InputMethod_Interception:
         return std::make_shared<InterceptionInput>(hwnd_);
     default:


### PR DESCRIPTION
## 修改说明

避免 `SendMessageWithWindowPos` 和 `PostMessageWithWindowPos` 拦截真实鼠标移动。

此前 WindowPos 输入模式会安装 `WH_MOUSE_LL` 低级鼠标钩子，吞掉真实鼠标移动事件，累积位移量，再以 60 FPS 通过 `SetCursorPos` 重新释放。

虽然这些模式没有调用 `BlockInput`，但该机制仍会导致用户在滑动期间感觉鼠标粘滞、跳动或卡顿。

本次修改让两种 WindowPos 输入模式直接使用当前真实鼠标位置：

- 不为 WindowPos 手势启动硬件鼠标跟踪线程；
- 不安装低级鼠标钩子；
- 不吞掉或重放真实鼠标移动；
- 继续通过移动目标窗口，使指定客户端坐标与当前鼠标位置对齐；
- 手势结束后立即恢复窗口原始位置；
- 不修改现有公开输入方式枚举。

原有鼠标跟踪实现仍通过内部 `track_hardware_mouse` 配置保留。

## 行为变化

修改前：

1. 拦截真实鼠标移动；
2. 吞掉原始移动事件；
3. 累积鼠标位移量；
4. 以 60 FPS 移动目标窗口；
5. 使用 `SetCursorPos` 重放鼠标位置。

修改后：

1. 读取当前真实鼠标位置；
2. 移动目标窗口，使目标客户端坐标与鼠标位置对齐；
3. 发送或投递鼠标消息；
4. 手势结束后恢复窗口位置。

这样在后台执行滑动时，用户仍可正常移动和使用桌面鼠标。

## 影响范围

涉及以下输入方式：

- `MaaWin32InputMethod_SendMessageWithWindowPos`
- `MaaWin32InputMethod_PostMessageWithWindowPos`

其他输入方式不受影响。

## Summary by Sourcery

为 SendMessage/PostMessage 的 WindowPos 输入方法禁用硬件鼠标跟踪，从而在保持窗口对齐到光标并在操作结束后恢复其位置的同时，不再拦截真实的鼠标移动。

Bug Fixes:
- 防止 SendMessageWithWindowPos 和 PostMessageWithWindowPos 输入方法安装低级鼠标钩子并消耗真实的鼠标移动事件。
- 确保在没有硬件跟踪的 WindowPos 手势中，在触摸释放后立即恢复目标窗口位置。

Enhancements:
- 为 MessageInput 增加可配置的 `track_hardware_mouse` 标志，用于控制在 WindowPos 模式下是否使用窗口位置跟踪线程和钩子。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable hardware mouse tracking for SendMessage/PostMessage WindowPos input methods so they no longer intercept real mouse movement while still aligning windows to the cursor and restoring their position afterward.

Bug Fixes:
- Prevent SendMessageWithWindowPos and PostMessageWithWindowPos input methods from installing low-level mouse hooks and consuming real mouse movement.
- Ensure WindowPos gestures without hardware tracking restore the target window position immediately after touch release.

Enhancements:
- Add a configurable track_hardware_mouse flag to MessageInput to control whether window position tracking threads and hooks are used for WindowPos modes.

</details>