### PR TITLE
ci: bump setup-windows10-sdk-action to v2.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
                   git submodule update --remote source/MaaUtils
 
             - name: Setup Windows 10 SDK
-              uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+              uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.5
               with:
                   sdk-version: 26100
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
                   submodules: recursive
 
             - name: Setup Windows 10 SDK
-              uses: GuillaumeFalourd/setup-windows10-sdk-action@v2
+              uses: GuillaumeFalourd/setup-windows10-sdk-action@v2.5
               with:
                   sdk-version: 26100
 


### PR DESCRIPTION
## Summary
- Bump `GuillaumeFalourd/setup-windows10-sdk-action` from `v2` to `v2.5` in the Windows build and test jobs.

## Context
Refs https://github.com/GuillaumeFalourd/setup-windows10-sdk-action/issues/31

`v2` triggers the GitHub Actions Node.js 20 deprecation warning; `v2.5` resolves it.

## Sourcery 总结

CI：
- 更新 Windows 构建和测试工作流，以使用 setup-windows10-sdk-action v2.5，消除之前版本操作所产生的 Node.js 20 弃用警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the Windows build and test workflows to use setup-windows10-sdk-action v2.5, eliminating the Node.js 20 deprecation warning from the previous action version.

</details>