### PR TITLE
chore: fix build error on libstdc++

### DIFF
--- a/source/MaaLinuxControlUnit/Wayland/WaylandClient.cpp
+++ b/source/MaaLinuxControlUnit/Wayland/WaylandClient.cpp
@@ -81,11 +81,13 @@ bool WaylandClient::bind_protocol()
     registry_listener_.global = [](void* data, struct wl_registry* registry, uint32_t id, const char* interface, uint32_t version) {
         const auto self = static_cast<WaylandClient*>(data);
 
-#define BIND(interface_type, global_member)                                                                                            \
-    if (std::string_view(interface) == #interface_type) {                                                                              \
-        LogDebug << "Bind protocol" << VAR(interface);                                                                                 \
-        self->global_member.reset(static_cast<interface_type*>(wl_registry_bind(registry, id, &interface_type##_interface, version))); \
-        return;                                                                                                                        \
+#define BIND(interface_type, global_member)                                                                     \
+    if (std::string_view(interface) == #interface_type) {                                                       \
+        LogDebug << "Bind protocol" << VAR(interface);                                                          \
+        self->global_member.reset(                                                                              \
+            static_cast<interface_type*>(wl_registry_bind(registry, id, &interface_type##_interface, version)), \
+            std::default_delete<interface_type> { });                                                           \
+        return;                                                                                                 \
     }
 
         BIND(wl_output, output_);


### PR DESCRIPTION
https://github.com/MaaXYZ/MaaFramework/pull/1406

看上去 libstdc++ 并不会自动使用 default_deleter

## Summary by Sourcery

Bug Fixes:
- 通过在重置托管指针时显式提供默认删除器，修复在使用 libstdc++ 时 Wayland 协议对象的所有权问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Wayland protocol object ownership on libstdc++ by explicitly supplying the default deleter when resetting managed pointers.

</details>