### PR TITLE
fix(Pipeline): 完善 focus 协议 Schema

### DIFF
--- a/test/schema/pipeline.schema.correct.json
+++ b/test/schema/pipeline.schema.correct.json
@@ -46,6 +46,29 @@
             }
         }
     },
+    "focus_v2": {
+        "focus": {
+            "Node.Action.Starting": "{name} 开始执行",
+            "Node.Action.Failed": {
+                "content": "{name} 执行失败",
+                "display": [
+                    "log",
+                    "modal"
+                ],
+                "trace": true
+            },
+            "Node.PipelineNode.Succeeded": {
+                "trace": true
+            },
+            "Node.RecognitionNode.Starting": {
+                "display": []
+            },
+            "Node.WaitFreezes.Failed": "$focus.wait_freezes_failed"
+        }
+    },
+    "focus_null": {
+        "focus": null
+    },
     "pipeline_override_recognition_v1": {
         "roi": "[]"
     },

--- a/test/schema/pipeline.schema.error.json
+++ b/test/schema/pipeline.schema.error.json
@@ -33,6 +33,22 @@
             "param": {}
         }
     },
+    "focus_v2": {
+        "focus": {
+            "Node.Action.Starting": {
+                "content": "{name} 开始执行",
+                "display": [
+                    "log",
+                    "invalid"
+                ],
+                "trace": "true"
+            },
+            "Node.Action.Succeeded": {
+                "contents": "{name} 执行成功"
+            },
+            "Unknown.Message": "{name} 未知消息"
+        }
+    },
     "pipeline_override_recognition_v1": {
         "roi": 0
     },

--- a/tools/pipeline.schema.json
+++ b/tools/pipeline.schema.json
@@ -255,6 +255,125 @@
         "jsonDefaultObject": {
             "default": {}
         },
