### PR TITLE
feat(win32): capture popup windows with PrintWindow 

### DIFF
--- a/source/MaaWin32ControlUnit/Screencap/PrintWindowScreencap.cpp
+++ b/source/MaaWin32ControlUnit/Screencap/PrintWindowScreencap.cpp
@@ -12,10 +12,60 @@ std::optional<cv::Mat> PrintWindowScreencap::screencap()
         return std::nullopt;
     }
 
+    auto image = capture_window(hwnd_);
+    if (!image) {
+        return std::nullopt;
+    }
+
+    HWND root = GetAncestor(hwnd_, GA_ROOTOWNER);
+    if (!root) {
+        root = hwnd_;
+    }
+
+    HWND popup = GetLastActivePopup(root);
+    if (!popup || popup == hwnd_ || popup == root || !IsWindow(popup) || !IsWindowVisible(popup)) {
+        return image;
+    }
+
+    auto popup_image = capture_window(popup);
+    if (!popup_image) {
+        LogWarn << "Failed to capture active popup, returning main window image" << VAR(popup);
+        return image;
+    }
+
+    POINT main_origin = { 0, 0 };
+    POINT popup_origin = { 0, 0 };
+    if (!ClientToScreen(hwnd_, &main_origin) || !ClientToScreen(popup, &popup_origin)) {
+        LogWarn << "Failed to locate active popup, returning main window image" << VAR(popup) << VAR(GetLastError());
+        return image;
+    }
+
+    const int offset_x = popup_origin.x - main_origin.x;
+    const int offset_y = popup_origin.y - main_origin.y;
+    const cv::Rect canvas_rect(0, 0, image->cols, image->rows);
+    const cv::Rect popup_rect(offset_x, offset_y, popup_image->cols, popup_image->rows);
+    const cv::Rect dst_rect = canvas_rect & popup_rect;
+    if (dst_rect.empty()) {
+        LogWarn << "Active popup is outside the main client area" << VAR(popup) << VAR(offset_x) << VAR(offset_y);
+        return image;
+    }
+
+    const cv::Rect src_rect(dst_rect.x - offset_x, dst_rect.y - offset_y, dst_rect.width, dst_rect.height);
+    (*popup_image)(src_rect).copyTo((*image)(dst_rect));
+    return image;
+}
+
+std::optional<cv::Mat> PrintWindowScreencap::capture_window(HWND capture_hwnd)
+{
+    if (!capture_hwnd || !IsWindow(capture_hwnd)) {
+        LogError << "Invalid capture window" << VAR(capture_hwnd);
+        return std::nullopt;
+    }
+
     // 确定要捕获的区域大小
     // 使用PW_CLIENTONLY标志，只获取客户端区域（不含窗口边框）
     RECT rect = { 0 };
-    if (!GetClientRect(hwnd_, &rect)) {
+    if (!GetClientRect(capture_hwnd, &rect)) {
         LogError << "GetClientRect failed, error code: " << GetLastError();
         return std::nullopt;
     }
@@ -44,12 +94,12 @@ std::optional<cv::Mat> PrintWindowScreencap::screencap()
             DeleteDC(mem_dc);
         }
         if (hdc) {
-            ReleaseDC(hwnd_, hdc);
+            ReleaseDC(capture_hwnd, hdc);
         }
     });
 
     // 创建与窗口兼容的 DC
-    hdc = GetDC(hwnd_);
+    hdc = GetDC(capture_hwnd);
     if (!hdc) {
         LogError << "GetDC failed, error code: " << GetLastError();
         return std::nullopt;
@@ -78,7 +128,7 @@ std::optional<cv::Mat> PrintWindowScreencap::screencap()
     // - PW_CLIENTONLY (0x1): 只获取客户端区域
     // - PW_RENDERFULLCONTENT (0x2): 捕获非最小化后台窗口
     constexpr UINT nFlags = PW_CLIENTONLY | PW_RENDERFULLCONTENT;
-    if (!PrintWindow(hwnd_, mem_dc, nFlags)) {
+    if (!PrintWindow(capture_hwnd, mem_dc, nFlags)) {
         LogError << "PrintWindow failed, error code: " << GetLastError();
         return std::nullopt;
     }
@@ -102,4 +152,3 @@ std::optional<cv::Mat> PrintWindowScreencap::screencap()
 }
 
 MAA_CTRL_UNIT_NS_END
-

--- a/source/MaaWin32ControlUnit/Screencap/PrintWindowScreencap.h
+++ b/source/MaaWin32ControlUnit/Screencap/PrintWindowScreencap.h
@@ -21,8 +21,9 @@ public: // from ScreencapBase
     virtual std::optional<cv::Mat> screencap() override;
 
 private:
+    std::optional<cv::Mat> capture_window(HWND hwnd);
+
     HWND hwnd_ = nullptr;
 };
 
 MAA_CTRL_UNIT_NS_END
-


### PR DESCRIPTION
## 说明

PrintWindow 当前只捕获绑定的主窗口，无法获取由独立窗口承载的公告等 popup 内容。

## 修改内容

- 将单窗口 PrintWindow 捕获逻辑抽取为独立函数。
- 使用 `GetLastActivePopup` 查找当前活动 popup。
- 分别捕获主窗口与 popup。
- 根据客户区屏幕坐标将 popup 叠加到主窗口截图。
- 保持最终截图尺寸与主窗口一致。
- popup 捕获或定位失败时回退到原始主窗口截图。

## 验证

- MaaWin32ControlUnit Release 构建通过。
- 待验证明日方舟 PC 客户端正常显示及最小化状态下的公告截图。

## Summary by Sourcery

在使用 PrintWindow 进行屏幕截图时，同时捕获 Win32 弹出窗口的客户端区域和主窗口，并调整在非硬件鼠标模式下基于消息的输入窗口跟踪行为。

New Features:
- 支持将活动弹出窗口的内容合成到主窗口截图中，同时保持最终图像尺寸与主客户端区域一致。

Bug Fixes:
- 在使用基于消息的输入且未启用硬件鼠标跟踪时，避免启动或停止窗口跟踪，并在触摸交互结束后立即恢复窗口位置。

Enhancements:
- 将 PrintWindow 的客户端区域捕获逻辑提取为可重用的辅助工具，以用于捕获任意窗口。
- 添加配置标志，以便在使用 SendMessage/PostMessage 的窗口位置输入模式时可以显式禁用硬件鼠标跟踪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Capture Win32 popup client areas alongside the main window in PrintWindow screencaps and adjust message-based input window tracking behavior for non-hardware-mouse modes.

New Features:
- Support compositing the active popup window content into the main window screenshot while keeping the final image size consistent with the main client area.

Bug Fixes:
- Avoid starting or stopping window tracking when using message-based input without hardware mouse tracking, restoring window position immediately after touch interactions instead.

Enhancements:
- Extract the PrintWindow client-area capture logic into a reusable helper for capturing arbitrary windows.
- Add configuration flags so SendMessage/PostMessage window-pos input modes can disable hardware mouse tracking explicitly.

</details>