### PR TITLE
docs: add failure attachment sampling to PI telemetry

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -32,6 +32,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-07-01 | v2.8.1  | Added `controller` / `resource` filters for `pretask`, with the same semantics as `task.controller` / `task.resource` |
 | 2026-07-22 | v2.9.0  | Added the `telemetry` anonymous telemetry (data reporting) configuration field |
 | 2026-08-05 | v2.9.1  | Added the `trace` field on `focus` message template objects for controlling whether node results are uploaded to telemetry by callback message type |
+| 2026-08-23 | v2.9.2  | Added the `telemetry.sentry.failure_attachments_sample_rate` field for independent failure diagnostic attachment sampling |
 
 ## `interface.json`
 
@@ -121,6 +122,9 @@ We have designated the version number for the independent release (January 30, 2
 
     - **traces_sample_rate** `number`  
       Transaction sample rate, ranging from `0` to `1`. _Optional_, defaults to `1.0`. Tasks are low-frequency business events; full sampling yields accurate success / failure statistics. For a large user base, this can be lowered to control the Sentry quota, but statistics then become sampled.
+
+    - **failure_attachments_sample_rate** `number` **💡 v2.9.2**  
+      Independent sampling rate for failure diagnostic attachments, ranging from `0` to `1`. _Optional_, defaults to `1.0`; `0` uploads no attachments and `1` uploads all eligible attachments. This only controls attachments uploaded with failure or error events and does not affect the corresponding Error Event, Sentry Logs, or transaction sampling. Clients that do not collect failure diagnostic attachments may ignore this field.
 
     - **environment** `string`  
       Environment label (e.g. `production`, `beta`), used to distinguish in Sentry. _Optional_; the default is decided by the Client (e.g. using the update channel, or falling back to `production`).

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -32,6 +32,7 @@
 | 2026-7-1 | v2.8.1 | `pretask` 支持 `controller` / `resource` 过滤字段，与 `task.controller` / `task.resource` 语义一致 |
 | 2026-7-22 | v2.9.0 | 新增 `telemetry` 匿名遥测（数据埋点）配置字段 |
 | 2026-8-5 | v2.9.1 | 新增 `focus` 消息模板对象的 `trace` 字段，用于按回调消息类型控制遥测是否上传节点结果 |
+| 2026-8-23 | v2.9.2 | 新增 `telemetry.sentry.failure_attachments_sample_rate` 失败诊断附件独立采样率字段 |
 
 ## `interface.json`
 
@@ -121,6 +122,9 @@
 
     - traces_sample_rate `number`  
       事务采样率，取值 `0`~`1`。可选，默认 `1.0`。任务为低频业务事件，全量上报可获得精确的成功 / 失败统计；用户量较大时可调低以控制 Sentry 配额，但统计将变为抽样。
+
+    - failure_attachments_sample_rate `number` **💡 v2.9.2**  
+      失败诊断附件独立采样率，取值 `0`~`1`。可选，默认 `1.0`；`0` 表示不上传附件，`1` 表示上传所有符合条件的附件。仅控制随失败 / 错误事件上传的附件，不影响对应的 Error Event、Sentry Logs 或事务采样。Client 不支持采集失败诊断附件时可忽略此字段。
 
     - environment `string`  
       环境标签（如 `production`、`beta`），用于在 Sentry 中区分。可选；缺省由 Client 决定（如使用更新频道，或回退为 `production`）。

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -1204,6 +1204,13 @@
                             "minimum": 0,
                             "maximum": 1
                         },
+                        "failure_attachments_sample_rate": {
+                            "type": "number",
+                            "title": "失败诊断附件采样率",
+                            "description": "💡 v2.9.2 可选。取值 0~1，默认 1.0；仅控制随失败 / 错误事件上传的附件，不影响对应的 Error Event、Sentry Logs 或事务采样",
+                            "minimum": 0,
+                            "maximum": 1
+                        },
                         "environment": {
                             "type": "string",
                             "title": "环境标签",


### PR DESCRIPTION
## Summary

- add PI v2.9.2 `telemetry.sentry.failure_attachments_sample_rate`
- document the field in Chinese and English
- validate the optional value as a number in the inclusive range `0` to `1`

## Motivation

Sentry failure attachments consume a quota that is independent from transaction volume. `traces_sample_rate` only controls transactions, so clients currently cannot reduce diagnostic attachment volume without either sampling unrelated telemetry or using a schema-invalid private extension.

The same field is already consumed by [MXU PR #309](https://github.com/MistEO/MXU/pull/309) and [MFAAvalonia](https://github.com/MaaXYZ/MFAAvalonia/commit/c3b2d1d1ea28dbc6788f97f3dad765b727d41b55). Adding it to PI makes those implementations schema-compliant and gives resource authors one portable setting.

## Semantics and compatibility

- `0`: upload no eligible failure diagnostic attachments
- `1`: upload all eligible failure diagnostic attachments
- omitted: default to `1.0`, preserving existing behavior
- only attachments are sampled; the corresponding Error Event, Sentry Logs, and transaction sampling are unaffected
- clients that do not collect failure diagnostic attachments may ignore the field

## Validation

- parsed `tools/interface.schema.json` successfully
- compiled the schema with AJV
- verified `0`, `0.1`, and `1` are accepted
- verified negative values, values above `1`, strings, and an unknown misspelled field are rejected

## Sourcery 总结

向 Project Interface 架构和文档中添加可配置的 Sentry 失败诊断附件采样功能。

新功能：
- 在 Project Interface v2.9.2 中添加 `telemetry.sentry.failure_attachments_sample_rate` 字段，用于独立控制失败诊断附件的上传。

增强功能：
- 将该字段定义为可选的数值型采样率，取值范围为 0 到 1，同时默认保持完整采样。

文档：
- 在英文和中文的 Project Interface v2 文档中说明失败附件采样的语义。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 Project Interface v2 添加可配置的 Sentry 失败诊断附件采样功能。

新功能：
- 添加可选设置 `telemetry.sentry.failure_attachments_sample_rate`，用于在 Project Interface v2.9.2 中独立控制失败诊断附件的采样率。

增强功能：
- 将采样设置限制为 0 到 1 之间的数值；未设置时仍保留全量采样行为。

文档：
- 在英文和中文的 Project Interface v2 文档中记录新的失败附件采样设置及其语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable sampling for Sentry failure diagnostic attachments to Project Interface v2.

New Features:
- Add the optional `telemetry.sentry.failure_attachments_sample_rate` setting to independently control failure diagnostic attachment sampling in Project Interface v2.9.2.

Enhancements:
- Constrain the sampling setting to numeric values from 0 to 1 while preserving full-sampling behavior when omitted.

Documentation:
- Document the new failure attachment sampling setting and its semantics in the English and Chinese Project Interface v2 documentation.

</details>

</details>