### PR TITLE
docs: PI 协议添加 checkbox 的最大选择数量和最小选择数量

### DIFF
--- a/docs/en_us/3.3-ProjectInterfaceV2.md
+++ b/docs/en_us/3.3-ProjectInterfaceV2.md
@@ -34,6 +34,7 @@ We have designated the version number for the independent release (January 30, 2
 | 2026-08-05 | v2.9.1  | Added the `trace` field on `focus` message template objects for controlling whether node results are uploaded to telemetry by callback message type |
 | 2026-08-23 | v2.9.2  | Added the `telemetry.sentry.failure_attachments_sample_rate` field for independent failure diagnostic attachment sampling |
 | 2026-08-24 | v2.10.0 | Added the `password` field on `input` option `inputs[]` to mark password/secret fields |
+| 2026-09-06 | v2.10.1 | Added `min_count` / `max_count` on `checkbox` options to limit the minimum / maximum number of selections |
 
 ## `interface.json`
 
@@ -668,7 +669,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - **cases** `object[]`  
     Used only when `type` is `"select"`, `"checkbox"`, or `"switch"`. Available options, an array of objects containing information about each option.
 
-    **Note:** When `type` is `"checkbox"`, the user can select multiple cases simultaneously. The `pipeline_override` of all selected cases will be merged in the order they appear in the `cases` array — regardless of the order in which the user checked them.
+    **Note:** When `type` is `"checkbox"`, the user can select multiple cases simultaneously. The `pipeline_override` of all selected cases will be merged in the order they appear in the `cases` array — regardless of the order in which the user checked them. Use `min_count` / `max_count` to limit the minimum / maximum number of selected cases. **💡 v2.10.1**
 
     **Note:** When `type` is `"switch"`, only two cases are supported, and the following rules must be followed:  
     - If `case.name` is one of `"Yes"`, `"yes"`, `"Y"`, or `"y"`, that case will be recognized as the **Yes option**  
@@ -780,7 +781,18 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - **default_case** `string` | `string[]`  
     Default option name. _Optional._
     - When `type` is `"select"` or `"switch"`: provide a single string; the Client uses it as the initial selected value.
-    - When `type` is `"checkbox"`: provide a string array; the Client uses it as the initial set of selected values. **💡 v2.3.0**
+    - When `type` is `"checkbox"`: provide a string array; the Client uses it as the initial set of selected values. **💡 v2.3.0**  
+      The number of items in `default_case` should satisfy `min_count` / `max_count` when those fields are set. **💡 v2.10.1**
+
+  - **min_count** `number` **💡 v2.10.1**  
+    Used only when `type` is `"checkbox"`. _Optional_, defaults to `0`. The minimum number of cases the user must select; a non-negative integer.  
+    `0` means selecting none is allowed. This value must not exceed the length of `cases`; if `max_count` is also set, it must not exceed `max_count`.  
+    The Client should validate on user selection: if fewer than `min_count` cases are selected, prompt the user to select more. Do not start the task with a selection that does not meet the lower bound.
+
+  - **max_count** `number` **💡 v2.10.1**  
+    Used only when `type` is `"checkbox"`. _Optional._ The maximum number of cases the user may select; a non-negative integer. When omitted, there is no limit (all cases may be selected).  
+    This value must not exceed the length of `cases`; if `min_count` is also set, it must not be less than `min_count`.  
+    The Client should prevent checking more than `max_count` cases.
 
 - **global_option** `string[]` **💡 v2.3.0**  
   _Optional._ Global option configuration, an array of strings. Array elements should correspond to key names in the `option` configuration.  
@@ -1098,6 +1110,8 @@ A single `input` option may mix normal fields and password fields. Do not set `d
       "type": "checkbox",
       "label": "$BattleFeatures",
       "description": "Select the battle features to enable, multiple selections allowed",
+      "min_count": 1,
+      "max_count": 2,
       "default_case": ["NormalStrike", "ChargedStrike"],
       "cases": [
         {

--- a/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
+++ b/docs/zh_cn/3.3-ProjectInterfaceV2协议.md
@@ -34,6 +34,7 @@
 | 2026-8-5 | v2.9.1 | 新增 `focus` 消息模板对象的 `trace` 字段，用于按回调消息类型控制遥测是否上传节点结果 |
 | 2026-8-23 | v2.9.2 | 新增 `telemetry.sentry.failure_attachments_sample_rate` 失败诊断附件独立采样率字段 |
 | 2026-8-24 | v2.10.0 | `input` 类型选项的 `inputs[]` 新增 `password` 字段，用于标记密码/密钥输入 |
+| 2026-9-6 | v2.10.1 | `checkbox` 类型新增 `min_count` / `max_count` 字段，用于限制最小 / 最大选择数量 |
 
 ## `interface.json`
 
@@ -42,7 +43,6 @@
 > 该文件可以通过 [schema](https://github.com/MaaXYZ/MaaFramework/blob/main/tools/interface.schema.json) 文件获得提示和校验功能
 >
 > 使用 VSCode 打开 项目模板 文件夹，可自动关联 schema 和文件
-
 ### 整体结构
 
 - interface_version `number`  
@@ -666,7 +666,7 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - cases `object[]`  
     仅在 `type` 为 `"select"`/`"checkbox"`/`"switch"` 时使用。可选项，为一个对象数组，含有各个可选项的信息。
 
-    **注意：** 当 `type` 为 `"checkbox"` 时，用户可以同时选中多个 case，所有被选中的 case 的 `pipeline_override` 会按照 `cases` 数组中的定义顺序依次合并生效，与用户勾选的先后顺序无关。
+    **注意：** 当 `type` 为 `"checkbox"` 时，用户可以同时选中多个 case，所有被选中的 case 的 `pipeline_override` 会按照 `cases` 数组中的定义顺序依次合并生效，与用户勾选的先后顺序无关。可通过 `min_count` / `max_count` 限制最少 / 最多选中数量。 **💡 v2.10.1**
 
     **注意：** 当 `type` 为 `"switch"` 时，仅支持两个 cases，且需遵循以下规则：
     - 如果 `case.name` 为 `"Yes"`、`"yes"`、`"Y"` 或 `"y"` 之一，该 case 会被识别为 **Yes 选项**
@@ -778,7 +778,18 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
   - default_case `string` | `string[]`  
     默认选项名称。可选。
     - 当 `type` 为 `"select"` / `"switch"` 时，填写单个字符串，Client 使用该值作为选项的初始选中值。
-    - 当 `type` 为 `"checkbox"` 时，填写字符串数组，Client 使用该值作为多选框的初始选中值。 **💡 v2.3.0**
+    - 当 `type` 为 `"checkbox"` 时，填写字符串数组，Client 使用该值作为多选框的初始选中值。 **💡 v2.3.0**  
+      `default_case` 的元素数量应满足 `min_count` / `max_count`（若已设置）。 **💡 v2.10.1**
+
+  - min_count `number` **💡 v2.10.1**  
+    仅在 `type` 为 `"checkbox"` 时使用。可选，默认 `0`。用户至少需要选中的 case 数量，为非负整数。  
+    为 `0` 时允许不选。该值不应大于 `cases` 的长度；若同时设置了 `max_count`，则不应大于 `max_count`。  
+    Client 应在用户选择时校验：选中数量少于 `min_count` 时提示用户补选，不应带着不满足下限的选择启动任务。
+
+  - max_count `number` **💡 v2.10.1**  
+    仅在 `type` 为 `"checkbox"` 时使用。可选。用户最多可以选中的 case 数量，为非负整数。不设置表示不限制（最多可选中全部 case）。  
+    该值不应大于 `cases` 的长度；若同时设置了 `min_count`，则不应小于 `min_count`。  
+    Client 应在用户选择时阻止超过 `max_count` 的勾选。
 
 - global_option `string[]` **💡 v2.3.0**  
   可选。全局选项配置，为一个字符串数组，数组元素应与 `option` 配置中的键名对应。  
@@ -1096,6 +1107,8 @@ PI_RESOURCE={"name":"官服","label":"官服","path":["./resource"]}
       "type": "checkbox",
       "label": "$战斗划火柴",
       "description": "选择要启用的划火柴功能，可多选",
+      "min_count": 1,
+      "max_count": 2,
       "default_case": ["普通划火柴", "蓄力划火柴"],
       "cases": [
         {

--- a/tools/interface.schema.json
+++ b/tools/interface.schema.json
@@ -412,10 +412,23 @@
                         "default_case": {
                             "type": "array",
                             "title": "默认选中项",
-                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值。💡 v2.10.1 元素数量应满足 min_count / max_count（若已设置）",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "min_count": {
+                            "type": "integer",
+                            "title": "最小选择数量",
+                            "description": "💡 v2.10.1 可选，默认 0。用户至少需要选中的 case 数量。为 0 时允许不选。不应大于 cases 长度；若同时设置 max_count，则不应大于 max_count",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "max_count": {
+                            "type": "integer",
+                            "title": "最大选择数量",
+                            "description": "💡 v2.10.1 可选。用户最多可以选中的 case 数量。不设置表示不限制（最多可选中全部 case）。不应大于 cases 长度；若同时设置 min_count，则不应小于 min_count",
+                            "minimum": 0
                         }
                     },
                     "required": [

--- a/tools/interface_import.schema.json
+++ b/tools/interface_import.schema.json
@@ -289,10 +289,23 @@
                         "default_case": {
                             "type": "array",
                             "title": "默认选中项",
-                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值。💡 v2.10.1 元素数量应满足 min_count / max_count（若已设置）",
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "min_count": {
+                            "type": "integer",
+                            "title": "最小选择数量",
+                            "description": "💡 v2.10.1 可选，默认 0。用户至少需要选中的 case 数量。为 0 时允许不选。不应大于 cases 长度；若同时设置 max_count，则不应大于 max_count",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "max_count": {
+                            "type": "integer",
+                            "title": "最大选择数量",
+                            "description": "💡 v2.10.1 可选。用户最多可以选中的 case 数量。不设置表示不限制（最多可选中全部 case）。不应大于 cases 长度；若同时设置 min_count，则不应小于 min_count",
+                            "minimum": 0
                         }
                     },
                     "required": [


### PR DESCRIPTION
## Sourcery 总结

为复选框选项添加可配置的最小和最大选择数量限制。

新功能：
- 为复选框选项添加 `min_count` 和 `max_count` 约束，以控制允许的选择范围。

增强功能：
- 更新 Project Interface V2 文档和接口架构，定义复选框选择约束及其验证规则。

文档：
- 在英文和中文接口文档中记录复选框选择限制、默认值要求以及配置示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable minimum and maximum selection limits for checkbox options.

New Features:
- Add `min_count` and `max_count` constraints for checkbox options to control the allowed selection range.

Enhancements:
- Update the Project Interface V2 documentation and interface schemas to define checkbox selection constraints and their validation rules.

Documentation:
- Document checkbox selection limits, default-value requirements, and an example configuration in the English and Chinese interface documentation.

</details>