### PR TITLE
feat: Agent 优雅关闭——关闭回调 API、可中断等待与断开时序修复

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,7 @@ jobs:
                   ./install/bin/PipelineTesting.exe ./install/test
 
             - name: Run Python testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   python3 -m pip install ./source/binding/Python
@@ -147,13 +148,17 @@ jobs:
                   python3 ./test/python/pipeline_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_main_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_tcp_main_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_dead_server_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_interrupt_main_test.py ./source/binding/Python ./install
 
             - name: Run NodeJS testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()
@@ -340,6 +345,7 @@ jobs:
                   ./install/bin/PipelineTesting ./install/test
 
             - name: Run Python testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   python3 -m venv .venv
@@ -349,13 +355,17 @@ jobs:
                   python3 ./test/python/pipeline_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_main_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_tcp_main_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_dead_server_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_interrupt_main_test.py ./source/binding/Python ./install
 
             - name: Run NodeJS testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()
@@ -470,6 +480,7 @@ jobs:
                   ./install/bin/PipelineTesting ./install/test
 
             - name: Run Python testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   python3 -m venv .venv
@@ -479,13 +490,17 @@ jobs:
                   python3 ./test/python/pipeline_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_main_test.py ./source/binding/Python ./install
                   python3 ./test/agent/agent_tcp_main_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_dead_server_test.py ./source/binding/Python ./install
+                  python3 ./test/agent/agent_interrupt_main_test.py ./source/binding/Python ./install
 
             - name: Run NodeJS testing
+              timeout-minutes: 30
               shell: bash
               run: |
                   cd test/nodejs
                   pnpm i
                   node binding.ts
+                  node server.ts
 
             - uses: actions/upload-artifact@v7
               if: always()

--- a/docs/en_us/2.2-IntegratedInterfaceOverview.md
+++ b/docs/en_us/2.2-IntegratedInterfaceOverview.md
@@ -1243,6 +1243,17 @@ Add instance event listener, returns listener id
 
 Add context event listener, returns listener id
 
+### MaaAgentServerSetShutdownCallback
+
+- `callback`: Shutdown callback
+- `trans_arg`: Argument passed to callback
+
+Set the shutdown callback. It is invoked when the AgentServer receives a ShutDownRequest, before the message loop stops; the ShutDownResponse is replied only after the callback returns.  
+The host may block inside the callback to finish cleanup (e.g. sending in-flight notifications), but should return as soon as possible.  
+Do NOT call `MaaAgentServerJoin` / `MaaAgentServerShutDown` inside the callback (they wait for the server thread itself, which is undefined behavior, typically throwing and terminating the process), and do not throw exceptions from the callback.  
+Must be set before `MaaAgentServerStartUp` (setting it is not synchronized with the message loop reading it).  
+Re-setting overwrites the previous callback; passing `null` does NOT clear it (returns `false`).  
+
 ### MaaAgentServerStartUp
 
 - `identifier`: Connection address
@@ -1251,11 +1262,15 @@ Start server and connect to `identifier`
 
 ### MaaAgentServerShutDown
 
-Stop server
+Stop server.  
+A local call interrupts the message loop's blocking wait (`MaaAgentServerJoin` returns accordingly), waits for the server thread to end, then closes the connection; a remote ShutDownRequest from AgentClient stops the server as well (the callback registered via `MaaAgentServerSetShutdownCallback` runs first).  
+Do NOT call this inside the shutdown callback (see that entry).
 
 ### MaaAgentServerJoin
 
-Synchronously wait for server thread to end
+Synchronously wait for the server thread to end.  
+The thread ends when a remote ShutDownRequest arrives (after the shutdown callback completes and the message loop stops) or on a local `MaaAgentServerShutDown`; `Join` then returns.  
+If the client never sends a shutdown request nor disappears with a notification, `Join` may wait indefinitely — call `MaaAgentServerShutDown` to interrupt it as a fallback.
 
 ### MaaAgentServerDetach
 

--- a/docs/zh_cn/2.2-集成接口一览.md
+++ b/docs/zh_cn/2.2-集成接口一览.md
@@ -1239,6 +1239,17 @@ Agent 客户端会监听 127.0.0.1 上的指定 TCP 端口。如果传入 `0`，
 
 添加上下文事件监听器，返回监听器 id
 
+### MaaAgentServerSetShutdownCallback
+
+- `callback`: 关闭回调
+- `trans_arg`: 传递给回调的参数
+
+设置关闭回调。AgentServer 收到 ShutDownRequest 时、停止消息循环前调用该回调；回调返回后才会回复 ShutDownResponse。  
+宿主可在回调中阻塞以完成收尾工作（如发送在途通知），但应尽快返回；  
+注意勿在回调中调用 `MaaAgentServerJoin` / `MaaAgentServerShutDown`（会等待自身线程，属未定义行为，通常表现为抛异常并终止进程），回调中不得抛出异常。  
+必须在 `MaaAgentServerStartUp` 之前设置（设置与消息循环读取之间无同步）。  
+重复设置将覆盖已有回调；传 `null` 不会清除回调（返回 `false`）。  
+
 ### MaaAgentServerStartUp
 
 - `identifier`: 连接地址
@@ -1247,11 +1258,15 @@ Agent 客户端会监听 127.0.0.1 上的指定 TCP 端口。如果传入 `0`，
 
 ### MaaAgentServerShutDown
 
-停止服务
+停止服务。  
+本地调用会中断消息循环阻塞中的等待（`MaaAgentServerJoin` 随之返回），并等待服务线程结束后关闭连接；远端 AgentClient 发来 ShutDownRequest 时同样停止（先执行 `MaaAgentServerSetShutdownCallback` 注册的回调）。  
+注意勿在关闭回调内调用本接口（见该条目说明）。
 
 ### MaaAgentServerJoin
 
-同步等待服务线程结束
+同步等待服务线程结束。  
+服务线程在收到远端 ShutDownRequest（关闭回调执行完毕、消息循环停止）或本地 `MaaAgentServerShutDown` 后结束，`Join` 随之返回。  
+若客户端既未发送关闭请求也未断开通知（如客户端进程已消失），`Join` 可能无限等待——可调用 `MaaAgentServerShutDown` 兜底中断。
 
 ### MaaAgentServerDetach
 

--- a/include/MaaAgentServer/MaaAgentServerAPI.h
+++ b/include/MaaAgentServer/MaaAgentServerAPI.h
@@ -17,6 +17,8 @@ extern "C"
     MAA_AGENT_SERVER_API MaaSinkId MaaAgentServerAddTaskerSink(MaaEventCallback sink, void* trans_arg);
     MAA_AGENT_SERVER_API MaaSinkId MaaAgentServerAddContextSink(MaaEventCallback sink, void* trans_arg);
 
