### PR TITLE
feat:pi协议中添加加密字段

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -703,7 +703,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       Detailed input field description to help users understand input requirements. Supports file paths, URLs, or direct text. Content supports Markdown format. _Optional._ Supports internationalization (starting with `$`).
 
     - **default** `string`  
-      Default value for the input field. _Optional._
+      Default value for the input field. _Optional._ Must not be set when `password` is `true`; JSON Schema rejects this combination. **💡 v2.10.0**
 
     - **pipeline_type** `string`  
       The data type of the input field in pipeline_override. Valid values: `"string"`, `"int"`, `"bool"`. When using variable substitution in pipeline_override, type conversion is performed according to this type.
@@ -723,7 +723,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       - **Logs and telemetry:** Never write the plaintext to logs, telemetry, crash reports, or any shareable output. When a placeholder is needed, use a mask such as `******`, or omit the field entirely.
       - **Config storage:** When writing the user configuration file, the value must be stored encrypted. Plaintext must not be persisted. After loading the config, decrypt only in memory for runtime use such as `pipeline_override` substitution and `pretask` arguments.
       - **Encryption:** The algorithm and ciphertext format are Client-defined; ciphertext need not be interoperable across Clients or machines. Prefer OS-provided credential protection (e.g. Windows DPAPI, macOS Keychain, Linux Secret Service).
-      - **`default` / `preset`:** Do not set `default` on password fields, and do not include password-field plaintext in `preset`. `interface.json` is typically distributed with resources, so plaintext secrets must not appear in it.
+      - **`default` / `preset`:** Do not set `default` on password fields (JSON Schema rejects `password: true` together with `default`). Do not include password-field plaintext in `preset`. That constraint requires a cross-reference between option definitions and preset values, **cannot** be expressed in JSON Schema, and must be enforced by the Client or a separate semantic validator. When applying a preset, the Client must skip password fields and must not write their plaintext into the user configuration. `interface.json` is typically distributed with resources, so plaintext secrets must not appear in it.
 
   - **hotkeys** `object[]`  
     Used only when `type` is `"hotkey"`. Hotkey configuration, an array of objects defining hotkey fields the user can capture. **💡 v2.8.0**
@@ -873,7 +873,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `input` | `record<string, string>` (input field name → value) | `{ "ChapterNumber": "4" }` |
       | `hotkey` | `record<string, string>` (hotkey field name → shortcut string) | `{ "FightCombo": "E" }` |
 
-      Input fields with `password` set to `true` must not appear in `preset`. **💡 v2.10.0**
+      Input fields with `password` set to `true` must not appear in `preset`. JSON Schema cannot enforce this constraint across option definitions; the Client or a semantic validator must. When applying a preset, the Client must skip these fields. **💡 v2.10.0**
 
   **Preset Example:**
 

--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -32,6 +32,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-07-01 | v2.8.1  | Added `controller` / `resource` filters for `pretask`, with the same semantics as `task.controller` / `task.resource` |
 | 2026-07-22 | v2.9.0  | Added the `telemetry` anonymous telemetry (data reporting) configuration field |
 | 2026-08-05 | v2.9.1  | Added the `trace` field on `focus` message template objects for controlling whether node results are uploaded to telemetry by callback message type |
+| 2026-08-24 | v2.10.0 | Added the `password` field on `input` option `inputs[]` to mark password/secret fields |
 
 ## `interface.json`
 