+        "FocusMessageEnum": {
+            "title": "Focus Message Enum",
+            "description": "focus 支持的节点回调消息类型。",
+            "type": "string",
+            "enum": [
+                "Node.PipelineNode.Starting",
+                "Node.PipelineNode.Succeeded",
+                "Node.PipelineNode.Failed",
+                "Node.RecognitionNode.Starting",
+                "Node.RecognitionNode.Succeeded",
+                "Node.RecognitionNode.Failed",
+                "Node.ActionNode.Starting",
+                "Node.ActionNode.Succeeded",
+                "Node.ActionNode.Failed",
+                "Node.NextList.Starting",
+                "Node.NextList.Succeeded",
+                "Node.NextList.Failed",
+                "Node.Recognition.Starting",
+                "Node.Recognition.Succeeded",
+                "Node.Recognition.Failed",
+                "Node.Action.Starting",
+                "Node.Action.Succeeded",
+                "Node.Action.Failed",
+                "Node.WaitFreezes.Starting",
+                "Node.WaitFreezes.Succeeded",
+                "Node.WaitFreezes.Failed"
+            ]
+        },
+        "FocusDisplayEnum": {
+            "title": "Focus Display Enum",
+            "description": "消息展示渠道。",
+            "type": "string",
+            "enum": [
+                "log",
+                "toast",
+                "notification",
+                "dialog",
+                "modal"
+            ],
+            "default": "log",
+            "markdownDescription": "*string*\n\n消息展示渠道。可选，默认 `\"log\"`。\n\n可选值：`\"log\"` | `\"toast\"` | `\"notification\"` | `\"dialog\"` | `\"modal\"`"
+        },
+        "FocusDisplay": {
+            "title": "Focus Display",
+            "description": "消息展示渠道，支持单个渠道或渠道数组。",
+            "default": "log",
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/FocusDisplayEnum"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/FocusDisplayEnum"
+                    }
+                }
+            ],
+            "markdownDescription": "*string* | *string array*\n\n消息展示渠道，支持单个渠道或渠道数组。可选，默认 `\"log\"`。\n\n可选值：`\"log\"` | `\"toast\"` | `\"notification\"` | `\"dialog\"` | `\"modal\"`"
+        },
+        "FocusTemplateObject": {
+            "title": "Focus Template Object",
+            "description": "消息模板完整写法。",
+            "type": "object",
+            "unevaluatedProperties": false,
+            "properties": {
+                "content": {
+                    "title": "Content Property",
+                    "description": "消息模板内容，支持直接文本、文件路径、URL 和国际化键。",
+                    "type": "string",
+                    "markdownDescription": "*string*\n\n消息模板内容，支持直接文本、文件路径、URL 和国际化键。内容支持 Markdown 和 `{name}` 等占位符。"
+                },
+                "display": {
+                    "title": "Display Property",
+                    "description": "消息展示渠道，支持单个渠道或渠道数组。可选，默认 \"log\"。",
+                    "$ref": "#/$defs/FocusDisplay",
+                    "markdownDescription": "*string* | *string array*\n\n消息展示渠道，支持单个渠道或渠道数组。可选，默认 `\"log\"`。"
+                },
+                "trace": {
+                    "title": "Trace Property",
+                    "description": "是否上传本次节点结果到遥测平台。可选，默认值与消息类型相关。",
+                    "type": "boolean",
+                    "markdownDescription": "*bool*\n\n是否上传本次节点结果到遥测平台。可选，默认值与消息类型相关。"
+                }
+            }
+        },
+        "FocusTemplate": {
+            "title": "Focus Template",
+            "description": "消息模板，支持字符串简写或对象完整写法。",
+            "default": "",
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/$defs/FocusTemplateObject"
+                }
+            ],
+            "markdownDescription": "*string* | *object*\n\n消息模板。字符串等价于只设置 `content` 且 `display` 为 `\"log\"`；对象可设置 `content`、`display` 和 `trace`。"
+        },
+        "Focus": {
+            "title": "Focus",
+            "description": "节点消息模板映射。",
+            "default": null,
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "object",
+                    "propertyNames": {
+                        "$ref": "#/$defs/FocusMessageEnum"
+                    },
+                    "additionalProperties": {
+                        "$ref": "#/$defs/FocusTemplate"
+                    }
+                }
+            ],
+            "markdownDescription": "*object* | *null*\n\n节点消息模板映射，键为节点回调消息类型，值为消息模板。可选，默认 `null`。"
+        },
         "jsonStringStringPair": {
             "type": "array",
             "items": false,
@@ -4263,9 +4382,9 @@
                 },
                 "focus": {
                     "title": "Focus Property",
-                    "description": "关注节点，会额外产生部分回调消息。可选，默认 null，不产生回调消息。",
-                    "$ref": "#/$defs/jsonDefaultNull",
-                    "markdownDescription": "*any*\n\n关注节点，会额外产生部分回调消息。可选，默认 null，不产生回调消息。\n\n详见 [节点通知](#节点通知)。"
+                    "description": "关注节点，配置节点回调消息模板。可选，默认 null，不产生回调消息。",
+                    "$ref": "#/$defs/Focus",
+                    "markdownDescription": "*object* | *null*\n\n关注节点，配置节点回调消息模板。可选，默认 null，不产生回调消息。\n\n详见 [节点通知](#节点通知)。"
                 },
                 "attach": {
                     "title": "Attach Property",


### PR DESCRIPTION
## Summary
- 为 Pipeline `focus` 字段补充结构化 Schema 定义
- 支持全部 21 个 `Node.*` 回调消息类型
- 支持 string / object 模板，以及 `content`、`display`、`trace` 字段
- 补充正确与错误 schema fixtures

## Validation
- `rtk uvx check-jsonschema --schemafile tools/pipeline.schema.json test/schema/pipeline.schema.correct.json`
- `rtk uvx check-jsonschema --schemafile tools/pipeline.schema.json test/schema/pipeline.schema.error.json`（预期失败，并命中新增约束）
- `git diff --cached --check`

## Sourcery 摘要

完善 Pipeline `focus` 字段的结构化 Schema 校验能力。

新功能：
- 为 Pipeline `focus` 字段定义结构化 Schema，涵盖全部 21 种 `Node.*` 回调消息类型及支持的模板字段。

问题修复：
- 通过强制执行新定义的结构，改进 Pipeline `focus` 配置的校验。

测试：
- 添加有效和无效的 Schema fixture，覆盖扩展后的 `focus` 约束。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

完善 Pipeline `focus` 字段的结构化 Schema 校验能力。

New Features:
- Define a structured schema for the Pipeline `focus` field, covering all 21 `Node.*` callback message types and supported template fields.

Bug Fixes:
- Improve validation of Pipeline `focus` configurations by enforcing the newly defined structure.

Tests:
- Add valid and invalid schema fixtures covering the expanded `focus` constraints.

</details>