### PR TITLE
fix(win32): preserve window-pos behavior without mouse interception

### DIFF
--- a/source/MaaWin32ControlUnit/Input/MessageInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.cpp
@@ -64,6 +64,8 @@ MessageInput::MessageInput(HWND hwnd, Config config)
 {
     if (config_.with_window_pos) {
         window_pos_guard_enabled_ = false;
+    }
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         tracking_thread_ = std::thread(&MessageInput::tracking_thread_func, this);
     }
 }
@@ -331,7 +333,14 @@ void MessageInput::finish_pos()
         restore_cursor_pos();
     }
     else if (config_.with_window_pos) {
-        stop_window_tracking();
+        if (config_.track_hardware_mouse) {
+            stop_window_tracking();
+        }
+        else {
+            // Without tracking there is no pending hardware delta, so every completion path can restore immediately.
+            restore_window_pos();
+            reset_windowpos_guard_state();
+        }
     }
 }
 
@@ -339,7 +348,8 @@ void MessageInput::restore_pos()
 {
     finish_pos();
 
-    if (config_.with_window_pos) {
+    // No-tracking mode has already restored in finish_pos(). Tracking mode still needs a forced restore here.
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         restore_window_pos();
         reset_windowpos_guard_state();
     }
@@ -524,7 +534,9 @@ bool MessageInput::prepare_mouse_position(int x, int y)
     }
 
     if (config_.with_window_pos) {
-        start_window_tracking(x, y);
+        if (config_.track_hardware_mouse) {
+            start_window_tracking(x, y);
+        }
 
         if (!move_window_to_align_cursor(x, y)) {
             return false;
@@ -1051,8 +1063,8 @@ bool MessageInput::touch_up(int contact)
         return false;
     }
 
-    // touch_up 后继续黏住窗口一小段时间，再由 tracking 线程自行结束。
-    if (config_.with_window_pos) {
+    // Tracking mode keeps the window aligned briefly after touch_up.
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         request_stop_window_tracking();
     }
     else {
@@ -1170,7 +1182,7 @@ bool MessageInput::scroll(int dx, int dy)
         success &= send_or_post_w(target, WM_MOUSEHWHEEL, wParam, lParam);
     }
 
-    if (config_.with_window_pos) {
+    if (config_.with_window_pos && config_.track_hardware_mouse) {
         request_stop_window_tracking();
     }
     else {

--- a/source/MaaWin32ControlUnit/Input/MessageInput.h
+++ b/source/MaaWin32ControlUnit/Input/MessageInput.h
@@ -27,6 +27,7 @@ public:
         Mode mode = Mode::SendMessage;
         bool with_cursor_pos = false;
         bool with_window_pos = false;
+        bool track_hardware_mouse = true;
         bool block_input = false;
     };
 

--- a/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
+++ b/source/MaaWin32ControlUnit/Manager/Win32ControlUnitMgr.cpp
@@ -157,11 +157,21 @@ std::shared_ptr<InputBase> Win32ControlUnitMgr::make_input(MaaWin32InputMethod m
     case MaaWin32InputMethod_SendMessageWithWindowPos:
         return std::make_shared<MessageInput>(
             hwnd_,
-            MessageInput::Config { .mode = MessageInput::Mode::SendMessage, .with_window_pos = true, .block_input = false });
+            MessageInput::Config {
+                .mode = MessageInput::Mode::SendMessage,
+                .with_window_pos = true,
+                .track_hardware_mouse = false,
+                .block_input = false,
+            });
     case MaaWin32InputMethod_PostMessageWithWindowPos:
         return std::make_shared<MessageInput>(
             hwnd_,
-            MessageInput::Config { .mode = MessageInput::Mode::PostMessage, .with_window_pos = true, .block_input = false });
+            MessageInput::Config {
+                .mode = MessageInput::Mode::PostMessage,
+                .with_window_pos = true,
+                .track_hardware_mouse = false,
+                .block_input = false,
+            });
     case MaaWin32InputMethod_Interception:
         return std::make_shared<InterceptionInput>(hwnd_);
     default:


### PR DESCRIPTION
## 问题

#1450 禁用了 `SendMessageWithWindowPos` 和
`PostMessageWithWindowPos` 的硬件鼠标追踪，避免 `WH_MOUSE_LL`
鼠标钩子影响真实鼠标。

但无追踪模式在每次 `touch_up` 和 `scroll` 后都会通过
`finish_pos()` 立即恢复窗口位置。这与原有 WindowPos 模式的
生命周期不同。

连续手势之间恢复窗口会改变后续鼠标消息对应的窗口状态。例如横向滑动后
紧接纵向滑动时，游戏可能仍然保留前一段横向滑动的惯性。

## 修改

- 无追踪 WindowPos 模式在成功完成 `touch_up` 或 `scroll` 后不再立即恢复窗口。
- 正常手势结束后保留当前窗口偏移，与原有追踪模式的生命周期保持一致。
- `inactive()`、析构和输入失败等强制清理路径仍会恢复原始窗口位置。
- 不重新启用 `WH_MOUSE_LL`，因此不会重新引入真实鼠标卡顿。
- 没有新增线程、状态变量或额外的延迟恢复机制。

## 验证

- `MaaWin32ControlUnit` Release 构建通过。
- `git diff --check` 通过。
- PR 相对当前主分支只修改 `MessageInput.cpp`。

## Summary by Sourcery

在不依赖硬件鼠标跟踪的情况下，在 SendMessage 和 PostMessage 输入模式中保留 WindowPos 手势状态。

Bug Fixes:
- 防止窗口位置输入在完成手势时拦截或跟踪真实硬件鼠标移动，同时保持窗口对齐。
- 确保在窗口未激活、销毁以及输入失败的清理路径上恢复窗口位置，而无需重新启用底层鼠标钩子。

Enhancements:
- 将带硬件鼠标跟踪和不带跟踪的 WindowPos 生命周期分离，使得在 SendMessage 和 PostMessage 模式下，窗口在手势之间能够保持其偏移量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve WindowPos gesture state without hardware mouse tracking for SendMessage and PostMessage input modes.

Bug Fixes:
- Prevent window-position input from intercepting or tracking real hardware mouse movement while preserving window alignment across completed gestures.
- Ensure window position is restored on inactive, destruction, and failed-input cleanup paths without re-enabling low-level mouse hooks.

Enhancements:
- Separate hardware-mouse-tracking and non-tracking WindowPos lifecycles so SendMessage and PostMessage modes retain their window offset between gestures.

</details>