### PR TITLE
feat: 禁止重复注册自定义识别和动作

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,7 @@ jobs:
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()
@@ -356,6 +357,7 @@ jobs:
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()
@@ -486,6 +488,7 @@ jobs:
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -99,7 +99,7 @@ Clear all resource event listeners
 - `recognition`: Custom recognizer
 - `trans_arg`: Argument passed to callback
 
-Register a custom recognizer named `name`.
+Register a custom recognizer named `name`. The name must not be empty. Custom recognizers and custom actions share one case-sensitive namespace. If the name is empty or either type already uses it, the function returns `false` and preserves any existing registration. Unregister the existing custom before replacing it.
 
 ### MaaResourceUnregisterCustomRecognition
 
@@ -117,7 +117,7 @@ Remove all custom recognizers.
 - `action`: Custom action
 - `trans_arg`: Argument passed to callback
 
-Register a custom action named `name`.
+Register a custom action named `name`. The name must not be empty. Custom recognizers and custom actions share one case-sensitive namespace. If the name is empty or either type already uses it, the function returns `false` and preserves any existing registration. Unregister the existing custom before replacing it.
 
 ### MaaResourceUnregisterCustomAction
 
@@ -1205,7 +1205,7 @@ Get custom action name list registered after Agent connection, write to `buffer`
 - `recognition`: Custom recognizer
 - `trans_arg`: Argument passed to callback
 
-Register a custom recognizer named `name`
+Register a custom recognizer named `name`. The name must not be empty. Custom recognizers and custom actions share one case-sensitive namespace. If the name is empty or either type already uses it, the function returns `false` and preserves any existing registration.
 
 ### MaaAgentServerRegisterCustomAction
 
@@ -1213,7 +1213,7 @@ Register a custom recognizer named `name`
 - `action`: Custom action
 - `trans_arg`: Argument passed to callback
 
-Register a custom action named `name`
+Register a custom action named `name`. The name must not be empty. Custom recognizers and custom actions share one case-sensitive namespace. If the name is empty or either type already uses it, the function returns `false` and preserves any existing registration.
 
 ### MaaAgentServerAddResourceSink
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -99,7 +99,7 @@
 - `recognition`: 自定义识别器
 - `trans_arg`: 传递给回调的参数
 
-注册名为 `name` 的自定义识别器 `recognition`
+注册名为 `name` 的自定义识别器 `recognition`。名称不得为空。自定义识别器和自定义操作共享一个区分大小写的命名空间。若名称为空或已被任一类型注册，则返回 `false` 且保留原注册；如需替换，应先移除原注册。
 
 ### MaaResourceUnregisterCustomRecognition
 
@@ -117,7 +117,7 @@
 - `action`: 自定义操作
 - `trans_arg`: 传递给回调的参数
 
-注册名为 `name` 的自定义操作 `action`
+注册名为 `name` 的自定义操作 `action`。名称不得为空。自定义识别器和自定义操作共享一个区分大小写的命名空间。若名称为空或已被任一类型注册，则返回 `false` 且保留原注册；如需替换，应先移除原注册。
 
 ### MaaResourceUnregisterCustomAction
 
@@ -1201,7 +1201,7 @@ Agent 客户端会监听 127.0.0.1 上的指定 TCP 端口。如果传入 `0`，
 - `recognition`: 自定义识别器
 - `trans_arg`: 传递给回调的参数
 
-注册名为 `name` 的自定义识别器 `recognition`
+注册名为 `name` 的自定义识别器 `recognition`。名称不得为空。自定义识别器和自定义操作共享一个区分大小写的命名空间。若名称为空或已被任一类型注册，则返回 `false` 且保留原注册。
 
 ### MaaAgentServerRegisterCustomAction
 
@@ -1209,7 +1209,7 @@ Agent 客户端会监听 127.0.0.1 上的指定 TCP 端口。如果传入 `0`，
 - `action`: 自定义操作
 - `trans_arg`: 传递给回调的参数
 
-注册名为 `name` 的自定义操作 `action`
+注册名为 `name` 的自定义操作 `action`。名称不得为空。自定义识别器和自定义操作共享一个区分大小写的命名空间。若名称为空或已被任一类型注册，则返回 `false` 且保留原注册。
 
 ### MaaAgentServerAddResourceSink
 

--- a/source/Common/MaaResource.cpp
+++ b/source/Common/MaaResource.cpp
@@ -50,8 +50,7 @@ MaaBool MaaResourceRegisterCustomRecognition(MaaResource* res, const char* name,
         return false;
     }
 
-    res->register_custom_recognition(name, recognition, trans_arg);
-    return true;
+    return res->register_custom_recognition(name, recognition, trans_arg);
 }
 
 MaaBool MaaResourceUnregisterCustomRecognition(MaaResource* res, const char* name)
@@ -89,8 +88,7 @@ MaaBool MaaResourceRegisterCustomAction(MaaResource* res, const char* name, MaaC
         return false;
     }
 
-    res->register_custom_action(name, action, trans_arg);
-    return true;
+    return res->register_custom_action(name, action, trans_arg);
 }
 
 MaaBool MaaResourceUnregisterCustomAction(MaaResource* res, const char* name)