+    MAA_AGENT_SERVER_API MaaBool MaaAgentServerSetShutdownCallback(MaaShutdownCallback callback, void* trans_arg);
+
     MAA_AGENT_SERVER_API MaaBool MaaAgentServerStartUp(const char* identifier);
     MAA_AGENT_SERVER_API void MaaAgentServerShutDown();
     MAA_AGENT_SERVER_API void MaaAgentServerJoin();

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -689,5 +689,6 @@ typedef MaaBool(MAA_CALL* MaaCustomActionCallback)(
 /// - Must not throw exceptions;
 /// - Should return as soon as possible (the client is synchronously waiting);
 /// - Must be set before MaaAgentServerStartUp (no synchronization between setting
-///   and the message loop reading it).
+///   and the message loop reading it);
+/// - Re-setting overwrites the previous callback; passing null does NOT clear it.
 typedef void(MAA_CALL* MaaShutdownCallback)(void* trans_arg);

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -677,3 +677,17 @@ typedef MaaBool(MAA_CALL* MaaCustomActionCallback)(
     MaaRecoId reco_id,
     const MaaRect* box,
     void* trans_arg);
+
+/// AgentServer shutdown callback, set via MaaAgentServerSetShutdownCallback.
+/// Called when a remote ShutDownRequest is received, before the message loop stops;
+/// the ShutDownResponse is replied only after the callback returns, so the host may
+/// block inside the callback to finish cleanup (e.g. flushing in-flight notifications).
+/// Notes:
+/// - Runs on the AgentServer message thread: do NOT call MaaAgentServerJoin /
+///   MaaAgentServerShutDown inside the callback. They wait for the calling thread
+///   itself, which is undefined behavior (typically throws / terminates);
+/// - Must not throw exceptions;
+/// - Should return as soon as possible (the client is synchronously waiting);
+/// - Must be set before MaaAgentServerStartUp (no synchronization between setting
+///   and the message loop reading it).
+typedef void(MAA_CALL* MaaShutdownCallback)(void* trans_arg);

--- a/sample/cpp/MaaAgent/agent_child.cpp
+++ b/sample/cpp/MaaAgent/agent_child.cpp
@@ -36,6 +36,8 @@ MaaBool ChildCustomActionInnerCallback(
     const MaaRect* box,
     void* trans_arg);
 
+void ChildShutdownCallback(void* trans_arg);
+
 int main(int argc, char** argv)
 {
     std::string log_dir = "./debug";
@@ -46,6 +48,7 @@ int main(int argc, char** argv)
     MaaAgentServerRegisterCustomRecognition("ChildCustomRecognition", ChildCustomRecognitionCallback, nullptr);
     MaaAgentServerRegisterCustomAction("ChildCustomAction", ChildCustomActionCallback, nullptr);
     MaaAgentServerRegisterCustomAction("ChildCustomActionInner", ChildCustomActionInnerCallback, nullptr);
+    MaaAgentServerSetShutdownCallback(ChildShutdownCallback, nullptr);
 
     // from agent_main.cpp
     const char* identifier = argv[1];
@@ -56,6 +59,11 @@ int main(int argc, char** argv)
     MaaAgentServerShutDown();
 
     return 0;
+}
+
+void ChildShutdownCallback(void* /*trans_arg*/)
+{
+    std::cout << "at ChildShutdownCallback" << std::endl;
 }
 
 MaaBool ChildCustomActionCallback(

--- a/sample/nodejs/server.ts
+++ b/sample/nodejs/server.ts
@@ -38,12 +38,16 @@ async function main() {
 
     const socket_id = process.argv[process.argv.length - 1]
 
-    await maa.AgentServer.start_up(socket_id)
+    maa.Server.set_shutdown_callback(async () => {
+        console.log('on_shutdown: cleanup before server stops...')
+    })
 
-    maa.AgentServer.register_custom_recognizer('MyRecongition', my_reco)
+    await maa.Server.start_up(socket_id)
 
-    await maa.AgentServer.join()
-    maa.AgentServer.shut_down()
+    maa.Server.register_custom_recognition('MyRecongition', my_reco)
+
+    await maa.Server.join()
+    maa.Server.shut_down()
 }
 
 main()

--- a/sample/python/demo3_agent.py
+++ b/sample/python/demo3_agent.py
@@ -17,6 +17,13 @@ def main():
 
     socket_id = sys.argv[-1]
 
+    def on_shutdown() -> None:
+        print("on_shutdown: cleanup before server stops...")
+        # 回调返回后服务端才会回复 ShutDownResponse，可在此阻塞完成收尾；
+        # 回调运行在服务端消息线程，应尽快返回，勿在回调内调用 Join/ShutDown
+
+    AgentServer.set_shutdown_callback(on_shutdown)
+
     AgentServer.start_up(socket_id)
     AgentServer.join()
     AgentServer.shut_down()

--- a/source/AgentCommon/Transceiver.cpp
+++ b/source/AgentCommon/Transceiver.cpp
@@ -258,17 +258,69 @@ bool Transceiver::alive()
     return zmq_sock_.handle() != nullptr && zmq::detail::poll(&zmq_pollitem_send_, 1, 0);
 }
 
+// 有界探活：在 duration 内等 socket 变为可写，用于区分两种"不可写"——
+// 对端活着但忙（HWM 打满，等一会儿就能写）和对端已死（断连后永远不可写）。
+// 旧的 alive() 是 0 超时探测，两种情况都返回 false，无法区分（见 #1123）。
+bool Transceiver::alive_for(const std::chrono::milliseconds& duration)
+{
+    std::unique_lock lock(socket_mutex_);
+
+    if (zmq_sock_.handle() == nullptr) {
+        return false;
+    }
+
+    const auto start_clock = std::chrono::steady_clock::now();
+
+    while (true) {
+        auto elapsed = duration_since(start_clock);
+        auto remaining_time = duration > elapsed ? duration - elapsed : std::chrono::milliseconds(0);
+        auto interval = std::min(remaining_time, std::chrono::milliseconds(1000));
+
+        try {
+            if (zmq::detail::poll(&zmq_pollitem_send_, 1, static_cast<long>(interval.count()))) {
+                return true;
+            }
+        }
+        catch (const zmq::error_t& e) {
+            // Android/Linux: signals may interrupt poll; retry with remaining time.
+            if (e.num() != EINTR) {
+                throw;
+            }
+        }
+
+        if (elapsed >= duration) {
+            return false;
+        }
+    }
+}
+
 void Transceiver::set_timeout(const std::chrono::milliseconds& timeout)
 {
     LogInfo << VAR(timeout) << VAR(ipc_addr_);
     timeout_ = timeout;
 }
 
-bool Transceiver::poll(zmq::pollitem_t& pollitem)
+void Transceiver::set_abort_pred(std::function<bool()> pred)
+{
+    LogInfo << VAR(ipc_addr_);
+    abort_pred_ = std::move(pred);
+}
+
+// 带中断的等待循环：每次醒来先问"该不该停"，再看事件有没有到。
+// 谓词有两道——调用者临时传的（如 recv 的 abort_pred 参数）和全局设的
+// （如 AgentServer 在 start_up 时设置的成员谓词），任一为真即放弃等待。
+bool Transceiver::poll(zmq::pollitem_t& pollitem, const std::function<bool()>& abort_pred)
 {
     const auto start_clock = std::chrono::steady_clock::now();
 
     while (true) {
+        if ((abort_pred && abort_pred()) || (abort_pred_ && abort_pred_())) {
+            // 被外部主动中断（如 AgentServer 本地 ShutDown）是预期中的退出路径，
+            // 不算异常，打 Info 而非 Error
+            LogInfo << "poll aborted" << VAR(ipc_addr_);
+            return false;
+        }
+
         auto elapsed = duration_since(start_clock);
         auto remaining_time = timeout_ > elapsed ? timeout_ - elapsed : std::chrono::milliseconds(0);
         auto interval = std::min(remaining_time, std::chrono::milliseconds(1000));
@@ -316,12 +368,18 @@ bool Transceiver::send(const json::value& j)
     return true;
 }
 
-std::optional<json::value> Transceiver::recv()
+std::optional<json::value> Transceiver::recv(const std::function<bool()>& abort_pred)
 {
     std::unique_lock lock(socket_mutex_);
 
-    if (!poll(zmq_pollitem_recv_)) {
-        LogError << "recv canceled";
+    if (!poll(zmq_pollitem_recv_, abort_pred)) {
+        if (abort_pred && abort_pred()) {
+            // 外部主动中断属预期路径，与真超时/错误的 Error 级区分
+            LogInfo << "recv aborted" << VAR(ipc_addr_);
+        }
+        else {
+            LogError << "recv canceled" << VAR(ipc_addr_);
+        }
         return std::nullopt;
     }
 

--- a/source/MaaAgentClient/Client/AgentClient.cpp
+++ b/source/MaaAgentClient/Client/AgentClient.cpp
@@ -15,6 +15,10 @@
 
 MAA_AGENT_CLIENT_NS_BEGIN
 
+// disconnect 握手前等待对端可写的时限：对端活着但忙（HWM 打满）时足够等到排空，
+// 对端已死（PAIR 断连后永远不可写）时不至于无限阻塞。
+inline static constexpr std::chrono::milliseconds k_shutdown_handshake_alive_timeout { 5000 };
+
 AgentClient::AgentClient(const std::string& identifier)
 {
     LogFunc;
@@ -202,18 +206,35 @@ bool AgentClient::disconnect()
 {
     LogFunc << VAR(ipc_addr_);
 
+    // 先反注册自定义动作/识别器（纯本地操作，不涉及 IPC，无论后续握手
+    // 成败都要做；放在最前面还能尽早切断"资源侧再派发 custom → 向垂死
+    // 服务端 IPC"的入口）
     clear_custom_registration();
+
+    if (connected()) {
+        // 探活：最多等 5 秒看 socket 能不能写。
+        // 能写 → 对端活着（哪怕正忙），走正常关闭握手（发 ShutDownRequest、
+        //        等对方执行完关闭回调后回 ShutDownResponse）。
+        // 不能写 → 对端已死，跳过握手（发了也没人收）。
+        //
+        // 为什么不用旧的 alive()：它是 0 超时探测，对端"活着但忙"（消息队列
+        // 打满）时会误判为死、直接跳过握手——导致 ShutDownRequest 永远发不
+        // 出去、服务端 Join 永远不返回、进程残留（上游 #1123 就是这个问题）。
+        if (alive_for(k_shutdown_handshake_alive_timeout)) {
+            send_and_recv<ShutDownResponse>(ShutDownRequest { });
+        }
+        else {
+            LogWarn << "server is not alive, skip shutdown handshake" << VAR(ipc_addr_);
+        }
+    }
+
+    // 握手完成（或跳过）后才摘事件监听。旧代码是先摘再握手——握手期间
+    // 产生的终态事件（如 Tasker.Task.Failed）就没人转发了，直接丢失。
+    // 现在顺序反过来，事件能先于关闭请求送达服务端（尽力而为：事件由
+    // 后台线程异步发送，极端调度下仍可能晚到、被服务端丢弃）。
     clear_controller_sink();
     clear_resource_sink();
     clear_tasker_sink();
-
-    if (!connected()) {
-        return true;
-    }
-
-    if (alive()) {
-        send_and_recv<ShutDownResponse>(ShutDownRequest { });
-    }
 
     connected_ = false;
     return true;

--- a/source/MaaAgentServer/API/MaaAgentServer.cpp
+++ b/source/MaaAgentServer/API/MaaAgentServer.cpp
@@ -37,6 +37,18 @@ void MaaAgentServerDetach()
     MAA_AGENT_SERVER_NS::AgentServer::get_instance().detach();
 }
 
+MaaBool MaaAgentServerSetShutdownCallback(MaaShutdownCallback callback, void* trans_arg)
+{
+    LogFunc << VAR_VOIDP(callback) << VAR_VOIDP(trans_arg);
+
+    if (!callback) {
+        LogError << "callback is null";
+        return false;
+    }
+
+    return MAA_AGENT_SERVER_NS::AgentServer::get_instance().set_shutdown_callback(callback, trans_arg);
+}
+
 MaaBool MaaAgentServerRegisterCustomRecognition(const char* name, MaaCustomRecognitionCallback recognition, void* trans_arg)
 {
     LogFunc << VAR(name) << VAR_VOIDP(recognition) << VAR_VOIDP(trans_arg);

--- a/source/MaaAgentServer/Server/AgentServer.cpp
+++ b/source/MaaAgentServer/Server/AgentServer.cpp
@@ -102,6 +102,19 @@ bool AgentServer::register_custom_action(const std::string& name, MaaCustomActio
     return custom_actions_.insert_or_assign(name, CustomActionSession { action, trans_arg }).second;
 }
 
+bool AgentServer::set_shutdown_callback(MaaShutdownCallback callback, void* trans_arg)
+{
+    LogInfo << VAR_VOIDP(callback) << VAR_VOIDP(trans_arg);
+
+    if (callback == nullptr) {
+        LogError << "callback is null";
+        return false;
+    }
+
+    shutdown_session_ = ShutdownSession { callback, trans_arg };
+    return true;
+}
+
 MaaSinkId AgentServer::add_resource_sink(MaaEventCallback sink, void* trans_arg)
 {
     return res_notifier_.add_sink(sink, trans_arg);
@@ -292,6 +305,12 @@ bool AgentServer::handle_shut_down_request(const json::value& j)
     }
 
     LogInfo << VAR(ipc_addr_);
+
+    if (shutdown_session_.callback) {
+        LogInfo << "shutdown callback begin" << VAR_VOIDP(shutdown_session_.trans_arg);
+        shutdown_session_.callback(shutdown_session_.trans_arg);
+        LogInfo << "shutdown callback end";
+    }
 
     msg_loop_running_ = false;
 

--- a/source/MaaAgentServer/Server/AgentServer.cpp
+++ b/source/MaaAgentServer/Server/AgentServer.cpp
@@ -31,6 +31,12 @@ bool AgentServer::start_up(const std::string& identifier)
     }
 
     msg_loop_running_ = true;
+
+    // 覆盖消息线程全部等待路径（send/recv/嵌套 send_and_recv）的中断开关：
+    // 对端消失后 POLLOUT/POLLIN 永不就绪且 timeout_ 默认无限，没有它，
+    // 本地 ShutDown 的 join 会随任一等待永久挂死（须在消息线程启动前设置）
+    set_abort_pred([this] { return !msg_loop_running_.load(); });
+
     msg_thread_ = std::thread(&AgentServer::request_msg_loop, this);
     if (!msg_thread_.joinable()) {
         LogError << "failed to start msg_thread";
@@ -44,20 +50,28 @@ void AgentServer::shut_down()
 {
     LogFunc << VAR(ipc_addr_);
 
+    // 先置 false（锁外）：让消息线程的 poll 谓词立即看到"该停了"，
+    // 这样下面 join 最多等一个 poll 周期（约 1 秒）就能返回。
+    // 如果放在锁内：另一线程正在 join() 持锁等待 → 我们在这里等锁 →
+    // 消息线程收不到中断信号 → join 永远不返回 → 死锁。
     msg_loop_running_ = false;
 
-    if (msg_thread_.joinable()) {
-        msg_thread_.join();
-    }
+    {
+        std::lock_guard lock(msg_thread_mutex_);
+        if (msg_thread_.joinable()) {
+            msg_thread_.join();
+        }
 
-    zmq_sock_.close();
-    zmq_ctx_.close();
+        zmq_sock_.close();
+        zmq_ctx_.close();
+    }
 }
 
 void AgentServer::join()
 {
     LogFunc << VAR(ipc_addr_);
 
+    std::lock_guard lock(msg_thread_mutex_);
     if (!msg_thread_.joinable()) {
         LogError << "msg_thread is not joinable";
         return;
@@ -70,6 +84,7 @@ void AgentServer::detach()
 {
     LogFunc << VAR(ipc_addr_);
 
+    std::lock_guard lock(msg_thread_mutex_);
     if (!msg_thread_.joinable()) {
         LogError << "msg_thread is not joinable";
         return;
@@ -111,6 +126,14 @@ bool AgentServer::set_shutdown_callback(MaaShutdownCallback callback, void* tran
         return false;
     }
 
+    // 必须在 start_up 之前设置：运行中修改的话，消息线程正在读 shutdown_session_
+    // 而宿主线程同时在写——两边没有任何同步，并发读写是数据竞争（未定义行为）
+    if (msg_loop_running_) {
+        LogError << "server is running, set_shutdown_callback must be called before start_up";
+        return false;
+    }
+
+    // 直接覆盖：重复注册时后设置的回调替换先设置的，不会叠加调用
     shutdown_session_ = ShutdownSession { callback, trans_arg };
     return true;
 }
@@ -306,15 +329,24 @@ bool AgentServer::handle_shut_down_request(const json::value& j)
 
     LogInfo << VAR(ipc_addr_);
 
+    // 先执行宿主注册的关闭回调，让 agent 有机会在退出前完成收尾
+    // （如冲走在途通知、写状态文件）——回调阻塞多久，响应就推迟多久
     if (shutdown_session_.callback) {
         LogInfo << "shutdown callback begin" << VAR_VOIDP(shutdown_session_.trans_arg);
         shutdown_session_.callback(shutdown_session_.trans_arg);
         LogInfo << "shutdown callback end";
     }
 
-    msg_loop_running_ = false;
-
+    // 先回响应再停循环。顺序不能反：poll() 每次醒来都会检查中断谓词
+    // （即 !msg_loop_running_），如果先置 false，下面这行 send 的 poll
+    // 会被自己的谓词掐断——响应永远发不出去，客户端的 disconnect()
+    // 只能等超时（默认无限）。
+    //
+    // 对端已死的情况：send 会等 POLLOUT（等不到），此时本地 ShutDown()
+    // 置 false 后谓词转为 true，send 被"合理地"打断——这正是我们想要的。
     send(ShutDownResponse { });
+
+    msg_loop_running_ = false;
 
     return true;
 }
@@ -389,8 +421,17 @@ void AgentServer::request_msg_loop()
     LogFunc << VAR(ipc_addr_);
 
     while (msg_loop_running_) {
-        auto msg_opt = recv();
+        // recv 传入"该不该停"的检查函数，poll 每秒醒来问一次：
+        // 本地 ShutDown() 置 false 后，最多 1 秒就能打断阻塞中的 recv。
+        // 没有它的话，客户端不发关闭请求就消失时，recv 会以默认无限
+        // 超时永远等下去——Join() 也跟着永远不返回，进程残留。
+        auto msg_opt = recv([this] { return !msg_loop_running_; });
         if (!msg_opt) {
+            // recv 失败有两种原因：被上面的谓词打断（正常关停，静默退出）
+            // 或真正的通信错误（打日志后退出）
+            if (!msg_loop_running_) {
+                return;
+            }
             LogError << "failed to recv msg" << VAR(ipc_addr_);
             return;
         }

--- a/source/MaaAgentServer/Server/AgentServer.h
+++ b/source/MaaAgentServer/Server/AgentServer.h
@@ -32,6 +32,12 @@ class AgentServer
         void* trans_arg = nullptr;
     };
 
+    struct ShutdownSession
+    {
+        MaaShutdownCallback callback = nullptr;
+        void* trans_arg = nullptr;
+    };
+
 public:
     ~AgentServer() = default;
 
@@ -42,6 +48,7 @@ public:
 
     bool register_custom_recognition(const std::string& name, MaaCustomRecognitionCallback recognition, void* trans_arg);
     bool register_custom_action(const std::string& name, MaaCustomActionCallback action, void* trans_arg);
+    bool set_shutdown_callback(MaaShutdownCallback callback, void* trans_arg);
 
     MaaSinkId add_resource_sink(MaaEventCallback sink, void* trans_arg);
     MaaSinkId add_controller_sink(MaaEventCallback sink, void* trans_arg);
@@ -67,6 +74,8 @@ private:
 private:
     std::unordered_map<std::string, CustomRecognitionSession> custom_recognitions_;
     std::unordered_map<std::string, CustomActionSession> custom_actions_;
+
+    ShutdownSession shutdown_session_;
 
     EventDispatcher res_notifier_;
     EventDispatcher ctrl_notifier_ = EventDispatcher(false);

--- a/source/MaaAgentServer/Server/AgentServer.h
+++ b/source/MaaAgentServer/Server/AgentServer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <atomic>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -82,8 +84,15 @@ private:
     EventDispatcher tasker_notifier_;
     EventDispatcher ctx_notifier_;
 
-    bool msg_loop_running_ = false;
+    // "消息循环是否该继续跑"的开关。宿主线程（ShutDown/本地关停）写 false，
+    // 消息线程（while 条件 + recv 的中断谓词）读。跨线程读写，用原子保证可见性。
+    std::atomic<bool> msg_loop_running_ = false;
     std::thread msg_thread_;
+    // shut_down / join / detach 可能从不同线程并发调用（典型场景：主线程
+    // 正在 join() 等待服务结束，另一个线程调用 ShutDown() 请求关停）。
+    // 这把锁保证 joinable() 检查和 join()/detach() 是原子的——没有它的话，
+    // 两个线程可能同时通过 joinable 检查、对同一线程 join 两次（未定义行为）。
+    std::mutex msg_thread_mutex_;
 };
 
 MAA_AGENT_SERVER_NS_END

--- a/source/binding/NodeJS/src/apis/callback.cpp
+++ b/source/binding/NodeJS/src/apis/callback.cpp
@@ -80,6 +80,18 @@ void ContextSink(void* context, const char* message, const char* details_json, v
     });
 }
 
+// 服务端关闭回调的 C++ 侧入口：把控制权交给 JS 层注册的回调函数。
+// ctx->Call 内部通过 ThreadSafeFunction 把调用转发到 JS 主线程，并阻塞
+// 等待（含 Promise settle）——所以 JS 侧的 async 回调真正执行完毕后，
+// 这里的 Call 才返回，ShutDownResponse 才会发出。
+void ShutdownCallback(void* trans_arg)
+{
+    auto ctx = reinterpret_cast<maajs::CallbackContext*>(trans_arg);
+    ctx->Call<void>([=](maajs::FunctionType fn) {
+        return fn.Call({ });
+    });
+}
+
 MaaBool CustomReco(
     MaaContext* context,
     MaaTaskId task_id,

--- a/source/binding/NodeJS/src/apis/callback.h
+++ b/source/binding/NodeJS/src/apis/callback.h
@@ -6,6 +6,7 @@ void ResourceSink(void* resource, const char* message, const char* details_json,
 void ControllerSink(void* controller, const char* message, const char* details_json, void* callback_arg);
 void TaskerSink(void* tasker, const char* message, const char* details_json, void* callback_arg);
 void ContextSink(void* context, const char* message, const char* details_json, void* callback_arg);
+void ShutdownCallback(void* trans_arg);
 
 MaaBool CustomReco(
     MaaContext* context,

--- a/source/binding/NodeJS/src/apis/server.cpp
+++ b/source/binding/NodeJS/src/apis/server.cpp
@@ -52,6 +52,18 @@ static void add_context_sink(maajs::FunctionType func)
     ExtContext::get(func.Env())->globalCallbacks.push_back(std::move(ctx));
 }
 
+// 注册关闭回调。ctx 由 globalCallbacks 持有（进程级存活），保证回调
+// 触发时 JS 函数对象和 ThreadSafeFunction 不会被 GC 回收。
+// C++ 侧返回 false（如服务端已 start_up 后再注册）时抛异常给 JS 层。
+static void set_shutdown_callback(maajs::EnvType env, maajs::FunctionType func)
+{
+    auto ctx = std::make_unique<maajs::CallbackContext>(func, "ShutdownCallback");
+    if (!MaaAgentServerSetShutdownCallback(ShutdownCallback, ctx.get())) {
+        throw maajs::MaaError { "Server set_shutdown_callback failed" };
+    }
+    ExtContext::get(env)->globalCallbacks.push_back(std::move(ctx));
+}
+
 static maajs::PromiseType start_up(maajs::EnvType env, std::string identifier)
 {
     auto work = new maajs::AsyncWork<bool>(env, [identifier]() { return MaaAgentServerStartUp(identifier.c_str()); });
@@ -94,6 +106,7 @@ maajs::ValueType load_server(maajs::EnvType env)
     MAA_BIND_FUNC(obj, "add_controller_sink", add_controller_sink);
     MAA_BIND_FUNC(obj, "add_tasker_sink", add_tasker_sink);
     MAA_BIND_FUNC(obj, "add_context_sink", add_context_sink);
+    MAA_BIND_FUNC(obj, "set_shutdown_callback", set_shutdown_callback);
     MAA_BIND_FUNC(obj, "start_up", start_up);
     MAA_BIND_FUNC(obj, "shut_down", shut_down);
     MAA_BIND_FUNC(obj, "join", join);

--- a/source/binding/NodeJS/src/apis/server.d.ts
+++ b/source/binding/NodeJS/src/apis/server.d.ts
@@ -13,6 +13,17 @@ declare global {
                 cb: (ctx: Context, msg: TaskerContextNotify) => MaybePromise<void>,
             ): void
 
+            /**
+             * Invoked when the AgentServer receives a ShutDownRequest, before the
+             * message loop stops; the ShutDownResponse is replied only after the
+             * callback (including the returned Promise) settles. Must be set
+             * before start_up; re-registration overwrites.
+             * Do NOT call maa.Server.join / maa.Server.shut_down inside the callback,
+             * and do NOT throw synchronously (it terminates the process); a rejected
+             * Promise is silently ignored and shutdown continues.
+             */
+            set_shutdown_callback(cb: () => MaybePromise<void>): void
+
             start_up(identifier: string): Promise<boolean>
             shut_down(): Promise<void>
             join(): Promise<void>

--- a/source/binding/Python/maa/agent/agent_server.py
+++ b/source/binding/Python/maa/agent/agent_server.py
@@ -179,6 +179,61 @@ class AgentServer:
 
         Library.agent_server().MaaAgentServerDetach()
 
+    _shutdown_callback_holder: "MaaShutdownCallback | None" = None
+
+    @staticmethod
+    def set_shutdown_callback(callback: Callable[[], None]) -> bool:
+        """设置关闭回调 / Set shutdown callback
+
+        在 AgentServer 收到 ShutDownRequest 时、停止消息循环前调用；回调返回后服务端才会回复 ShutDownResponse。
+        Invoked when the AgentServer receives a ShutDownRequest, before the message loop stops; the ShutDownResponse is replied only after the callback returns.
+
+        回调在服务端消息线程内阻塞执行，须为零参数的同步函数（async 函数传入时只会创建协程、不会真正执行）；
+        回调内抛出的异常会被打印到 stderr 后忽略、关闭流程照常继续——清理逻辑失败不会被发现，须自行兜底。
+        勿在回调内调用 Join/ShutDown（会等待自身线程，属未定义行为，通常表现为抛异常并终止进程）。
+        须在 start_up 前注册（运行中注册会被拒绝），重复注册将覆盖。
+        The callback runs blocking on the server message thread, must be a zero-argument synchronous function
+        (an async function would only create a coroutine without executing it); exceptions raised inside are
+        printed to stderr and ignored while shutdown continues — cleanup failures go unnoticed, so handle them yourself.
+        Do not call Join/ShutDown inside (undefined behavior, typically throwing and terminating).
+        Must be set before start_up (rejected while the server is running); re-registration overwrites.
+
+        Args:
+            callback: 关闭回调函数 / Shutdown callback function
+
+        Returns:
+            bool: 是否成功 / Whether successful
+
+        Raises:
+            TypeError: callback 不可调用 / callback is not callable
+        """
+
+        if not callable(callback):
+            raise TypeError(f"callback must be callable, got {type(callback).__name__}")
+
+        AgentServer._set_api_properties()
+
+        @MaaShutdownCallback
+        def _c_callback(trans_arg):
+            callback()
+
+        # 先在 C++ 侧换指针，成功才替换 holder——两步顺序不能反：
+        #   1. 如果先换 holder 再调 C++：失败时（C++ 保留了旧回调 A 的指针），
+        #      Python 侧旧回调 A 已被丢弃 → GC 回收 A → C++ 手里是悬垂指针 → 崩溃
+        #   2. 现在的顺序：C++ 先换成新回调 B → Python 再丢弃 A 的引用 → 安全
+        ret = bool(
+            Library.agent_server().MaaAgentServerSetShutdownCallback(
+                _c_callback,
+                None,
+            )
+        )
+
+        # 只有注册成功才替换持有引用（防止 GC 把 C++ 还在用的旧回调回收掉）
+        if ret:
+            AgentServer._shutdown_callback_holder = _c_callback
+
+        return ret
+
     _sink_holder: dict[int, "EventSink"] = {}
 
     @staticmethod
@@ -351,5 +406,11 @@ class AgentServer:
         Library.agent_server().MaaAgentServerAddContextSink.restype = MaaSinkId
         Library.agent_server().MaaAgentServerAddContextSink.argtypes = [
             MaaEventCallback,
+            ctypes.c_void_p,
+        ]
+
+        Library.agent_server().MaaAgentServerSetShutdownCallback.restype = MaaBool
+        Library.agent_server().MaaAgentServerSetShutdownCallback.argtypes = [
+            MaaShutdownCallback,
             ctypes.c_void_p,
         ]

--- a/source/binding/Python/maa/define.py
+++ b/source/binding/Python/maa/define.py
@@ -66,6 +66,7 @@ __all__ = [
     "MaaEventCallback",
     "MaaCustomRecognitionCallback",
     "MaaCustomActionCallback",
+    "MaaShutdownCallback",
     "MaaCustomControllerCallbacks",
     # Enums
     "MaaStatusEnum",
@@ -692,6 +693,8 @@ class MaaControllerFeatureEnum(IntEnum):
 FUNCTYPE = ctypes.WINFUNCTYPE if (platform.system() == "Windows") else ctypes.CFUNCTYPE
 
 MaaEventCallback = FUNCTYPE(None, ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p)
+
+MaaShutdownCallback = FUNCTYPE(None, ctypes.c_void_p)
 
 MaaCustomRecognitionCallback = FUNCTYPE(
     MaaBool,  # return value

--- a/source/include/MaaAgent/Transceiver.h
+++ b/source/include/MaaAgent/Transceiver.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <mutex>
 #include <optional>
 
@@ -76,15 +77,28 @@ protected:
     void uninit_socket();
 
     bool send(const json::value& j);
-    std::optional<json::value> recv();
+    // 接收一条消息。abort_pred 是"该不该放弃等待"的检查函数——
+    // poll 每秒醒来调它一次，返回 true 就不等了（用于让外部打断阻塞的 recv）。
+    std::optional<json::value> recv(
+        const std::function<bool()>& abort_pred = nullptr);
 
     bool alive();
+    // 有界探活：在 duration 内等 socket 可写。区分"对端忙"（等一会儿就能写）
+    // 和"对端死了"（永远不可写）。旧 alive() 两种都返回 false，无法区分（#1123）。
+    bool alive_for(const std::chrono::milliseconds& duration);
     void set_timeout(const std::chrono::milliseconds& timeout);
+
+    // 设置全局中断谓词：poll 每秒醒来时调它一次，返回 true 就放弃等待。
+    // 相当于给这个 Transceiver 的所有等待（send/recv/嵌套 send_and_recv）
+    // 装了一个总开关——AgentServer 在 start_up 时设置为"消息循环该停了吗"，
+    // 这样本地 ShutDown() 置 false 后，无论消息线程卡在哪个等待上，
+    // 最多 1 秒就会被唤醒并放弃。须在等待开始前设置（如线程启动前）。
+    void set_abort_pred(std::function<bool()> pred);
 
 private:
     void handle_image(const ImageHeader& header);
     void handle_image_encoded(const ImageEncodedHeader& header);
-    bool poll(zmq::pollitem_t& pollitem);
+    bool poll(zmq::pollitem_t& pollitem, const std::function<bool()>& abort_pred = nullptr);
 
 protected:
     // 返回实际绑定的端口号，如果传入 0 则自动选择可用端口
@@ -116,6 +130,9 @@ private:
     zmq::pollitem_t zmq_pollitem_send_ { };
     zmq::pollitem_t zmq_pollitem_recv_ { };
     std::chrono::milliseconds timeout_ = std::chrono::milliseconds::max();
+
+    // 全局等待中断谓词（set_abort_pred 设置，poll 统一检查；等待开始前设置、期间只读）
+    std::function<bool()> abort_pred_ = nullptr;
 };
 
 MAA_AGENT_NS_END

--- a/source/modules/MaaAgentServer.cppm
+++ b/source/modules/MaaAgentServer.cppm
@@ -14,3 +14,4 @@ export using ::MaaAgentServerStartUp;
 export using ::MaaAgentServerShutDown;
 export using ::MaaAgentServerJoin;
 export using ::MaaAgentServerDetach;
+export using ::MaaAgentServerSetShutdownCallback;

--- a/source/modules/MaaFramework.cppm
+++ b/source/modules/MaaFramework.cppm
@@ -128,6 +128,7 @@ export using ::MaaNotificationCallback;
 export using ::MaaEventCallback;
 export using ::MaaCustomRecognitionCallback;
 export using ::MaaCustomActionCallback;
+export using ::MaaShutdownCallback;
 
 // Instance/MaaContext.h
 

--- a/test/agent/agent_child_test.py
+++ b/test/agent/agent_child_test.py
@@ -13,6 +13,7 @@ import os
 from pathlib import Path
 import sys
 import io
+import time
 import numpy
 
 # Fix encoding issues on Windows (cp1252 cannot encode some Unicode characters)
@@ -50,6 +51,19 @@ from maa.pipeline import JRecognitionType, JActionType, JOCR, JClick
 
 analyzed: bool = False
 runned: bool = False
+shutdown_callback_ran: bool = False
+
+shutdown_marker: Path = install_dir / "test" / "agent_shutdown_callback_ran"
+
+
+def on_shutdown() -> None:
+    global shutdown_callback_ran
+    shutdown_callback_ran = True
+    print("on_shutdown callback")
+    # 模拟宿主收尾耗时；若 ShutDownResponse 先于回调发出，main 侧断言必然失败
+    time.sleep(1)
+    shutdown_marker.parent.mkdir(parents=True, exist_ok=True)
+    shutdown_marker.write_text("done", encoding="utf-8")
 
 
 def main():
@@ -58,9 +72,32 @@ def main():
         exit(1)
 
     socket_id = sys.argv[-1]
+
+    shutdown_marker.unlink(missing_ok=True)
+
+    # 冒烟：可注册、可覆盖。首个回调若被调用会置位 flag（用于断言「覆盖而非追加」语义）
+    first_callback_ran = False
+
+    def _first_callback():
+        nonlocal first_callback_ran
+        first_callback_ran = True
+
+    if not AgentServer.set_shutdown_callback(_first_callback):
+        print("failed to register first shutdown callback")
+        exit(1)
+    if not AgentServer.set_shutdown_callback(on_shutdown):
+        print("failed to overwrite shutdown callback")
+        exit(1)
+
     AgentServer.start_up(socket_id)
     AgentServer.join()
     AgentServer.shut_down()
+
+    # join 返回即代表消息循环已停止；此时回调必然已执行过
+    # （marker 文件由 main 侧在 disconnect 断言后删除，此处不依赖文件）
+    assert shutdown_callback_ran, "shutdown callback should have run before message loop stops"
+    # 覆盖语义：首个回调不应被调用（若实现错成追加，两个都会跑）
+    assert not first_callback_ran, "re-registration should overwrite, not append"
 
 
 @AgentServer.custom_recognition("MyRec")

--- a/test/agent/agent_dead_server_test.py
+++ b/test/agent/agent_dead_server_test.py
@@ -1,0 +1,130 @@
+"""
+AgentClient 对端已死时的 disconnect 测试
+
+测试范围:
+1. AgentClient: 连接建立后杀死 AgentServer 子进程
+2. AgentClient::disconnect: 对端已死时应跳过关闭握手并在有界时间内返回
+   （alive_for 探活 5s 上限，而非无限阻塞在发送等待上）
+"""
+
+import atexit
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+
+if len(sys.argv) < 3:
+    print("Usage: python agent_dead_server_test.py <binding_dir> <install_dir>")
+    sys.exit(1)
+
+binding_dir = Path(sys.argv[1]).resolve()
+install_dir = Path(sys.argv[2]).resolve()
+
+os.environ["MAAFW_BINARY_PATH"] = str(f"{install_dir}/bin")
+print(f"binding_dir: {binding_dir}")
+print(f"install_dir: {install_dir}")
+
+if str(binding_dir) not in sys.path:
+    sys.path.insert(0, str(binding_dir))
+
+from maa.library import Library
+from maa.resource import Resource
+from maa.controller import DbgController
+from maa.tasker import Tasker
+from maa.agent_client import AgentClient
+from maa.toolkit import Toolkit
+
+# alive_for 有界探活 5s + 余量
+DISCONNECT_TIME_LIMIT = 7.0
+
+
+def api_test():
+    resource = Resource()
+    resource.post_bundle(
+        install_dir / "test" / "PipelineSmoking" / "resource"
+    ).wait()
+    if not resource.loaded:
+        print("failed to load resource")
+        exit(1)
+
+    dbg_controller = DbgController(
+        install_dir / "test" / "PipelineSmoking" / "Screenshot",
+    )
+    dbg_controller.post_connection().wait()
+
+    tasker = Tasker()
+    tasker.bind(resource, dbg_controller)
+    if not tasker.inited:
+        print("failed to init tasker")
+        exit(1)
+
+    agent = AgentClient()
+    socket_id = agent.identifier
+    if not agent.bind(resource):
+        print("failed to bind resource")
+        exit(1)
+    if not agent.register_sink(resource, dbg_controller, tasker):
+        print("failed to register sink")
+        exit(1)
+
+    child_proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "agent_child_test.py"),
+            str(binding_dir),
+            str(install_dir),
+            socket_id,
+        ],
+    )
+
+    # 测试中途失败时回收子进程，避免残留
+    def _kill_child():
+        if child_proc.poll() is None:
+            child_proc.kill()
+        child_proc.wait()
+
+    atexit.register(_kill_child)
+
+    if not agent.connect():
+        print("failed to connect to agent server")
+        exit(1)
+    print("agent.connect() succeeded")
+
+    # ============================================================
+    # 杀死服务端子进程，模拟 agent 进程崩溃
+    # ============================================================
+    child_proc.kill()
+    child_proc.wait()
+    time.sleep(1)  # 给 ZMQ 时间感知对端消失
+    print("agent server killed, calling disconnect()...")
+
+    # 残余路径保险：若 ZMQ 未及时感知死亡，alive_for 可能因陈旧 POLLOUT
+    # 通过，握手 recv 将等待响应——设置有限超时使该路径有界失败（≈10s，
+    # 触发下方 7s 断言）而非无限挂死拖垮 CI
+    agent.set_timeout(10_000)
+
+    # ============================================================
+    # disconnect 应在有限时间内返回（alive_for 探活上限 5s + 余量），
+    # 而非无限阻塞在关闭握手的发送等待上
+    # ============================================================
+    t0 = time.time()
+    if not agent.disconnect():
+        print("failed to disconnect")
+        exit(1)
+    elapsed = time.time() - t0
+    print(f"agent.disconnect() returned in {elapsed:.2f}s")
+
+    assert elapsed < DISCONNECT_TIME_LIMIT, (
+        f"disconnect took {elapsed:.2f}s on dead server, "
+        f"expected < {DISCONNECT_TIME_LIMIT}s (bounded alive_for)"
+    )
+    print("disconnect on dead server is bounded, test passed")
+
+
+if __name__ == "__main__":
+    print(f"AgentClient (dead server) MaaFw Version: {Library.version()}")
+
+    Toolkit.init_option(install_dir / "bin")
+
+    api_test()

--- a/test/agent/agent_interrupt_child_test.py
+++ b/test/agent/agent_interrupt_child_test.py
@@ -1,0 +1,76 @@
+"""
+AgentServer 可中断测试（子进程侧）
+
+模拟客户端进程消失（不发 ShutDownRequest）后，宿主本地调用 ShutDown 中断
+阻塞中的 Join：start_up → 3 秒后本地 shut_down → join 计时返回。
+验证消息循环的 recv 可被 ShutDown 中断（修复前默认无限超时下 Join 永久阻塞）。
+"""
+
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+
+if len(sys.argv) < 4:
+    print("Call agent_interrupt_main_test.py instead of this file.")
+    sys.exit(1)
+
+binding_dir = Path(sys.argv[1]).resolve()
+install_dir = Path(sys.argv[2]).resolve()
+
+os.environ["MAAFW_BINARY_PATH"] = str(f"{install_dir}/bin")
+
+if str(binding_dir) not in sys.path:
+    sys.path.insert(0, str(binding_dir))
+
+from maa.agent.agent_server import AgentServer
+from maa.tasker import Tasker
+from maa.library import Library
+
+# 本地 ShutDown 在连接 3 秒后触发；join 随 poll 的 1 秒粒度检查尽快返回
+LOCAL_SHUTDOWN_DELAY = 3.0
+JOIN_TIME_LIMIT = 15.0
+
+
+def main():
+    socket_id = sys.argv[-1]
+
+    AgentServer.start_up(socket_id)
+
+    def local_shutdown():
+        time.sleep(LOCAL_SHUTDOWN_DELAY)
+        print("calling local AgentServer.shut_down()...")
+        AgentServer.shut_down()
+
+    # 非 daemon：join 该线程后再退出，避免解释器关闭时打断半执行的 shut_down
+    shutdown_thread = threading.Thread(target=local_shutdown)
+    shutdown_thread.start()
+
+    t0 = time.time()
+    AgentServer.join()
+    elapsed = time.time() - t0
+    print(f"AgentServer.join() returned after {elapsed:.2f}s")
+
+    # join 能返回即证明阻塞的 recv 可被本地 ShutDown 中断（修复前永久挂死）
+    assert elapsed < JOIN_TIME_LIMIT, (
+        f"join took {elapsed:.2f}s, expected < {JOIN_TIME_LIMIT}s "
+        f"(interruptible by local shut_down)"
+    )
+    # 下限：本场景下 join 不可能合法地早于本地 ShutDown 定时返回
+    # （对端静默、无任何报文、默认无限超时——提前返回意味着循环异常退出）
+    assert elapsed >= LOCAL_SHUTDOWN_DELAY, (
+        f"join returned in {elapsed:.2f}s, earlier than the {LOCAL_SHUTDOWN_DELAY}s "
+        f"local shut_down timer — loop likely exited on error, not interruption"
+    )
+    print("interruptible join OK")
+
+    shutdown_thread.join(timeout=10)
+
+
+if __name__ == "__main__":
+    print(f"AgentServer (interrupt) MaaFw Version: {Library.version()}")
+
+    Tasker.set_log_dir(install_dir / "bin" / "debug")
+
+    main()

--- a/test/agent/agent_interrupt_main_test.py
+++ b/test/agent/agent_interrupt_main_test.py
@@ -1,0 +1,110 @@
+"""
+AgentServer 可中断测试（主进程侧）
+
+测试范围:
+1. AgentClient 连接后直接退出（不发 ShutDownRequest），模拟客户端进程消失
+2. AgentServer 侧（子进程）在本地 ShutDown 兜底下，阻塞中的 Join 应在
+   有限时间内返回——验证消息循环 recv 的可中断性
+   （修复前：默认无限超时下 Join 永久阻塞，agent 进程残留）
+"""
+
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+if len(sys.argv) < 3:
+    print("Usage: python agent_interrupt_main_test.py <binding_dir> <install_dir>")
+    sys.exit(1)
+
+binding_dir = Path(sys.argv[1]).resolve()
+install_dir = Path(sys.argv[2]).resolve()
+
+os.environ["MAAFW_BINARY_PATH"] = str(f"{install_dir}/bin")
+print(f"binding_dir: {binding_dir}")
+print(f"install_dir: {install_dir}")
+
+if str(binding_dir) not in sys.path:
+    sys.path.insert(0, str(binding_dir))
+
+from maa.library import Library
+from maa.resource import Resource
+from maa.controller import DbgController
+from maa.tasker import Tasker
+from maa.agent_client import AgentClient
+from maa.toolkit import Toolkit
+
+# 子进程内部断言 join < 15s（3s 定时 + 1s poll 粒度 + 慢机余量）
+CHILD_WAIT_TIMEOUT = 60
+
+
+def api_test():
+    resource = Resource()
+    resource.post_bundle(
+        install_dir / "test" / "PipelineSmoking" / "resource"
+    ).wait()
+    if not resource.loaded:
+        print("failed to load resource")
+        exit(1)
+
+    dbg_controller = DbgController(
+        install_dir / "test" / "PipelineSmoking" / "Screenshot",
+    )
+    dbg_controller.post_connection().wait()
+
+    tasker = Tasker()
+    tasker.bind(resource, dbg_controller)
+    if not tasker.inited:
+        print("failed to init tasker")
+        exit(1)
+
+    agent = AgentClient()
+    socket_id = agent.identifier
+    if not agent.bind(resource):
+        print("failed to bind resource")
+        exit(1)
+    if not agent.register_sink(resource, dbg_controller, tasker):
+        print("failed to register sink")
+        exit(1)
+
+    child_proc = subprocess.Popen(
+        [
+            sys.executable,
+            str(Path(__file__).parent / "agent_interrupt_child_test.py"),
+            str(binding_dir),
+            str(install_dir),
+            socket_id,
+        ],
+    )
+
+    if not agent.connect():
+        print("failed to connect to agent server")
+        child_proc.kill()
+        exit(1)
+    print("agent.connect() succeeded")
+
+    # ============================================================
+    # 主进程不调用 disconnect、不发 ShutDownRequest，原地等待子进程——
+    # 模拟客户端进程消失。子进程的 Join 只能靠其本地 ShutDown 兜底打断
+    # ============================================================
+    print("parent exits WITHOUT disconnect (simulating client vanishing)")
+
+    try:
+        child_proc.wait(timeout=CHILD_WAIT_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        print(f"child process still alive after {CHILD_WAIT_TIMEOUT}s, join hung")
+        child_proc.kill()
+        exit(1)
+
+    if child_proc.returncode != 0:
+        print(f"agent child process exited with {child_proc.returncode}")
+        exit(1)
+    print("agent child process exited gracefully (interruptible join verified)")
+
+
+if __name__ == "__main__":
+    print(f"AgentClient (interrupt) MaaFw Version: {Library.version()}")
+
+    Toolkit.init_option(install_dir / "bin")
+
+    api_test()

--- a/test/agent/agent_main_test.py
+++ b/test/agent/agent_main_test.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import sys
 import subprocess
+import time
 
 if len(sys.argv) < 3:
     print("Usage: python agent_main_test.py <binding_dir> <install_dir>")
@@ -109,7 +110,10 @@ def api_test():
     # ============================================================
     # 启动 AgentServer 子进程
     # ============================================================
-    subprocess.Popen(
+    shutdown_marker = install_dir / "test" / "agent_shutdown_callback_ran"
+    shutdown_marker.unlink(missing_ok=True)
+
+    child_proc = subprocess.Popen(
         [
             "python",
             str(Path(__file__).parent / "agent_child_test.py"),
@@ -118,6 +122,22 @@ def api_test():
             socket_id,
         ],
     )
+
+    # 有限超时：子进程启动失败（import 崩溃等）时快速失败，而非无限等待拖到 CI 步超时
+    if not agent.set_timeout(60_000):
+        print("failed to set timeout to 60s")
+        exit(1)
+
+    # 测试中途失败（exit/assert）时回收子进程，避免其卡在 join 上残留；
+    # 成功路径子进程已自行退出，kill 对已退出进程无副作用
+    import atexit
+
+    def _kill_child():
+        if child_proc.poll() is None:
+            child_proc.kill()
+        child_proc.wait()
+
+    atexit.register(_kill_child)
 
     # 等待连接
     if not agent.connect():
@@ -193,13 +213,36 @@ def api_test():
     # ============================================================
     # 断开连接
     # ============================================================
+    t0 = time.time()
     if not agent.disconnect():
         print("failed to disconnect")
         exit(1)
-    print("agent.disconnect() succeeded")
+    elapsed = time.time() - t0
+    print(f"agent.disconnect() succeeded in {elapsed:.2f}s")
+
+    # 正常路径下响应应在回调（含 1s sleep）后立即到达，远小于超时上界；
+    # 若响应缺失（如发送被中断谓词误杀），disconnect 会等满 60s 超时——此断言必红
+    assert elapsed < 10, (
+        f"disconnect took {elapsed:.2f}s — ShutDownResponse likely never arrived "
+        f"(timeout fallback), expected < 10s for normal graceful shutdown"
+    )
 
     # 验证断开连接后的状态
     print(f"agent.connected after disconnect: {agent.connected}")
+
+    # disconnect 返回即代表服务端 shutdown 回调已执行完毕（Response 在回调之后才发）
+    if not shutdown_marker.exists():
+        print("shutdown callback marker not found after disconnect")
+        exit(1)
+    print("shutdown callback ran before disconnect returned")
+    shutdown_marker.unlink()
+
+    # 子进程应在 Join 返回后自行退出，无需外部强杀
+    child_proc.wait(timeout=15)
+    if child_proc.returncode != 0:
+        print(f"agent child process exited with {child_proc.returncode}")
+        exit(1)
+    print("agent child process exited gracefully")
 
     print("\n" + "=" * 50)
     print("All agent tests passed!")

--- a/test/agent/agent_tcp_main_test.py
+++ b/test/agent/agent_tcp_main_test.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import socket
 import sys
 import subprocess
+import time
 
 if len(sys.argv) < 3:
     print("Usage: python agent_tcp_main_test.py <binding_dir> <install_dir>")
@@ -117,7 +118,10 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
     # ============================================================
     # 启动 AgentServer 子进程 (TCP 模式)
     # ============================================================
-    subprocess.Popen(
+    shutdown_marker = install_dir / "test" / "agent_shutdown_callback_ran"
+    shutdown_marker.unlink(missing_ok=True)
+
+    child_proc = subprocess.Popen(
         [
             sys.executable,
             str(Path(__file__).parent / "agent_tcp_child_test.py"),
@@ -127,6 +131,26 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
         ],
     )
 
+    # 有限超时：子进程启动失败（import 崩溃等）时快速失败，而非无限等待拖到 CI 步超时
+    if not agent.set_timeout(60_000):
+        print("failed to set timeout to 60s")
+        exit(1)
+
+    try:
+        _tcp_flow_body(agent, tasker, socket_id, shutdown_marker, scenario)
+        # 成功路径：子进程应已自行优雅退出
+        child_proc.wait(timeout=15)
+        if child_proc.returncode != 0:
+            print(f"agent child process exited with {child_proc.returncode}")
+            exit(1)
+    finally:
+        # 失败路径也要回收子进程，避免其卡在 join 上残留
+        if child_proc.poll() is None:
+            child_proc.kill()
+            child_proc.wait(timeout=15)
+
+
+def _tcp_flow_body(agent, tasker, socket_id, shutdown_marker, scenario):
     # 等待连接
     if not agent.connect():
         print("failed to connect to agent server via TCP")
@@ -201,13 +225,29 @@ def run_tcp_flow(agent: AgentClient, socket_id: str, *, scenario: str):
     # ============================================================
     # 断开连接
     # ============================================================
+    t0 = time.time()
     if not agent.disconnect():
         print("failed to disconnect")
         exit(1)
-    print("agent.disconnect() succeeded")
+    elapsed = time.time() - t0
+    print(f"agent.disconnect() succeeded in {elapsed:.2f}s")
+
+    # 正常路径下响应应在回调（含 1s sleep）后立即到达，远小于超时上界；
+    # 若响应缺失（如发送被中断谓词误杀），disconnect 会等满 60s 超时——此断言必红
+    assert elapsed < 10, (
+        f"disconnect took {elapsed:.2f}s — ShutDownResponse likely never arrived "
+        f"(timeout fallback), expected < 10s for normal graceful shutdown"
+    )
 
     # 验证断开连接后的状态
     print(f"agent.connected after disconnect: {agent.connected}")
+
+    # disconnect 返回即代表服务端 shutdown 回调已执行完毕（Response 在回调之后才发）
+    if not shutdown_marker.exists():
+        print("shutdown callback marker not found after disconnect")
+        exit(1)
+    print("shutdown callback ran before disconnect returned")
+    shutdown_marker.unlink()
 
     print("\n" + "=" * 50)
     print(f"{scenario} passed!")

--- a/test/nodejs/server.ts
+++ b/test/nodejs/server.ts
@@ -1,11 +1,48 @@
+// 依赖 Node >= 23.6 的原生 TypeScript 类型剥离（CI 已钉 Node 24，与 binding.ts 同机制）
 import './maa-server.ts'
 
 async function main() {
-    console.log('MaaFw Version:', maa.Global)
-    // console.log('MaaFw Role', maa.AgentRole)
+    console.log('MaaFw Version:', maa.Global.version)
 
-    console.log('AgentServer', maa.Server)
+    // Server 构建冒烟：maa.Server 存在且关键 API 齐全
+    const server = maa.Server
+    if (!server) {
+        console.error('maa.Server is undefined')
+        process.exit(1)
+    }
+    for (const api of [
+        'register_custom_recognition',
+        'register_custom_action',
+        'add_resource_sink',
+        'add_controller_sink',
+        'add_tasker_sink',
+        'add_context_sink',
+        'set_shutdown_callback',
+        'start_up',
+        'shut_down',
+        'join',
+        'detach'
+    ]) {
+        if (typeof (server as unknown as Record<string, unknown>)[api] !== 'function') {
+            console.error(`maa.Server.${api} is missing`)
+            process.exit(1)
+        }
+    }
+    console.log('maa.Server API surface OK')
 
+    // set_shutdown_callback 冒烟：可注册、可覆盖注册（后注册者替换先注册者）
+    server.set_shutdown_callback(() => {
+        console.log('on shutdown callback (first, should be overwritten)')
+    })
+
+    server.set_shutdown_callback(async () => {
+        console.log('on shutdown callback')
+        // async 回调会被服务端阻塞等待完成（MaybePromise 语义）
+        await new Promise(resolve => setTimeout(resolve, 100))
+    })
+    console.log('set_shutdown_callback registered (sync + async overwrite) OK')
+
+    console.log('server.ts smoke tests passed')
     process.exit(0)
 }
 


### PR DESCRIPTION
## 解决什么问题

**下游场景**（MaaEnd/MXU）：

任务结束瞬间调 `disconnect()` → 终态事件（`Tasker.Task.Failed`）在转发给 agent 之前就被截断 → 失败通知收不到

且 `if (alive())` 竞态偶发跳过 ShutDownRequest → 服务端 `Join()` 永远不返回 → agent 进程残留需强杀（#1123）

## 改动内容

### 新 API：`MaaAgentServerSetShutdownCallback`

agent 收到 ShutDownRequest 时先执行宿主注册的回调（可阻塞），回调返回后才回复 ShutDownResponse
客户端 `disconnect()` 一返回就代表对方收尾完成

### 客户端修复：`disconnect()` 时序重排

- 先发 ShutDownRequest 等响应、再摘事件监听 → 终态事件不再丢失
- 探活改为 5 秒有界等待 → 对端已死时不再无限阻塞（修复 #1123 场景）

### 服务端修复：所有等待可被本地 ShutDown 打断

- 新增 `set_abort_pred` 成员级中断谓词，覆盖 send/recv/嵌套调用全部等待路径
- 客户端进程消失后本地 `ShutDown()` 可在 1 秒内打断阻塞的 `Join()`
- `shut_down/join/detach` 加互斥锁，多线程同时调用不再崩溃

### 测试

新增三个端到端测试并接入 CI：
- 正常关闭时回调先于 ShutDownResponse（`elapsed < 10s` 断言防响应丢失回归）
- 对端崩溃后 `disconnect()` 有界返回（5s 探活 + 7s 断言）
- 客户端消失后本地 `ShutDown()` 能打断阻塞的 `Join()`（3-15s 双向断言）

Closes #1123

## Sourcery 总结

通过协调主机清理、保留最终通知，并使断开连接和服务器等待操作具有时间限制且可中断，实现 AgentServer 的平滑关闭。

新功能：
- 为 AgentServer 添加关闭回调 API，并通过 C++、Python 和 Node.js 接口提供，使主机清理能够在关闭确认之前完成。

错误修复：
- 在客户端断开连接时保留终端事件：在移除事件监听器之前完成关闭握手。
- 限制客户端存活检查的等待时间，避免服务器已停止时断开连接操作卡住。
- 允许本地 AgentServer 关闭操作中断阻塞的消息等待，防止客户端消失后 Join 卡住。
- 确保并发执行关闭、join 和 detach 操作时的安全性。

增强功能：
- 改进 AgentServer 的关闭时序，并记录回调生命周期、执行顺序和使用限制。

CI：
- 在所有受支持的平台上运行扩展后的 agent 和 Node.js 关闭场景，并将测试步骤超时时间设置为 30 分钟。

文档：
- 在中文和英文 API 指南中记录 AgentServer 关闭回调，以及更新后的关闭、join 和关闭中断行为。

测试：
- 添加端到端测试，覆盖回调先于响应的顺序、服务器故障后的有界断开连接，以及可中断的服务器 join。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable graceful AgentServer shutdown by coordinating host cleanup, preserving final notifications, and making disconnect and server waits bounded and interruptible.

New Features:
- Add a shutdown callback API for AgentServer, exposed through the C++, Python, and Node.js interfaces, allowing host cleanup to complete before shutdown acknowledgement.

Bug Fixes:
- Preserve terminal events during client disconnect by completing the shutdown handshake before removing event listeners.
- Bound client liveness checks so disconnect does not hang when the server has died.
- Allow local AgentServer shutdown to interrupt blocked message waits, preventing Join from hanging after client disappearance.
- Make concurrent shutdown, join, and detach operations safe.

Enhancements:
- Improve AgentServer shutdown sequencing and document callback lifecycle, ordering, and usage constraints.

CI:
- Run the expanded agent and Node.js shutdown scenarios across all supported platforms with 30-minute test-step timeouts.

Documentation:
- Document the AgentServer shutdown callback and updated shutdown, join, and shutdown interruption behavior in English and Chinese API guides.

Tests:
- Add end-to-end coverage for callback-before-response ordering, bounded disconnect after server failure, and interruptible server joins.

</details>

## Sourcery 摘要

通过主机清理回调、可靠的最终事件传递，以及有界且可中断的连接拆除，实现 AgentServer 的优雅关闭。

新功能：
- 在 C++、Python 和 Node.js 接口中新增 AgentServer 关闭回调 API，确保主机清理工作在关闭确认之前完成。

错误修复：
- 在移除事件监听器之前完成客户端关闭握手，以保留终止事件。
- 限制客户端断开连接存活检查的时长，避免服务器不可用时发生挂起。
- 允许本地 AgentServer 关闭中断阻塞等待，防止客户端消失后 Join 操作挂起。
- 确保并发执行关闭、join 和 detach 操作时的安全性。

改进：
- 改进 AgentServer 的关闭顺序，使关闭响应能够准确表示已注册清理工作的完成状态。

CI：
- 在受支持的平台上扩展 agent 和 Node.js 关闭场景，并限制 CI 测试时长。

文档：
- 在英文和中文指南中记录关闭回调 API，以及更新后的关闭、join 和中断行为。

测试：
- 新增端到端测试，覆盖回调顺序、服务器故障后的有界断开，以及可中断的服务器 join。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable graceful AgentServer shutdown with host cleanup callbacks, reliable final event delivery, and bounded, interruptible connection teardown.

New Features:
- Add an AgentServer shutdown callback API across the C++, Python, and Node.js interfaces so host cleanup completes before shutdown acknowledgement.

Bug Fixes:
- Preserve terminal events by completing the client shutdown handshake before removing event listeners.
- Bound client disconnect liveness checks to avoid hangs when the server is unavailable.
- Allow local AgentServer shutdown to interrupt blocked waits and prevent Join from hanging after client disappearance.
- Make concurrent shutdown, join, and detach operations safe.

Enhancements:
- Improve AgentServer shutdown ordering so shutdown responses accurately signal completion of registered cleanup.

CI:
- Expand agent and Node.js shutdown scenarios across supported platforms with bounded CI test durations.

Documentation:
- Document the shutdown callback API and updated shutdown, join, and interruption behavior in English and Chinese guides.

Tests:
- Add end-to-end coverage for callback ordering, bounded disconnect after server failure, and interruptible server joins.

</details>