### PR TITLE
feat(PlayCover): 适配 PlayTools 多指触控协议

### DIFF
--- a/include/MaaFramework/Instance/MaaController.h
+++ b/include/MaaFramework/Instance/MaaController.h
@@ -113,7 +113,6 @@ extern "C"
      *
      * @note This controller is designed for PlayCover on macOS.
      * @note Some features are not supported: start_app, input_text, click_key, key_down, key_up, scroll.
-     * @note Only single touch is supported (contact must be 0).
      */
     MAA_FRAMEWORK_API MaaController* MaaPlayCoverControllerCreate(const char* address, const char* uuid);
 

--- a/source/MaaPlayCoverControlUnit/Client/PlayToolsClient.cpp
+++ b/source/MaaPlayCoverControlUnit/Client/PlayToolsClient.cpp
@@ -229,19 +229,25 @@ bool PlayToolsClient::screencap(std::vector<uint8_t>& buffer, int& width, int& h
     return true;
 }
 
-bool PlayToolsClient::touch(TouchPhase phase, int x, int y)
+bool PlayToolsClient::touch(TouchPhase phase, int x, int y, int contact)
 {
+    // PlayTools carries the contact in a single byte
+    if (contact < 0 || contact > 0xFF) {
+        LogWarn << "invalid touch contact" << VAR(contact);
+        return false;
+    }
+
     if (!open()) {
         return false;
     }
 
     uint16_t nx = htons(static_cast<uint16_t>(x));
     uint16_t ny = htons(static_cast<uint16_t>(y));
-    uint8_t payload[5] = { static_cast<uint8_t>(phase), 0, 0, 0, 0 };
+    uint8_t payload[6] = { static_cast<uint8_t>(phase), 0, 0, 0, 0, static_cast<uint8_t>(contact) };
     std::memcpy(payload + 1, &nx, sizeof(nx));
     std::memcpy(payload + 3, &ny, sizeof(ny));
 
-    constexpr char request[6] = { 0, 9, 'T', 'U', 'C', 'H' };
+    constexpr char request[6] = { 0, 10, 'T', 'U', 'C', 'H' };
     boost::system::error_code ec;
     boost::asio::write(socket_, boost::asio::buffer(request), ec);
     if (ec) {
@@ -249,7 +255,7 @@ bool PlayToolsClient::touch(TouchPhase phase, int x, int y)
         close();
         return false;
     }
-    boost::asio::write(socket_, boost::asio::buffer(payload, 5), ec);
+    boost::asio::write(socket_, boost::asio::buffer(payload, 6), ec);
     if (ec) {
         LogError << "Cannot send touch payload:" << ec.message();
         close();

--- a/source/MaaPlayCoverControlUnit/Client/PlayToolsClient.h
+++ b/source/MaaPlayCoverControlUnit/Client/PlayToolsClient.h
@@ -33,7 +33,7 @@ public:
     bool connected() const;
 
     bool screencap(std::vector<uint8_t>& buffer, int& width, int& height);
-    bool touch(TouchPhase phase, int x, int y);
+    bool touch(TouchPhase phase, int x, int y, int contact);
     bool terminate();
 
     std::pair<int, int> screen_size() const;

--- a/source/MaaPlayCoverControlUnit/Manager/PlayCoverControlUnitMgr.cpp
+++ b/source/MaaPlayCoverControlUnit/Manager/PlayCoverControlUnitMgr.cpp
@@ -125,18 +125,11 @@ bool PlayCoverControlUnitMgr::touch_down(int contact, int x, int y, int pressure
 
     std::ignore = pressure;
 
-    if (contact != 0) {
-        LogWarn << "PlayCover only supports single touch, contact:" << contact;
+    if (!client_->touch(PlayToolsClient::TouchPhase::Began, x, y, contact)) {
         return false;
     }
 
-    if (!client_->touch(PlayToolsClient::TouchPhase::Began, x, y)) {
-        return false;
-    }
-
-    last_touch_x_ = x;
-    last_touch_y_ = y;
-    has_last_touch_point_ = true;
+    last_touch_points_[contact] = { x, y };
     return true;
 }
 
@@ -149,18 +142,11 @@ bool PlayCoverControlUnitMgr::touch_move(int contact, int x, int y, int pressure
 
     std::ignore = pressure;
 
-    if (contact != 0) {
-        LogWarn << "PlayCover only supports single touch, contact:" << contact;
+    if (!client_->touch(PlayToolsClient::TouchPhase::Moved, x, y, contact)) {
         return false;
     }
 
-    if (!client_->touch(PlayToolsClient::TouchPhase::Moved, x, y)) {
-        return false;
-    }
-
-    last_touch_x_ = x;
-    last_touch_y_ = y;
-    has_last_touch_point_ = true;
+    last_touch_points_[contact] = { x, y };
     return true;
 }
 
@@ -171,28 +157,23 @@ bool PlayCoverControlUnitMgr::touch_up(int contact)
         return false;
     }
 
-    if (contact != 0) {
-        LogWarn << "PlayCover only supports single touch, contact:" << contact;
-        return false;
-    }
-
     int up_x = 0;
     int up_y = 0;
-    if (has_last_touch_point_) {
-        up_x = last_touch_x_;
-        up_y = last_touch_y_;
-    }
-    else {
+    const auto it = last_touch_points_.find(contact);
+    if (it != last_touch_points_.end()) {
+        up_x = it->second.first;
+        up_y = it->second.second;
+    } else {
         auto [width, height] = client_->screen_size();
         up_x = width / 2;
         up_y = height / 2;
     }
 
-    if (!client_->touch(PlayToolsClient::TouchPhase::Ended, up_x, up_y)) {
+    if (!client_->touch(PlayToolsClient::TouchPhase::Ended, up_x, up_y, contact)) {
         return false;
     }
 
-    has_last_touch_point_ = false;
+    last_touch_points_.erase(contact);
     return true;
 }
 

--- a/source/MaaPlayCoverControlUnit/Manager/PlayCoverControlUnitMgr.h
+++ b/source/MaaPlayCoverControlUnit/Manager/PlayCoverControlUnitMgr.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 
 #include "MaaControlUnit/ControlUnitAPI.h"
@@ -52,9 +53,7 @@ private:
     std::unique_ptr<PlayToolsClient> client_;
     std::string address_;
     std::string uuid_;
-    int last_touch_x_ = 0;
-    int last_touch_y_ = 0;
-    bool has_last_touch_point_ = false;
+    std::unordered_map<int, std::pair<int, int>> last_touch_points_;
 };
 
 MAA_CTRL_UNIT_NS_END


### PR DESCRIPTION
https://github.com/hguandl/PlayTools/commit/56b0270a3dfb33d4662e0727483a94e1514ec172

## Sourcery 摘要

通过更新后的 PlayTools 触控协议支持多点触控输入。

新功能：
- 在 PlayCover 输入处理中添加对 PlayTools 协议多点触控接触点的支持。

增强功能：
- 独立跟踪每个活动触控接触点的最新坐标，并支持针对特定接触点的触控生命周期事件。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

使 PlayCover 触控处理适配 PlayTools 多点触控协议。

新功能：
- 通过更新后的 PlayTools 触控协议支持多点触控输入，包括每个触点的开始、移动和结束事件。

增强功能：
- 独立跟踪每个活动触点的最新坐标，并拒绝超出协议范围的触点标识符。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过更新后的 PlayTools 触控协议启用 PlayCover 多点触控输入。

新功能：
- 调整 PlayCover 输入处理，以适配更新后的 PlayTools 协议，支持多点触控接触点及其生命周期事件。

增强功能：
- 独立跟踪每个活动触控接触点的最新坐标，并根据协议范围验证接触点标识符。

文档：
- 更新 PlayCover 控制器文档，以反映多点触控支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable PlayCover multi-touch input through the updated PlayTools touch protocol.

New Features:
- Adapt PlayCover input handling to the updated PlayTools protocol to support multi-touch contacts and their lifecycle events.

Enhancements:
- Track the latest coordinates independently for each active touch contact and validate contact identifiers against the protocol range.

Documentation:
- Update the PlayCover controller documentation to reflect multi-touch support.

</details>

</details>

</details>