--- a/source/MaaAgentClient/Client/AgentClient.cpp
+++ b/source/MaaAgentClient/Client/AgentClient.cpp
@@ -175,6 +175,7 @@ bool AgentClient::connect()
     }
     const auto& resp = *resp_opt;
     LogInfo << VAR(resp);
+    remote_session_started_ = true;
 
     if (resp.protocol != kProtocolVersion) {
         LogError << "Protocol version mismatch" << "client:" << VAR(MAA_VERSION) << VAR(kProtocolVersion) << "server:" << VAR(resp.version)
@@ -215,7 +216,7 @@ bool AgentClient::disconnect()
     clear_resource_sink();
     clear_tasker_sink();
 
-    if (!connected()) {
+    if (!remote_session_started_) {
         return true;
     }
 
@@ -224,6 +225,7 @@ bool AgentClient::disconnect()
     }
 
     connected_ = false;
+    remote_session_started_ = false;
     return true;
 }
 

--- a/source/MaaAgentClient/Client/AgentClient.cpp
+++ b/source/MaaAgentClient/Client/AgentClient.cpp
@@ -165,6 +165,7 @@ bool AgentClient::connect()
     }
 
     clear_custom_registration();
+    connected_ = false;
 
     auto resp_opt = send_and_recv<StartUpResponse>(StartUpRequest { });
 
@@ -184,15 +185,22 @@ bool AgentClient::connect()
 
     for (const auto& reco : resp.recognitions) {
         LogInfo << "register recognition" << VAR(reco);
-        bound_res_->register_custom_recognition(reco, reco_agent, this);
+        if (!bound_res_->register_custom_recognition(reco, reco_agent, this)) {
+            LogError << "failed to register recognition" << VAR(reco);
+            clear_custom_registration();
+            return false;
+        }
+        registered_recognitions_.emplace_back(reco);
     }
     for (const auto& act : resp.actions) {
         LogInfo << "register action" << VAR(act);
-        bound_res_->register_custom_action(act, action_agent, this);
+        if (!bound_res_->register_custom_action(act, action_agent, this)) {
+            LogError << "failed to register action" << VAR(act);
+            clear_custom_registration();
+            return false;
+        }
+        registered_actions_.emplace_back(act);
     }
-
-    registered_recognitions_ = resp.recognitions;
-    registered_actions_ = resp.actions;
 
     connected_ = true;
     return true;

--- a/source/MaaAgentClient/Client/AgentClient.h
+++ b/source/MaaAgentClient/Client/AgentClient.h
@@ -187,6 +187,7 @@ private:
     MaaSinkId reg_ctrl_sink_id_ = MaaInvalidId;
 
     bool connected_ = false;
+    bool remote_session_started_ = false;
     std::string identifier_;
 
     std::map<std::string, MaaContext*> context_map_;

--- a/source/MaaAgentServer/RemoteInstance/RemoteResource.cpp
+++ b/source/MaaAgentServer/RemoteInstance/RemoteResource.cpp
@@ -192,9 +192,10 @@ std::optional<json::object> RemoteResource::get_node_data(const std::string& nod
     return resp_opt->node_data;
 }
 
-void RemoteResource::register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg)
+bool RemoteResource::register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg)
 {
     LogError << "Can NOT register custom recognition at remote resource" << VAR(name) << VAR_VOIDP(recognition) << VAR_VOIDP(trans_arg);
+    return false;
 }
 
 void RemoteResource::unregister_custom_recognition(const std::string& name)
@@ -207,9 +208,10 @@ void RemoteResource::clear_custom_recognition()
     LogError << "Can NOT clear custom recognition at remote resource";
 }
 
-void RemoteResource::register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg)
+bool RemoteResource::register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg)
 {
     LogError << "Can NOT register custom action at remote resource" << VAR(name) << VAR_VOIDP(action) << VAR_VOIDP(trans_arg);
+    return false;
 }
 
 void RemoteResource::unregister_custom_action(const std::string& name)

--- a/source/MaaAgentServer/RemoteInstance/RemoteResource.h
+++ b/source/MaaAgentServer/RemoteInstance/RemoteResource.h
@@ -31,10 +31,10 @@ public:
     virtual bool override_image(const std::string& image_name, const cv::Mat& image) override;
     virtual std::optional<json::object> get_node_data(const std::string& node_name) const override;
 
-    virtual void register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) override;
+    virtual bool register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) override;
     virtual void unregister_custom_recognition(const std::string& name) override;
     virtual void clear_custom_recognition() override;
-    virtual void register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) override;
+    virtual bool register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) override;
     virtual void unregister_custom_action(const std::string& name) override;
     virtual void clear_custom_action() override;
 

--- a/source/MaaAgentServer/Server/AgentServer.cpp
+++ b/source/MaaAgentServer/Server/AgentServer.cpp
@@ -87,7 +87,12 @@ bool AgentServer::register_custom_recognition(const std::string& name, MaaCustom
         return false;
     }
 