@@ -320,6 +321,7 @@ We have designated the version number for the independent release (January 30, 2
     _Optional._ Pre-task configuration options, an array whose elements should correspond to key names in the outer `option` configuration. The Client will prompt the user to make selections for these options.  
     If `option` is set, the Client should serialize the current values of these options as a **single-line compact JSON string**, and automatically append it as the last argument after `args`. If `option` is omitted or empty, this JSON argument is not appended.  
     The JSON object uses option key names as field names, and the value type is the same as `OptionValue` in `preset.task[].option`: `select` / `switch` use a `case.name` string, `checkbox` uses an array of `case.name` strings, and `input` uses an object from input field `name` to string value. Sub-options (`option.option`) activated by the user's selection should also be included under their own option key names; options that do not satisfy the current `controller` / `resource` constraints should not be included.  
+    In the JSON passed to the pre-task process, fields with `password` set to `true` should still use the decrypted plaintext (for the program to consume), but the Client must not write that JSON or the plaintext to logs. **💡 v2.10.0**  
     `pretask.option` is only used to generate arguments for the pre-task process; it does not participate in `pipeline_override` merging.  
 
   **Single pretask example:**
@@ -712,6 +714,17 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
     - **pattern_msg** `string`  
       Message displayed when regex validation of user input fails. _Optional._ Supports internationalization (starting with `$`).
 
+    - **password** `bool` **💡 v2.10.0**  
+      _Optional_, defaults to `false`. When `true`, treat this input field as a password / secret.
+
+      The Client must follow these constraints:
+
+      - **UI:** Render a password input (masked). Do not echo the plaintext in the UI. Saved values must also be shown masked.
+      - **Logs and telemetry:** Never write the plaintext to logs, telemetry, crash reports, or any shareable output. When a placeholder is needed, use a mask such as `******`, or omit the field entirely.
+      - **Config storage:** When writing the user configuration file, the value must be stored encrypted. Plaintext must not be persisted. After loading the config, decrypt only in memory for runtime use such as `pipeline_override` substitution and `pretask` arguments.
+      - **Encryption:** The algorithm and ciphertext format are Client-defined; ciphertext need not be interoperable across Clients or machines. Prefer OS-provided credential protection (e.g. Windows DPAPI, macOS Keychain, Linux Secret Service).
+      - **`default` / `preset`:** Do not set `default` on password fields, and do not include password-field plaintext in `preset`. `interface.json` is typically distributed with resources, so plaintext secrets must not appear in it.
+
   - **hotkeys** `object[]`  
     Used only when `type` is `"hotkey"`. Hotkey configuration, an array of objects defining hotkey fields the user can capture. **💡 v2.8.0**
 
@@ -859,6 +872,8 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `checkbox` | `string[]` (array of `case.name`) | `["AutoBattle", "AutoPickup"]` |
       | `input` | `record<string, string>` (input field name → value) | `{ "ChapterNumber": "4" }` |
       | `hotkey` | `record<string, string>` (hotkey field name → shortcut string) | `{ "FightCombo": "E" }` |
+
+      Input fields with `password` set to `true` must not appear in `preset`. **💡 v2.10.0**
 
   **Preset Example:**
 
@@ -1024,6 +1039,42 @@ If both `global_option` and a `task.option` reference the same option, and that 
         "EnterTheShow": {
           "next": "MainChapter_{ChapterNumber}",
           "timeout": "{Timeout}"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Password Input Field Example 💡 v2.10.0
+
+A single `input` option may mix normal fields and password fields. Do not set `default` on password fields.
+
+```jsonc
+{
+  "option": {
+    "AccountLogin": {
+      "type": "input",
+      "label": "$AccountLogin",
+      "inputs": [
+        {
+          "name": "username",
+          "label": "$Username",
+          "pipeline_type": "string"
+        },
+        {
+          "name": "password",
+          "label": "$Password",
+          "pipeline_type": "string",
+          "password": true
+        }
+      ],
+      "pipeline_override": {
+        "Login": {
+          "custom_action_param": {
+            "username": "{username}",
+            "password": "{password}"
+          }
         }
       }
     }

--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -723,7 +723,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       - **Logs and telemetry:** Never write the plaintext to logs, telemetry, crash reports, or any shareable output. When a placeholder is needed, use a mask such as `******`, or omit the field entirely.
       - **Config storage:** When writing the user configuration file, the value must be stored encrypted. Plaintext must not be persisted. After loading the config, decrypt only in memory for runtime use such as `pipeline_override` substitution and `pretask` arguments.
       - **Encryption:** The algorithm and ciphertext format are Client-defined; ciphertext need not be interoperable across Clients or machines. Prefer OS-provided credential protection (e.g. Windows DPAPI, macOS Keychain, Linux Secret Service).
-      - **`default` / `preset`:** Do not set `default` on password fields (JSON Schema rejects `password: true` together with `default`). Do not include password-field plaintext in `preset`. That constraint requires a cross-reference between option definitions and preset values, **cannot** be expressed in JSON Schema, and must be enforced by the Client or a separate semantic validator. When applying a preset, the Client must skip password fields and must not write their plaintext into the user configuration. `interface.json` is typically distributed with resources, so plaintext secrets must not appear in it.
+      - **`default` / `preset`:** Do not set `default` on password fields (JSON Schema rejects `password: true` together with `default`). Resource authors must not put password fields in `preset`. `interface.json` is typically distributed with resources, so plaintext secrets must not appear in it.
 
   - **hotkeys** `object[]`  
     Used only when `type` is `"hotkey"`. Hotkey configuration, an array of objects defining hotkey fields the user can capture. **💡 v2.8.0**
@@ -873,7 +873,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `input` | `record<string, string>` (input field name → value) | `{ "ChapterNumber": "4" }` |
       | `hotkey` | `record<string, string>` (hotkey field name → shortcut string) | `{ "FightCombo": "E" }` |
 
-      Input fields with `password` set to `true` must not appear in `preset`. JSON Schema cannot enforce this constraint across option definitions; the Client or a semantic validator must. When applying a preset, the Client must skip these fields. **💡 v2.10.0**
+      Do not put input fields with `password` set to `true` in `preset`. **💡 v2.10.0**
 
   **Preset Example:**
 

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -32,6 +32,7 @@
 | 2026-7-1 | v2.8.1 | `pretask` 支持 `controller` / `resource` 过滤字段，与 `task.controller` / `task.resource` 语义一致 |
 | 2026-7-22 | v2.9.0 | 新增 `telemetry` 匿名遥测（数据埋点）配置字段 |
 | 2026-8-5 | v2.9.1 | 新增 `focus` 消息模板对象的 `trace` 字段，用于按回调消息类型控制遥测是否上传节点结果 |
+| 2026-8-24 | v2.10.0 | `input` 类型选项的 `inputs[]` 新增 `password` 字段，用于标记密码/密钥输入 |
 
 ## `interface.json`
 
@@ -321,6 +322,7 @@
     可选。预任务配置项，为一个数组，数组元素应与外层 `option` 配置中的键名对应。Client 会根据这些配置项让用户进行选择。  
     若设置了 `option`，Client 应将这些 option 的当前取值序列化为**单行紧凑 JSON 字符串**，并自动追加为最后一个参数，位于 `args` 之后。若未设置或为空，则不追加该 JSON 参数。  
     该 JSON 对象以 option 键名为字段名，取值类型与 `preset.task[].option` 中的 `OptionValue` 一致：`select` / `switch` 为 `case.name` 字符串，`checkbox` 为 `case.name` 字符串数组，`input` 为输入字段 `name` 到字符串值的对象。因用户选择而激活的子配置项（`option.option`）也应以其自身 option 键名加入该对象；不满足当前 `controller` / `resource` 限制的 option 不应加入。  
+    传给预任务进程的 JSON 中，`password` 为 `true` 的字段仍应使用解密后的原文（供程序使用），但 Client 不得将该 JSON 或其中的原文写入日志。 **💡 v2.10.0**  
     `pretask.option` 仅用于生成传给预任务进程的参数，不参与 `pipeline_override` 合并。  
 
   **单个 pretask 示例：**
@@ -710,6 +712,17 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
     - pattern_msg `string`  
       正则校验用户输入错误时，显示的信息。可选。支持国际化（以`$`开头）。
 
+    - password `bool` **💡 v2.10.0**  
+      可选，默认 `false`。为 `true` 时，将该输入字段视为密码 / 密钥。
+
+      Client 必须遵守以下约束：
+
+      - **界面：** 使用密码输入框（掩码显示），不得在 UI 中回显原文。已保存的值在界面中同样应掩码展示。
+      - **日志与遥测：** 不得将原文写入日志、遥测、崩溃报告或任何可分享的输出。需要占位时使用掩码（如 `******`），或直接省略该字段。
+      - **配置存储：** 写入用户配置文件时必须加密存储，不得以明文落盘。读取配置后仅在内存中解密，供 `pipeline_override` 替换、`pretask` 传参等运行时使用。
+      - **加密实现：** 算法与密文格式由 Client 自行决定，密文不必跨 Client / 跨设备可互解。建议优先使用操作系统提供的凭据保护（如 Windows DPAPI、macOS Keychain、Linux Secret Service）。
+      - **`default` / `preset`：** 密码字段不应设置 `default`，`preset` 中也不应包含密码字段的明文。`interface.json` 通常会随资源分发，明文密钥不得出现在其中。
+
   - hotkeys `object[]`  
     仅在 `type` 为 `"hotkey"` 时使用。快捷键配置，为一个对象数组，定义用户可捕获的快捷键字段。 **💡 v2.8.0**
 
@@ -857,6 +870,8 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `checkbox` | `string[]`（`case.name` 数组） | `["自动战斗", "自动拾取"]` |
       | `input` | `record<string, string>`（输入字段 name → 值） | `{ "章节号": "4" }` |
       | `hotkey` | `record<string, string>`（快捷键字段 name → 快捷键字符串） | `{ "FightCombo": "E" }` |
+
+      `password` 为 `true` 的输入字段不应出现在 `preset` 中。 **💡 v2.10.0**
 
   **预设示例：**
 
@@ -1022,6 +1037,42 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
         "EnterTheShow": {
           "next": "MainChapter_{章节号}",
           "timeout": "{超时时间}"
+        }
+      }
+    }
+  }
+}
+```
+
+#### password 输入字段示例 💡 v2.10.0
+
+同一 `input` 选项中可以混合普通字段与密码字段。密码字段不要填写 `default`。
+
+```jsonc
+{
+  "option": {
+    "账号登录": {
+      "type": "input",
+      "label": "$账号登录",
+      "inputs": [
+        {
+          "name": "username",
+          "label": "$用户名",
+          "pipeline_type": "string"
+        },
+        {
+          "name": "password",
+          "label": "$密码",
+          "pipeline_type": "string",
+          "password": true
+        }
+      ],
+      "pipeline_override": {
+        "Login": {
+          "custom_action_param": {
+            "username": "{username}",
+            "password": "{password}"
+          }
         }
       }
     }

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -721,7 +721,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       - **日志与遥测：** 不得将原文写入日志、遥测、崩溃报告或任何可分享的输出。需要占位时使用掩码（如 `******`），或直接省略该字段。
       - **配置存储：** 写入用户配置文件时必须加密存储，不得以明文落盘。读取配置后仅在内存中解密，供 `pipeline_override` 替换、`pretask` 传参等运行时使用。
       - **加密实现：** 算法与密文格式由 Client 自行决定，密文不必跨 Client / 跨设备可互解。建议优先使用操作系统提供的凭据保护（如 Windows DPAPI、macOS Keychain、Linux Secret Service）。
-      - **`default` / `preset`：** 密码字段禁止设置 `default`（JSON Schema 会拒绝 `password: true` 与 `default` 同时出现）。`preset` 中不得包含密码字段的明文；该约束依赖 `option` 定义与 `preset` 取值的交叉引用，**无法**由 JSON Schema 表达，须由 Client 或独立语义校验器执行。应用预设时，Client 应忽略密码字段，不得把其中的明文写入用户配置。`interface.json` 通常会随资源分发，明文密钥不得出现在其中。
+      - **`default` / `preset`：** 密码字段禁止设置 `default`（JSON Schema 会拒绝 `password: true` 与 `default` 同时出现）。资源作者不要把密码字段写入 `preset`。`interface.json` 通常会随资源分发，明文密钥不得出现在其中。
 
   - hotkeys `object[]`  
     仅在 `type` 为 `"hotkey"` 时使用。快捷键配置，为一个对象数组，定义用户可捕获的快捷键字段。 **💡 v2.8.0**
@@ -871,7 +871,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `input` | `record<string, string>`（输入字段 name → 值） | `{ "章节号": "4" }` |
       | `hotkey` | `record<string, string>`（快捷键字段 name → 快捷键字符串） | `{ "FightCombo": "E" }` |
 
-      `password` 为 `true` 的输入字段不得出现在 `preset` 中。JSON Schema 无法跨 `option` 定义校验此约束，须由 Client 或语义校验器执行；应用预设时 Client 应忽略这些字段。 **💡 v2.10.0**
+      `password` 为 `true` 的输入字段不要写入 `preset`。 **💡 v2.10.0**
 
   **预设示例：**
 

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -701,7 +701,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       输入字段详细描述信息，帮助用户理解输入要求。支持文件路径、URL或直接文本，内容支持Markdown格式。可选。支持国际化（以`$`开头）。
 
     - default `string`  
-      输入字段的默认值。可选。
+      输入字段的默认值。可选。`password` 为 `true` 时禁止设置此字段；JSON Schema 会拒绝该组合。 **💡 v2.10.0**
 
     - pipeline_type `string`  
       输入字段在 pipeline_override 中的数据类型。可选值：`"string"`, `"int"`, `"bool"`。当使用 pipeline_override 中的变量替换时，会根据该类型进行类型转换。
@@ -721,7 +721,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       - **日志与遥测：** 不得将原文写入日志、遥测、崩溃报告或任何可分享的输出。需要占位时使用掩码（如 `******`），或直接省略该字段。
       - **配置存储：** 写入用户配置文件时必须加密存储，不得以明文落盘。读取配置后仅在内存中解密，供 `pipeline_override` 替换、`pretask` 传参等运行时使用。
       - **加密实现：** 算法与密文格式由 Client 自行决定，密文不必跨 Client / 跨设备可互解。建议优先使用操作系统提供的凭据保护（如 Windows DPAPI、macOS Keychain、Linux Secret Service）。
-      - **`default` / `preset`：** 密码字段不应设置 `default`，`preset` 中也不应包含密码字段的明文。`interface.json` 通常会随资源分发，明文密钥不得出现在其中。
+      - **`default` / `preset`：** 密码字段禁止设置 `default`（JSON Schema 会拒绝 `password: true` 与 `default` 同时出现）。`preset` 中不得包含密码字段的明文；该约束依赖 `option` 定义与 `preset` 取值的交叉引用，**无法**由 JSON Schema 表达，须由 Client 或独立语义校验器执行。应用预设时，Client 应忽略密码字段，不得把其中的明文写入用户配置。`interface.json` 通常会随资源分发，明文密钥不得出现在其中。
 
   - hotkeys `object[]`  
     仅在 `type` 为 `"hotkey"` 时使用。快捷键配置，为一个对象数组，定义用户可捕获的快捷键字段。 **💡 v2.8.0**
@@ -871,7 +871,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       | `input` | `record<string, string>`（输入字段 name → 值） | `{ "章节号": "4" }` |
       | `hotkey` | `record<string, string>`（快捷键字段 name → 快捷键字符串） | `{ "FightCombo": "E" }` |
 
-      `password` 为 `true` 的输入字段不应出现在 `preset` 中。 **💡 v2.10.0**
+      `password` 为 `true` 的输入字段不得出现在 `preset` 中。JSON Schema 无法跨 `option` 定义校验此约束，须由 Client 或语义校验器执行；应用预设时 Client 应忽略这些字段。 **💡 v2.10.0**
 
   **预设示例：**
 

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -79,7 +79,7 @@
                 "default": {
                     "type": "string",
                     "title": "默认值",
-                    "description": "输入字段的默认值"
+                    "description": "输入字段的默认值。💡 v2.10.0 password 为 true 时禁止设置此字段"
                 },
                 "pipeline_type": {
                     "type": "string",
@@ -104,14 +104,31 @@
                 "password": {
                     "type": "boolean",
                     "title": "密码字段",
-                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用",
+                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用。为 true 时禁止同时设置 default",
                     "default": false
                 }
             },
             "required": [
                 "name"
             ],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "if": {
+                "properties": {
+                    "password": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "password"
+                ]
+            },
+            "then": {
+                "not": {
+                    "required": [
+                        "default"
+                    ]
+                }
+            }
         },
         "hotkeyItem": {
             "type": "object",
@@ -1370,7 +1387,7 @@
                                 "option": {
                                     "type": "object",
                                     "title": "任务选项预设值",
-                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 password 为 true 的输入字段不得出现在预设值中；该跨 option 定义的约束无法由本 Schema 表达，须由 Client 或语义校验器执行",
                                     "additionalProperties": true
                                 }
                             },

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -1387,7 +1387,7 @@
                                 "option": {
                                     "type": "object",
                                     "title": "任务选项预设值",
-                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 password 为 true 的输入字段不得出现在预设值中；该跨 option 定义的约束无法由本 Schema 表达，须由 Client 或语义校验器执行",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 资源作者不要把 password 为 true 的输入字段写入预设值",
                                     "additionalProperties": true
                                 }
                             },

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -100,6 +100,12 @@
                     "$ref": "#/definitions/i18nString",
                     "title": "校验错误信息",
                     "description": "正则校验用户输入错误时显示的信息"
+                },
+                "password": {
+                    "type": "boolean",
+                    "title": "密码字段",
+                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用",
+                    "default": false
                 }
             },
             "required": [

--- a/tools/interface_import.schema.json
+++ b/tools/interface_import.schema.json
@@ -536,7 +536,7 @@
                                 "option": {
                                     "type": "object",
                                     "title": "任务选项预设值",
-                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 password 为 true 的输入字段不得出现在预设值中；该跨 option 定义的约束无法由本 Schema 表达，须由 Client 或语义校验器执行",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 资源作者不要把 password 为 true 的输入字段写入预设值",
                                     "additionalProperties": true
                                 }
                             },

--- a/tools/interface_import.schema.json
+++ b/tools/interface_import.schema.json
@@ -79,7 +79,7 @@
                 "default": {
                     "type": "string",
                     "title": "默认值",
-                    "description": "输入字段的默认值"
+                    "description": "输入字段的默认值。💡 v2.10.0 password 为 true 时禁止设置此字段"
                 },
                 "pipeline_type": {
                     "type": "string",
@@ -104,14 +104,31 @@
                 "password": {
                     "type": "boolean",
                     "title": "密码字段",
-                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用",
+                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用。为 true 时禁止同时设置 default",
                     "default": false
                 }
             },
             "required": [
                 "name"
             ],
-            "additionalProperties": false
+            "additionalProperties": false,
+            "if": {
+                "properties": {
+                    "password": {
+                        "const": true
+                    }
+                },
+                "required": [
+                    "password"
+                ]
+            },
+            "then": {
+                "not": {
+                    "required": [
+                        "default"
+                    ]
+                }
+            }
         },
         "optionDefinition": {
             "type": "object",
@@ -519,7 +536,7 @@
                                 "option": {
                                     "type": "object",
                                     "title": "任务选项预设值",
-                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>。💡 v2.10.0 password 为 true 的输入字段不得出现在预设值中；该跨 option 定义的约束无法由本 Schema 表达，须由 Client 或语义校验器执行",
                                     "additionalProperties": true
                                 }
                             },

--- a/tools/interface_import.schema.json
+++ b/tools/interface_import.schema.json
@@ -100,6 +100,12 @@
                     "$ref": "#/definitions/i18nString",
                     "title": "校验错误信息",
                     "description": "正则校验用户输入错误时显示的信息"
+                },
+                "password": {
+                    "type": "boolean",
+                    "title": "密码字段",
+                    "description": "💡 v2.10.0 可选，默认 false。为 true 时 Client 应将该字段视为密码：UI 掩码显示，不得将原文写入日志/遥测；用户配置中须加密存储，仅在内存中解密供运行时使用",
+                    "default": false
                 }
             },
             "required": [


### PR DESCRIPTION
## Sourcery 摘要

为 PI 协议添加加密密码字段支持，同时防止密码值出现在面向用户或可共享的数据中。

新功能：
- 为 PI 输入字段添加 `password` 标志，用于标识敏感值并定义其在各客户端中的处理方式。

改进：
- 记录密码输入的安全处理要求，包括掩码显示、加密配置存储，以及从日志、遥测数据、默认值和预设值中排除。

文档：
- 更新英文和中文 Project Interface V2 文档，添加密码字段行为、示例以及 v2.10.0 版本条目。

维护工作：
- 扩展接口架构，以支持新的 `password` 输入属性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 PI 协议添加安全密码字段支持，并记录其处理要求。

新功能：
- 为 PI 协议输入字段添加 `password` 属性，用于标识机密值并定义客户端的安全处理方式。

增强功能：
- 明确密码输入的安全处理要求，包括掩码显示、加密配置存储，以及从日志、遥测数据、默认值和预设值中排除。

文档：
- 更新英文和中文 Project Interface V2 文档，加入密码字段行为、示例以及 v2.10.0 条目。

杂项：
- 扩展接口架构，以支持新的密码输入属性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为 PI 协议添加安全密码字段支持，并记录其处理要求。

新功能：
- 为 PI 输入字段添加 `password` 属性，用于标识机密值并定义客户端的安全处理方式。

增强功能：
- 明确密码值的安全处理要求，包括掩码显示、加密配置存储，以及从日志、遥测数据、默认值和预设值中排除。

文档：
- 在英文和中文的 Project Interface V2 规范中记录密码输入行为、示例以及 v2.10.0 接口版本。

例行工作：
- 扩展接口架构，以支持新的密码输入属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add secure password-field support to the PI protocol and document its handling requirements.

New Features:
- Add a `password` attribute to PI input fields to identify secret values and define secure client handling.

Enhancements:
- Specify secure handling for password values, including masked display, encrypted configuration storage, and exclusion from logs, telemetry, defaults, and presets.

Documentation:
- Document password input behavior, examples, and the v2.10.0 interface version in the English and Chinese Project Interface V2 specifications.

Chores:
- Extend the interface schemas to support the new password input attribute.

</details>

</details>

</details>