-    return custom_recognitions_.insert_or_assign(name, CustomRecognitionSession { recognition, trans_arg }).second;
+    if (custom_recognitions_.contains(name) || custom_actions_.contains(name)) {
+        LogError << "custom name already registered" << VAR(name);
+        return false;
+    }
+
+    return custom_recognitions_.emplace(name, CustomRecognitionSession { recognition, trans_arg }).second;
 }
 
 bool AgentServer::register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg)
@@ -99,7 +104,12 @@ bool AgentServer::register_custom_action(const std::string& name, MaaCustomActio
         return false;
     }
 
-    return custom_actions_.insert_or_assign(name, CustomActionSession { action, trans_arg }).second;
+    if (custom_recognitions_.contains(name) || custom_actions_.contains(name)) {
+        LogError << "custom name already registered" << VAR(name);
+        return false;
+    }
+
+    return custom_actions_.emplace(name, CustomActionSession { action, trans_arg }).second;
 }
 
 MaaSinkId AgentServer::add_resource_sink(MaaEventCallback sink, void* trans_arg)

--- a/source/MaaFramework/Resource/ResourceMgr.cpp
+++ b/source/MaaFramework/Resource/ResourceMgr.cpp
@@ -283,15 +283,22 @@ std::optional<json::object> ResourceMgr::get_node_data(const std::string& node_n
     return PipelineDumper::dump(it->second);
 }
 
-void ResourceMgr::register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg)
+bool ResourceMgr::register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg)
 {
     LogDebug << VAR(name) << VAR_VOIDP(recognition) << VAR_VOIDP(trans_arg);
 
     if (name.empty() || !recognition) {
         LogError << "empty name or handle";
-        return;
+        return false;
     }
-    custom_recognition_sessions_.insert_or_assign(name, CustomRecognitionSession { .recognition = recognition, .trans_arg = trans_arg });
+
+    if (custom_recognition_sessions_.contains(name) || custom_action_sessions_.contains(name)) {
+        LogError << "custom name already registered" << VAR(name);
+        return false;
+    }
+
+    return custom_recognition_sessions_.emplace(name, CustomRecognitionSession { .recognition = recognition, .trans_arg = trans_arg })
+        .second;
 }
 
 void ResourceMgr::unregister_custom_recognition(const std::string& name)
@@ -312,15 +319,21 @@ void ResourceMgr::clear_custom_recognition()
     custom_recognition_sessions_.clear();
 }
 
-void ResourceMgr::register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg)
+bool ResourceMgr::register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg)
 {
     LogDebug << VAR(name) << VAR_VOIDP(action) << VAR_VOIDP(trans_arg);
 
     if (name.empty() || !action) {
         LogError << "empty name or handle";
-        return;
+        return false;
     }
-    custom_action_sessions_.insert_or_assign(name, CustomActionSession { .action = action, .trans_arg = trans_arg });
+
+    if (custom_recognition_sessions_.contains(name) || custom_action_sessions_.contains(name)) {
+        LogError << "custom name already registered" << VAR(name);
+        return false;
+    }
+
+    return custom_action_sessions_.emplace(name, CustomActionSession { .action = action, .trans_arg = trans_arg }).second;
 }
 
 void ResourceMgr::unregister_custom_action(const std::string& name)

--- a/source/MaaFramework/Resource/ResourceMgr.h
+++ b/source/MaaFramework/Resource/ResourceMgr.h
@@ -67,10 +67,10 @@ public: // MaaResource
     virtual bool override_image(const std::string& image_name, const cv::Mat& image) override;
     virtual std::optional<json::object> get_node_data(const std::string& node_name) const override;
 
-    virtual void register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) override;
+    virtual bool register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) override;
     virtual void unregister_custom_recognition(const std::string& name) override;
     virtual void clear_custom_recognition() override;
-    virtual void register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) override;
+    virtual bool register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) override;
     virtual void unregister_custom_action(const std::string& name) override;
     virtual void clear_custom_action() override;
 

--- a/source/binding/NodeJS/src/apis/resource.cpp
+++ b/source/binding/NodeJS/src/apis/resource.cpp
@@ -134,13 +134,20 @@ void ResourceImpl::set_inference_execution_provider(std::string provider)
 
 void ResourceImpl::register_custom_recognition(std::string key, maajs::FunctionType func)
 {
+    if (!resource) {
+        throw maajs::MaaError { "Resource has been destroyed" };
+    }
+    if (key.empty()) {
+        throw maajs::MaaError { "Custom name must not be empty" };
+    }
+
     auto ctx = new maajs::CallbackContext(func, "CustomReco");
     if (MaaResourceRegisterCustomRecognition(resource, key.c_str(), CustomReco, ctx)) {
         recos[key] = ctx;
     }
     else {
         delete ctx;
-        throw maajs::MaaError { "Resource register_custom_recognition failed" };
+        throw maajs::MaaError { std::format("Custom name is already registered: '{}'", key) };
     }
 }
 
@@ -169,13 +176,20 @@ void ResourceImpl::clear_custom_recognition()
 
 void ResourceImpl::register_custom_action(std::string key, maajs::FunctionType func)
 {
+    if (!resource) {
+        throw maajs::MaaError { "Resource has been destroyed" };
+    }
+    if (key.empty()) {
+        throw maajs::MaaError { "Custom name must not be empty" };
+    }
+
     auto ctx = new maajs::CallbackContext(func, "CustomAct");
     if (MaaResourceRegisterCustomAction(resource, key.c_str(), CustomAct, ctx)) {
         acts[key] = ctx;
     }
     else {
         delete ctx;
-        throw maajs::MaaError { "Resource register_custom_action failed" };
+        throw maajs::MaaError { std::format("Custom name is already registered: '{}'", key) };
     }
 }
 

--- a/source/binding/NodeJS/src/apis/server.cpp
+++ b/source/binding/NodeJS/src/apis/server.cpp
@@ -1,5 +1,7 @@
 #include "loader.h"
 
+#include <format>
+
 #include <MaaAgentServer/MaaAgentServerAPI.h>
 
 #include "../foundation/spec.h"
@@ -8,18 +10,26 @@
 
 static void register_custom_recognition(maajs::EnvType env, std::string key, maajs::FunctionType func)
 {
+    if (key.empty()) {
+        throw maajs::MaaError { "Custom name must not be empty" };
+    }
+
     auto ctx = std::make_unique<maajs::CallbackContext>(func, "CustomReco");
     if (!MaaAgentServerRegisterCustomRecognition(key.c_str(), CustomReco, ctx.get())) {
-        throw maajs::MaaError { "Server register_custom_recognition failed" };
+        throw maajs::MaaError { std::format("Custom name is already registered: '{}'", key) };
     }
     ExtContext::get(env)->globalCallbacks.push_back(std::move(ctx));
 }
 
 static void register_custom_action(maajs::EnvType env, std::string key, maajs::FunctionType func)
 {
+    if (key.empty()) {
+        throw maajs::MaaError { "Custom name must not be empty" };
+    }
+
     auto ctx = std::make_unique<maajs::CallbackContext>(func, "CustomAct");
     if (!MaaAgentServerRegisterCustomAction(key.c_str(), CustomAct, ctx.get())) {
-        throw maajs::MaaError { "Server register_custom_action failed" };
+        throw maajs::MaaError { std::format("Custom name is already registered: '{}'", key) };
     }
     ExtContext::get(env)->globalCallbacks.push_back(std::move(ctx));
 }

--- a/source/binding/Python/maa/agent/agent_server.py
+++ b/source/binding/Python/maa/agent/agent_server.py
@@ -44,12 +44,20 @@ class AgentServer:
 
         Returns:
             装饰器函数 / Decorator function
+
+        Raises:
+            ValueError: 名称为空 / The name is empty
+            RuntimeError: 名称已被注册 / The name is already registered
         """
+
+        if not name:
+            raise ValueError("Custom name must not be empty")
 
         def wrapper_recognition(
             recognition: type["CustomRecognition"],
         ) -> type["CustomRecognition"]:
-            AgentServer.register_custom_recognition(name=name, recognition=recognition())
+            if not AgentServer.register_custom_recognition(name=name, recognition=recognition()):
+                raise RuntimeError(f"Custom name is already registered: {name!r}")
             return recognition
 
         return wrapper_recognition
@@ -73,16 +81,18 @@ class AgentServer:
 
         AgentServer._set_api_properties()
 
-        # avoid gc
-        AgentServer._custom_recognition_holder[name] = recognition
-
-        return bool(
+        success = bool(
             Library.agent_server().MaaAgentServerRegisterCustomRecognition(
                 name.encode(),
                 recognition.c_handle,
                 recognition.c_arg,
             )
         )
+        if success:
+            # avoid gc
+            AgentServer._custom_recognition_holder[name] = recognition
+
+        return success
 
     @staticmethod
     def custom_action(
@@ -96,10 +106,18 @@ class AgentServer:
 
         Returns:
             装饰器函数 / Decorator function
+
+        Raises:
+            ValueError: 名称为空 / The name is empty
+            RuntimeError: 名称已被注册 / The name is already registered
         """
 
+        if not name:
+            raise ValueError("Custom name must not be empty")
+
         def wrapper_action(action: type["CustomAction"]) -> type["CustomAction"]:
-            AgentServer.register_custom_action(name=name, action=action())
+            if not AgentServer.register_custom_action(name=name, action=action()):
+                raise RuntimeError(f"Custom name is already registered: {name!r}")
             return action
 
         return wrapper_action
@@ -120,16 +138,18 @@ class AgentServer:
 
         AgentServer._set_api_properties()
 
-        # avoid gc
-        AgentServer._custom_action_holder[name] = action
-
-        return bool(
+        success = bool(
             Library.agent_server().MaaAgentServerRegisterCustomAction(
                 name.encode(),
                 action.c_handle,
                 action.c_arg,
             )
         )
+        if success:
+            # avoid gc
+            AgentServer._custom_action_holder[name] = action
+
+        return success
 
     @staticmethod
     def start_up(identifier: str) -> bool:

--- a/source/binding/Python/maa/resource.py
+++ b/source/binding/Python/maa/resource.py
@@ -363,12 +363,20 @@ class Resource:
 
         Returns:
             装饰器函数 / Decorator function
+
+        Raises:
+            ValueError: 名称为空 / The name is empty
+            RuntimeError: 名称已被注册 / The name is already registered
         """
+
+        if not name:
+            raise ValueError("Custom name must not be empty")
 
         def wrapper_recognition(
             recognition: type["CustomRecognition"],
         ) -> type["CustomRecognition"]:
-            self.register_custom_recognition(name=name, recognition=recognition())
+            if not self.register_custom_recognition(name=name, recognition=recognition()):
+                raise RuntimeError(f"Custom name is already registered: {name!r}")
             return recognition
 
         return wrapper_recognition
@@ -387,10 +395,7 @@ class Resource:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        # avoid gc
-        self._custom_recognition_holder[name] = recognition
-
-        return bool(
+        success = bool(
             Library.framework().MaaResourceRegisterCustomRecognition(
                 self._handle,
                 name.encode(),
@@ -398,6 +403,11 @@ class Resource:
                 recognition.c_arg,
             )
         )
+        if success:
+            # avoid gc
+            self._custom_recognition_holder[name] = recognition
+
+        return success
 
     def unregister_custom_recognition(self, name: str) -> bool:
         """移除自定义识别器 / Remove the custom recognizer
@@ -440,10 +450,18 @@ class Resource:
 
         Returns:
             装饰器函数 / Decorator function
+
+        Raises:
+            ValueError: 名称为空 / The name is empty
+            RuntimeError: 名称已被注册 / The name is already registered
         """
 
+        if not name:
+            raise ValueError("Custom name must not be empty")
+
         def wrapper_action(action: type["CustomAction"]) -> type["CustomAction"]:
-            self.register_custom_action(name=name, action=action())
+            if not self.register_custom_action(name=name, action=action()):
+                raise RuntimeError(f"Custom name is already registered: {name!r}")
             return action
 
         return wrapper_action
@@ -458,10 +476,7 @@ class Resource:
         Returns:
             bool: 是否成功 / Whether successful
         """
-        # avoid gc
-        self._custom_action_holder[name] = action
-
-        return bool(
+        success = bool(
             Library.framework().MaaResourceRegisterCustomAction(
                 self._handle,
                 name.encode(),
@@ -469,6 +484,11 @@ class Resource:
                 action.c_arg,
             )
         )
+        if success:
+            # avoid gc
+            self._custom_action_holder[name] = action
+
+        return success
 
     def unregister_custom_action(self, name: str) -> bool:
         """移除自定义操作 / Remove the custom action

--- a/source/include/Common/MaaTypes.h
+++ b/source/include/Common/MaaTypes.h
@@ -53,10 +53,10 @@ public:
     virtual bool running() const = 0;
     virtual bool clear() = 0;
 
-    virtual void register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) = 0;
+    virtual bool register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg) = 0;
     virtual void unregister_custom_recognition(const std::string& name) = 0;
     virtual void clear_custom_recognition() = 0;
-    virtual void register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) = 0;
+    virtual bool register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg) = 0;
     virtual void unregister_custom_action(const std::string& name) = 0;
     virtual void clear_custom_action() = 0;
 

--- a/source/include/MaaAgent/Message.hpp
+++ b/source/include/MaaAgent/Message.hpp
@@ -14,7 +14,7 @@ MAA_AGENT_NS_BEGIN
 // ReverseRequest: server -> client
 
 using MessageTypePlaceholder = int;
-inline static constexpr int kProtocolVersion = 7;
+inline static constexpr int kProtocolVersion = 8;
 
 struct StartUpRequest
 {

--- a/test/agent/agent_child_test.py
+++ b/test/agent/agent_child_test.py
@@ -382,6 +382,39 @@ class MyAction(CustomAction):
         return CustomAction.RunResult(success=True)
 
 
+original_reco = AgentServer._custom_recognition_holder["MyRec"]
+original_action = AgentServer._custom_action_holder["MyAct"]
+assert not AgentServer.register_custom_recognition("MyRec", MyRecognition())
+assert not AgentServer.register_custom_action("MyAct", MyAction())
+assert not AgentServer.register_custom_action("MyRec", MyAction())
+assert not AgentServer.register_custom_recognition("MyAct", MyRecognition())
+assert AgentServer._custom_recognition_holder["MyRec"] is original_reco
+assert AgentServer._custom_action_holder["MyAct"] is original_action
+assert AgentServer.register_custom_recognition("CaseSensitive", MyRecognition())
+assert AgentServer.register_custom_action("casesensitive", MyAction())
+assert not AgentServer.register_custom_recognition("", MyRecognition())
+assert not AgentServer.register_custom_action("", MyAction())
+
+try:
+    AgentServer.custom_recognition("MyAct")(MyRecognition)
+    assert False, "duplicate custom decorator should raise RuntimeError"
+except RuntimeError as error:
+    assert str(error) == "Custom name is already registered: 'MyAct'"
+
+try:
+    AgentServer.custom_action("MyRec")(MyAction)
+    assert False, "duplicate custom decorator should raise RuntimeError"
+except RuntimeError as error:
+    assert str(error) == "Custom name is already registered: 'MyRec'"
+
+for custom_decorator in [AgentServer.custom_recognition, AgentServer.custom_action]:
+    try:
+        custom_decorator("")
+        assert False, "empty custom name should raise ValueError"
+    except ValueError as error:
+        assert str(error) == "Custom name must not be empty"
+
+
 # ============================================================================
 # Event Sink 装饰器方式注册
 # ============================================================================

--- a/test/agent/agent_main_test.py
+++ b/test/agent/agent_main_test.py
@@ -115,7 +115,7 @@ def api_test():
     # ============================================================
     # 启动 AgentServer 子进程
     # ============================================================
-    subprocess.Popen(
+    child_process = subprocess.Popen(
         [
             "python",
             str(Path(__file__).parent / "agent_child_test.py"),
@@ -124,14 +124,6 @@ def api_test():
             socket_id,
         ],
     )
-
-    conflicting_action = ConflictingAction()
-    assert resource.register_custom_action("MyAct", conflicting_action)
-    assert not agent.connect(), "connect should fail on duplicate custom name"
-    assert not agent.connected, "agent should remain disconnected after registration rollback"
-    assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
-    assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
-    assert resource.unregister_custom_action("MyAct")
 
     # 等待连接
     if not agent.connect():
@@ -211,9 +203,42 @@ def api_test():
         print("failed to disconnect")
         exit(1)
     print("agent.disconnect() succeeded")
+    child_process.wait(timeout=10)
+    assert child_process.returncode == 0
 
     # 验证断开连接后的状态
     print(f"agent.connected after disconnect: {agent.connected}")
+
+    # 用独立 socket 测试注册冲突，避免依赖失败后的 socket 重建行为。
+    conflict_agent = AgentClient()
+    conflict_socket_id = conflict_agent.identifier
+    assert conflict_agent.bind(resource)
+    assert conflict_agent.register_sink(resource, dbg_controller, tasker)
+
+    conflict_child = subprocess.Popen(
+        [
+            "python",
+            str(Path(__file__).parent / "agent_child_test.py"),
+            str(binding_dir),
+            str(install_dir),
+            conflict_socket_id,
+        ],
+    )
+
+    try:
+        assert resource.register_custom_action("MyAct", ConflictingAction())
+        assert not conflict_agent.connect(), "connect should fail on duplicate custom name"
+        assert not conflict_agent.connected, "agent should remain disconnected after registration rollback"
+        assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
+        assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
+        assert conflict_agent.disconnect(), "disconnect should stop the server after registration rollback"
+        conflict_child.wait(timeout=10)
+        assert conflict_child.returncode == 0
+    finally:
+        if conflict_child.poll() is None:
+            conflict_agent.disconnect()
+            conflict_child.terminate()
+            conflict_child.wait(timeout=10)
 
     print("\n" + "=" * 50)
     print("All agent tests passed!")

--- a/test/agent/agent_main_test.py
+++ b/test/agent/agent_main_test.py
@@ -32,6 +32,12 @@ from maa.controller import DbgController
 from maa.tasker import Tasker
 from maa.agent_client import AgentClient
 from maa.toolkit import Toolkit
+from maa.custom_action import CustomAction
+
+
+class ConflictingAction(CustomAction):
+    def run(self, context, argv):
+        return True
 
 
 def api_test():
@@ -118,6 +124,14 @@ def api_test():
             socket_id,
         ],
     )
+
+    conflicting_action = ConflictingAction()
+    assert resource.register_custom_action("MyAct", conflicting_action)
+    assert not agent.connect(), "connect should fail on duplicate custom name"
+    assert not agent.connected, "agent should remain disconnected after registration rollback"
+    assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
+    assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
+    assert resource.unregister_custom_action("MyAct")
 
     # 等待连接
     if not agent.connect():

--- a/test/agent/agent_tcp_main_test.py
+++ b/test/agent/agent_tcp_main_test.py
@@ -123,7 +123,7 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
     # ============================================================
     # 启动 AgentServer 子进程 (TCP 模式)
     # ============================================================
-    subprocess.Popen(
+    child_process = subprocess.Popen(
         [
             sys.executable,
             str(Path(__file__).parent / "agent_tcp_child_test.py"),
@@ -132,14 +132,6 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
             socket_id,  # 传递端口号字符串
         ],
     )
-
-    conflicting_action = ConflictingAction()
-    assert resource.register_custom_action("MyAct", conflicting_action)
-    assert not agent.connect(), "connect should fail on duplicate custom name"
-    assert not agent.connected, "agent should remain disconnected after registration rollback"
-    assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
-    assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
-    assert resource.unregister_custom_action("MyAct")
 
     # 等待连接
     if not agent.connect():
@@ -219,9 +211,41 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
         print("failed to disconnect")
         exit(1)
     print("agent.disconnect() succeeded")
+    child_process.wait(timeout=10)
+    assert child_process.returncode == 0
 
     # 验证断开连接后的状态
     print(f"agent.connected after disconnect: {agent.connected}")
+
+    # 用独立 socket 测试注册冲突，避免依赖失败后的 socket 重建行为。
+    conflict_agent = AgentClient.create_tcp(0)
+    assert conflict_agent.bind(resource)
+    assert conflict_agent.register_sink(resource, dbg_controller, tasker)
+
+    conflict_child = subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "agent_tcp_child_test.py"),
+            str(binding_dir),
+            str(install_dir),
+            conflict_agent.identifier,
+        ],
+    )
+
+    try:
+        assert resource.register_custom_action("MyAct", ConflictingAction())
+        assert not conflict_agent.connect(), "connect should fail on duplicate custom name"
+        assert not conflict_agent.connected, "agent should remain disconnected after registration rollback"
+        assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
+        assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
+        assert conflict_agent.disconnect(), "disconnect should stop the server after registration rollback"
+        conflict_child.wait(timeout=10)
+        assert conflict_child.returncode == 0
+    finally:
+        if conflict_child.poll() is None:
+            conflict_agent.disconnect()
+            conflict_child.terminate()
+            conflict_child.wait(timeout=10)
 
     print("\n" + "=" * 50)
     print(f"{scenario} passed!")

--- a/test/agent/agent_tcp_main_test.py
+++ b/test/agent/agent_tcp_main_test.py
@@ -33,6 +33,12 @@ from maa.controller import DbgController
 from maa.tasker import Tasker
 from maa.agent_client import AgentClient
 from maa.toolkit import Toolkit
+from maa.custom_action import CustomAction
+
+
+class ConflictingAction(CustomAction):
+    def run(self, context, argv):
+        return True
 
 NUMERIC_IDENTIFIER_FLAG = "--numeric-identifier-flow"
 
@@ -126,6 +132,14 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
             socket_id,  # 传递端口号字符串
         ],
     )
+
+    conflicting_action = ConflictingAction()
+    assert resource.register_custom_action("MyAct", conflicting_action)
+    assert not agent.connect(), "connect should fail on duplicate custom name"
+    assert not agent.connected, "agent should remain disconnected after registration rollback"
+    assert "MyAct" in resource.custom_action_list, "existing custom action should be preserved"
+    assert "MyRec" not in resource.custom_recognition_list, "agent registrations should be rolled back"
+    assert resource.unregister_custom_action("MyAct")
 
     # 等待连接
     if not agent.connect():

--- a/test/nodejs/binding.ts
+++ b/test/nodejs/binding.ts
@@ -124,6 +124,45 @@ async function api_test() {
 
     resource.register_custom_action('MyAct', myAct)
     resource.register_custom_recognition('MyRec', myReco)
+    resource.register_custom_recognition('ResourceCaseSensitive', myReco)
+    resource.register_custom_action('resourcecasesensitive', myAct)
+
+    for (const { register, expectedMessage } of [
+        {
+            register: () => resource.register_custom_action('MyAct', myAct),
+            expectedMessage: "Custom name is already registered: 'MyAct'"
+        },
+        {
+            register: () => resource.register_custom_recognition('MyRec', myReco),
+            expectedMessage: "Custom name is already registered: 'MyRec'"
+        },
+        {
+            register: () => resource.register_custom_action('MyRec', myAct),
+            expectedMessage: "Custom name is already registered: 'MyRec'"
+        },
+        {
+            register: () => resource.register_custom_recognition('MyAct', myReco),
+            expectedMessage: "Custom name is already registered: 'MyAct'"
+        },
+        {
+            register: () => resource.register_custom_action('', myAct),
+            expectedMessage: 'Custom name must not be empty'
+        },
+        {
+            register: () => resource.register_custom_recognition('', myReco),
+            expectedMessage: 'Custom name must not be empty'
+        }
+    ]) {
+        let errorMessage = ''
+        try {
+            register()
+        } catch (error) {
+            errorMessage = error instanceof Error ? error.message : String(error)
+        }
+        if (!errorMessage.includes(expectedMessage)) {
+            throw new Error(`unexpected custom registration error: ${errorMessage}`)
+        }
+    }
 
     const ppover = {
         Entry: { next: 'Rec' },

--- a/test/nodejs/server.ts
+++ b/test/nodejs/server.ts
@@ -1,10 +1,60 @@
 import './maa-server.ts'
 
+const myReco: maa.CustomRecognitionCallback = () => [[0, 0, 0, 0], 'NodeServerRec']
+const myAct: maa.CustomActionCallback = () => true
+
+function expectRegistrationError(register: () => void, expectedMessage: string) {
+    let errorMessage = ''
+    try {
+        register()
+    } catch (error) {
+        errorMessage = error instanceof Error ? error.message : String(error)
+    }
+    if (!errorMessage.includes(expectedMessage)) {
+        throw new Error(`unexpected custom registration error: ${errorMessage}`)
+    }
+}
+
 async function main() {
     console.log('MaaFw Version:', maa.Global)
     // console.log('MaaFw Role', maa.AgentRole)
 
     console.log('AgentServer', maa.Server)
+
+    maa.Server.register_custom_action('NodeServerAct', myAct)
+    maa.Server.register_custom_recognition('NodeServerRec', myReco)
+
+    for (const { register, expectedMessage } of [
+        {
+            register: () => maa.Server.register_custom_action('NodeServerAct', myAct),
+            expectedMessage: "Custom name is already registered: 'NodeServerAct'"
+        },
+        {
+            register: () => maa.Server.register_custom_recognition('NodeServerRec', myReco),
+            expectedMessage: "Custom name is already registered: 'NodeServerRec'"
+        },
+        {
+            register: () => maa.Server.register_custom_action('NodeServerRec', myAct),
+            expectedMessage: "Custom name is already registered: 'NodeServerRec'"
+        },
+        {
+            register: () => maa.Server.register_custom_recognition('NodeServerAct', myReco),
+            expectedMessage: "Custom name is already registered: 'NodeServerAct'"
+        },
+        {
+            register: () => maa.Server.register_custom_action('', myAct),
+            expectedMessage: 'Custom name must not be empty'
+        },
+        {
+            register: () => maa.Server.register_custom_recognition('', myReco),
+            expectedMessage: 'Custom name must not be empty'
+        }
+    ]) {
+        expectRegistrationError(register, expectedMessage)
+    }
+
+    maa.Server.register_custom_recognition('NodeServerCaseSensitive', myReco)
+    maa.Server.register_custom_action('nodeservercasesensitive', myAct)
 
     process.exit(0)
 }

--- a/test/python/binding_test.py
+++ b/test/python/binding_test.py
@@ -276,8 +276,40 @@ def test_resource_api():
     # 测试自定义识别/动作注册
     my_reco = MyRecognition()
     my_action = MyAction()
-    resource.register_custom_recognition("MyRec", my_reco)
-    resource.register_custom_action("MyAct", my_action)
+    assert resource.register_custom_recognition("MyRec", my_reco)
+    assert resource.register_custom_action("MyAct", my_action)
+
+    duplicate_reco = MyRecognition()
+    duplicate_action = MyAction()
+    assert not resource.register_custom_recognition("MyRec", duplicate_reco)
+    assert not resource.register_custom_action("MyAct", duplicate_action)
+    assert not resource.register_custom_action("MyRec", duplicate_action)
+    assert not resource.register_custom_recognition("MyAct", duplicate_reco)
+    assert resource._custom_recognition_holder["MyRec"] is my_reco
+    assert resource._custom_action_holder["MyAct"] is my_action
+    assert resource.register_custom_recognition("CaseSensitive", MyRecognition())
+    assert resource.register_custom_action("casesensitive", MyAction())
+    assert not resource.register_custom_recognition("", MyRecognition())
+    assert not resource.register_custom_action("", MyAction())
+
+    try:
+        resource.custom_recognition("MyAct")(MyRecognition)
+        assert False, "duplicate custom decorator should raise RuntimeError"
+    except RuntimeError as error:
+        assert str(error) == "Custom name is already registered: 'MyAct'"
+
+    try:
+        resource.custom_action("MyRec")(MyAction)
+        assert False, "duplicate custom decorator should raise RuntimeError"
+    except RuntimeError as error:
+        assert str(error) == "Custom name is already registered: 'MyRec'"
+
+    for custom_decorator in [resource.custom_recognition, resource.custom_action]:
+        try:
+            custom_decorator("")
+            assert False, "empty custom name should raise ValueError"
+        except ValueError as error:
+            assert str(error) == "Custom name must not be empty"
 
     # 测试 custom_recognition_list 和 custom_action_list
     reco_list = resource.custom_recognition_list
@@ -300,8 +332,8 @@ def test_resource_api():
     assert "MyAct" not in action_list_after, "MyAct should be unregistered"
 
     # 重新注册用于后续测试
-    resource.register_custom_recognition("MyRec", my_reco)
-    resource.register_custom_action("MyAct", my_action)
+    assert resource.register_custom_recognition("MyRec", my_reco)
+    assert resource.register_custom_action("MyAct", my_action)
 
     # 测试 override_pipeline (resource 级别)
     # 先创建被引用的节点


### PR DESCRIPTION
## 概述

- 禁止注册空名称或重复名称的 Custom。
- `CustomRecognition` 和 `CustomAction` 共用同一个大小写敏感的命名空间。
- C API、Python Binding 和 NodeJS Binding 统一返回或抛出注册失败结果。
- 注册冲突时保留既有注册，不产生部分注册状态。
- AgentClient 连接过程中注册失败时，回滚本次连接已注册的 Custom；显式 `disconnect()` 仍可请求 AgentServer 退出。
- Agent 协议版本由 7 升级至 8。

## 测试

- 新增 Python Resource 和 AgentServer 重复注册测试。
- 新增 NodeJS Resource 和 AgentServer 注册测试。
- 新增 `Foo` / `foo` 大小写敏感测试。
- 新增 IPC 和 TCP AgentClient 注册回滚测试。
- C++ 构建和安装通过。
- Python Binding、Agent IPC、Agent TCP 测试通过。
- Python 语法检查、NodeJS TypeScript 语法检查和 `git diff --check` 通过。
- NodeJS 依赖使用 frozen lockfile 安装；完整 NodeJS 运行时由 CI 覆盖。

本次修改了 `.github/workflows/test.yml`，合并前需要 dry run 所有 workflows。

Closes #1404