### PR TITLE
feat: TouchDown/KeyDown 新增 auto_up，任务停止时自动抬起仍按下的输入

### DIFF
--- a/docs/en_us/3.1-PipelineProtocol.md
+++ b/docs/en_us/3.1-PipelineProtocol.md
@@ -182,6 +182,7 @@ Typical flow: recognize inside `roi` (with `roi_offset`), get `box`, then calcul
 | v5.7 | `anchor` supports object format (specifying target node / clearing anchor); `And` / `Or` support node name reference |
 | v5.8 | OCR added `color_filter` field; Shell `timeout` renamed to `shell_timeout`; Added `Screencap` action |
 | v5.9 | String-form `roi` / `target` added `[Anchor]AnchorName` reference support; fixed inconsistent action-failure follow-up behavior with/without `[JumpBack]` (error-handling path does not jump back) |
+| v5.10 | Added `auto_up` to `TouchDown` / `KeyDown`; automatically release still-held contacts/keys when the task is stopped or finished |
 
 ### Pipeline v1
 
@@ -1095,10 +1096,15 @@ Additional properties for this action:
 - `pressure`: *int* **💡 v5.0**  
     Touch pressure. Optional, default `0`. The actual range depends on the controller implementation.
 
+- `auto_up`: *bool* **💡 v5.10**  
+    Whether to automatically lift still-held contacts when the task is stopped or finished. Optional, default `true`.  
+    If the user stops the task midway, or the task ends without a matching `TouchUp`, the contact is lifted automatically so the device is not left pressed.  
+    Set to `false` to keep the contact held after the task ends.
+
 ### `TouchMove`
 
 **💡 v5.0**  
-Move an existing touch contact. Fields are identical to `TouchDown` and update the contact position.
+Move an existing touch contact. Fields are identical to `TouchDown` (`auto_up` only applies to `TouchDown`) and update the contact position.
 
 ### `TouchUp`
 
@@ -1180,6 +1186,11 @@ Additional properties for this action:
 
 - `key`: *int*  
     The key to press, supporting only virtual key code of corresponding controller. Required.
+
+- `auto_up`: *bool* **💡 v5.10**  
+    Whether to automatically release still-held keys when the task is stopped or finished. Optional, default `true`.  
+    If the user stops the task midway, or the task ends without a matching `KeyUp`, the key is released automatically so the device is not left pressed.  
+    Set to `false` to keep the key held after the task ends.
 
 ### `KeyUp`
 

--- a/docs/zh_cn/3.1-任务流水线协议.md
+++ b/docs/zh_cn/3.1-任务流水线协议.md
@@ -186,6 +186,7 @@ Android 设置界面存在菜单 `显示`/`存储`/`无障碍`，其中 `存储`
 | v5.7 | `anchor` 新增 object 形式（指定目标节点 / 清除锚点）; `And` / `Or` 新增节点名称引用支持 |
 | v5.8 | OCR 新增 `color_filter` 字段; Shell `timeout` 重命名为 `shell_timeout`; 新增 `Screencap` 动作 |
 | v5.9 | `roi` / `target` 的 string 形式新增 `[Anchor]锚点名` 引用支持; 修复 action 失败时有无 `[JumpBack]` 的行为不一致（错误处理路径不触发回跳） |
+| v5.10 | `TouchDown` / `KeyDown` 新增 `auto_up` 字段，任务停止或结束时自动抬起仍按下的触点/按键 |
 
 ### Pipeline v1
 
@@ -1104,10 +1105,15 @@ Pipeline v2 时，将这些字段放到 `recognition.param` 中即可。
 - `pressure`: *int*  
     触控压力，范围取决于控制器实现。可选，默认 0 。
 
+- `auto_up`: *bool* **💡 v5.10**  
+    任务停止或结束时是否自动抬起仍按住的触点。可选，默认 true 。  
+    若用户中途停止任务，或任务正常结束时仍未执行对应的 `TouchUp`，将自动抬起该触点，避免设备保持按下导致无法正常操作。  
+    设为 false 可在任务结束后继续保持按下状态。
+
 ### `TouchMove`
 
 **💡 v5.0**  
-移动触控点。字段含义与 `TouchDown` 一致，用于更新触点位置。
+移动触控点。字段含义与 `TouchDown` 一致（`auto_up` 仅对 `TouchDown` 生效），用于更新触点位置。
 
 ### `TouchUp`
 
@@ -1188,6 +1194,11 @@ Pipeline v2 时，将这些字段放到 `recognition.param` 中即可。
 
 - `key`: *int*  
     要按下的键，仅支持对应控制器的虚拟按键码。必选。
+
+- `auto_up`: *bool* **💡 v5.10**  
+    任务停止或结束时是否自动抬起仍按下的按键。可选，默认 true 。  
+    若用户中途停止任务，或任务正常结束时仍未执行对应的 `KeyUp`，将自动抬起该按键，避免设备保持按下导致无法正常操作。  
+    设为 false 可在任务结束后继续保持按下状态。
 
 ### `KeyUp`
 

--- a/source/MaaFramework/Controller/ControllerAgent.cpp
+++ b/source/MaaFramework/Controller/ControllerAgent.cpp
@@ -28,6 +28,8 @@ ControllerAgent::ControllerAgent(std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAP
 ControllerAgent::~ControllerAgent()
 {
     LogFunc;
+
+    auto_release_pressed();
 }
 
 bool ControllerAgent::set_option(MaaCtrlOption key, MaaOptionValue value, MaaOptionValueSize val_size)
@@ -267,6 +269,8 @@ void ControllerAgent::post_stop()
     if (action_runner_ && action_runner_->running()) {
         action_runner_->clear();
     }
+
+    auto_release_pressed();
 }
 
 bool ControllerAgent::running() const
@@ -451,9 +455,11 @@ bool ControllerAgent::handle_click(const ClickParam& param)
 
     bool ret = true;
     if (control_unit_->get_features() & MaaControllerFeature_UseMouseDownAndUpInsteadOfClick) {
+        remember_touch_down(param.contact, true);
         ret &= control_unit_->touch_down(param.contact, point.x, point.y, param.pressure);
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
         ret &= control_unit_->touch_up(param.contact);
+        remember_touch_up(param.contact);
     }
     else {
         ret &= control_unit_->click(point.x, point.y);
@@ -473,9 +479,11 @@ bool ControllerAgent::handle_long_press(const LongPressParam& param)
 
     bool ret = true;
     if (control_unit_->get_features() & MaaControllerFeature_UseMouseDownAndUpInsteadOfClick) {
+        remember_touch_down(param.contact, true);
         ret &= control_unit_->touch_down(param.contact, point.x, point.y, param.pressure);
         std::this_thread::sleep_for(std::chrono::milliseconds(param.duration));
         ret &= control_unit_->touch_up(param.contact);
+        remember_touch_up(param.contact);
     }
     else {
         LogWarn << "long press not supported, use click instead";
@@ -501,6 +509,7 @@ bool ControllerAgent::handle_swipe(const SwipeParam& param)
     bool ret = !param.end.empty();
 
     if (!param.only_hover && use_touch_down_up) {
+        remember_touch_down(param.contact, true);
         ret &= control_unit_->touch_down(param.contact, begin.x, begin.y, param.pressure);
     }
 
@@ -547,6 +556,7 @@ bool ControllerAgent::handle_swipe(const SwipeParam& param)
 
     if (!param.only_hover && use_touch_down_up) {
         ret &= control_unit_->touch_up(param.contact);
+        remember_touch_up(param.contact);
     }
 
     return ret;
@@ -643,6 +653,7 @@ bool ControllerAgent::handle_multi_swipe(const MultiSwipeParam& param)
 
             if (seg_op.step_index == 0) {
                 if (!s.only_hover) {
+                    remember_touch_down(contact, true);
                     ret &= control_unit_->touch_down(contact, seg_op.begin.x, seg_op.begin.y, s.pressure);
                 }
                 ++seg_op.step_index;
@@ -656,6 +667,7 @@ bool ControllerAgent::handle_multi_swipe(const MultiSwipeParam& param)
             else if (seg_op.step_index == seg_op.total_step) {
                 if (!s.only_hover) {
                     ret &= control_unit_->touch_up(contact);
+                    remember_touch_up(contact);
                 }
                 ++seg_op.step_index;
                 ++over_count;
@@ -681,7 +693,13 @@ bool ControllerAgent::handle_touch_down(const TouchParam& param)
     }
 
     cv::Point point = preproc_touch_point(param.point);
+    remember_touch_down(param.contact, param.auto_up);
     bool ret = control_unit_->touch_down(param.contact, point.x, point.y, param.pressure);
+
+    if (param.auto_up && need_to_stop_) {
+        ret &= control_unit_->touch_up(param.contact);
+        remember_touch_up(param.contact);
+    }
 
     return ret;
 }
@@ -707,6 +725,7 @@ bool ControllerAgent::handle_touch_up(const TouchParam& param)
     }
 
     bool ret = control_unit_->touch_up(param.contact);
+    remember_touch_up(param.contact);
 
     return ret;
 }
@@ -739,9 +758,11 @@ bool ControllerAgent::handle_click_key(const ClickKeyParam& param)
 
     for (const auto& keycode : param.keycode) {
         if (use_key_down_up) {
+            remember_key_down(keycode, true);
             ret &= control_unit_->key_down(keycode);
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
             ret &= control_unit_->key_up(keycode);
+            remember_key_up(keycode);
         }
         else {
             ret &= control_unit_->click_key(keycode);
@@ -764,9 +785,11 @@ bool ControllerAgent::handle_long_press_key(const LongPressKeyParam& param)
 
     for (const auto& keycode : param.keycode) {
         if (use_key_down_up) {
+            remember_key_down(keycode, true);
             ret &= control_unit_->key_down(keycode);
             std::this_thread::sleep_for(std::chrono::milliseconds(param.duration));
             ret &= control_unit_->key_up(keycode);
+            remember_key_up(keycode);
         }
         else {
             LogWarn << "long press key not supported, use click instead";
@@ -842,7 +865,13 @@ bool ControllerAgent::handle_key_down(const ClickKeyParam& param)
     bool ret = !param.keycode.empty();
 
     for (const auto& keycode : param.keycode) {
+        remember_key_down(keycode, param.auto_up);
         ret &= control_unit_->key_down(keycode);
+
+        if (param.auto_up && need_to_stop_) {
+            ret &= control_unit_->key_up(keycode);
+            remember_key_up(keycode);
+        }
     }
 
     return ret;
@@ -859,6 +888,7 @@ bool ControllerAgent::handle_key_up(const ClickKeyParam& param)
 
     for (const auto& keycode : param.keycode) {
         ret &= control_unit_->key_up(keycode);
+        remember_key_up(keycode);
     }
 
     return ret;
@@ -923,6 +953,69 @@ bool ControllerAgent::check_stop()
 
     need_to_stop_ = false;
     return true;
+}
+
+void ControllerAgent::remember_touch_down(int contact, bool auto_up)
+{
+    std::unique_lock lock(pressed_mutex_);
+    if (auto_up) {
+        auto_up_contacts_.insert(contact);
+    }
+    else {
+        auto_up_contacts_.erase(contact);
+    }
+}
+
+void ControllerAgent::remember_touch_up(int contact)
+{
+    std::unique_lock lock(pressed_mutex_);
+    auto_up_contacts_.erase(contact);
+}
+
+void ControllerAgent::remember_key_down(int keycode, bool auto_up)
+{
+    std::unique_lock lock(pressed_mutex_);
+    if (auto_up) {
+        auto_up_keys_.insert(keycode);
+    }
+    else {
+        auto_up_keys_.erase(keycode);
+    }
+}
+
+void ControllerAgent::remember_key_up(int keycode)
+{
+    std::unique_lock lock(pressed_mutex_);
+    auto_up_keys_.erase(keycode);
+}
+
+void ControllerAgent::auto_release_pressed()
+{
+    std::set<int> contacts;
+    std::set<int> keys;
+    {
+        std::unique_lock lock(pressed_mutex_);
+        contacts.swap(auto_up_contacts_);
+        keys.swap(auto_up_keys_);
+    }
+
+    if (contacts.empty() && keys.empty()) {
+        return;
+    }
+
+    LogInfo << "auto release pressed" << VAR(contacts) << VAR(keys);
+
+    if (!control_unit_) {
+        LogError << "control_unit_ is nullptr";
+        return;
+    }
+
+    for (int contact : contacts) {
+        control_unit_->touch_up(contact);
+    }
+    for (int keycode : keys) {
+        control_unit_->key_up(keycode);
+    }
 }
 
 bool ControllerAgent::run_action(typename AsyncRunner<Action>::Id id, Action action)

--- a/source/MaaFramework/Controller/ControllerAgent.h
+++ b/source/MaaFramework/Controller/ControllerAgent.h
@@ -65,8 +65,9 @@ struct TouchParam
     int contact = 0;
     cv::Point point { };
     int pressure = 0;
+    bool auto_up = false;
 
-    MEO_TOJSON(contact, point, pressure);
+    MEO_TOJSON(contact, point, pressure, auto_up);
 };
 
 struct RelativeMoveParam
@@ -80,8 +81,9 @@ struct RelativeMoveParam
 struct ClickKeyParam
 {
     std::vector<int> keycode;
+    bool auto_up = false;
 
-    MEO_TOJSON(keycode);
+    MEO_TOJSON(keycode, auto_up);
 };
 
 struct LongPressKeyParam
@@ -220,6 +222,7 @@ public: // MaaController
 
 public: // for Actuator
     void post_stop();
+    void auto_release_pressed();
 
     bool click(ClickParam p);
     bool long_press(LongPressParam p);
@@ -271,6 +274,11 @@ private:
     bool handle_shell(const ShellParam& param);
     bool handle_inactive();
 
+    void remember_touch_down(int contact, bool auto_up);
+    void remember_touch_up(int contact);
+    void remember_key_down(int keycode, bool auto_up);
+    void remember_key_up(int keycode);
+
     MaaCtrlId post(Action action);
     MaaCtrlId focus_id(MaaCtrlId id);
     bool check_stop();
@@ -295,6 +303,10 @@ private: // options
 
 private:
     bool need_to_stop_ = false;
+
+    std::mutex pressed_mutex_;
+    std::set<int> auto_up_contacts_;
+    std::set<int> auto_up_keys_;
 
 private:
     const std::shared_ptr<MAA_CTRL_UNIT_NS::ControlUnitAPI> control_unit_ = nullptr;

--- a/source/MaaFramework/Resource/PipelineDumper.cpp
+++ b/source/MaaFramework/Resource/PipelineDumper.cpp
@@ -356,6 +356,7 @@ PipelineV2::JAction PipelineDumper::dump_act(Action::Type type, const Action::Pa
             .target = dump_target(p.target),
             .target_offset = dump_rect(p.target.offset),
             .pressure = p.pressure,
+            .auto_up = p.auto_up,
         };
     } break;
 
@@ -386,6 +387,7 @@ PipelineV2::JAction PipelineDumper::dump_act(Action::Type type, const Action::Pa
         const auto& p = std::get<Action::KeyParam>(param);
         act.param = PipelineV2::JKey {
             .key = p.key,
+            .auto_up = p.auto_up,
         };
     } break;
 

--- a/source/MaaFramework/Resource/PipelineParser.cpp
+++ b/source/MaaFramework/Resource/PipelineParser.cpp
@@ -1398,6 +1398,12 @@ bool PipelineParser::parse_key_param(const json::value& input, Action::KeyParam&
     }
 
     output.key = key;
+
+    if (!get_and_check_value(input, "auto_up", output.auto_up, default_value.auto_up)) {
+        LogError << "failed to get_and_check_value auto_up" << VAR(input);
+        return false;
+    }
+
     return true;
 }
 
@@ -1415,6 +1421,11 @@ bool PipelineParser::parse_touch(const json::value& input, Action::TouchParam& o
 
     if (!get_and_check_value(input, "pressure", output.pressure, default_value.pressure)) {
         LogError << "failed to get_and_check_value pressure" << VAR(input);
+        return false;
+    }
+
+    if (!get_and_check_value(input, "auto_up", output.auto_up, default_value.auto_up)) {
+        LogError << "failed to get_and_check_value auto_up" << VAR(input);
         return false;
     }
 

--- a/source/MaaFramework/Resource/PipelineTypes.h
+++ b/source/MaaFramework/Resource/PipelineTypes.h
@@ -186,6 +186,7 @@ struct TouchParam
     uint contact = 0;
     Target target;
     int pressure = 0;
+    bool auto_up = true;
 };
 
 struct TouchUpParam
@@ -196,6 +197,7 @@ struct TouchUpParam
 struct KeyParam
 {
     int key = 0;
+    bool auto_up = true;
 };
 
 struct ClickKeyParam

--- a/source/MaaFramework/Resource/PipelineTypesV2.h
+++ b/source/MaaFramework/Resource/PipelineTypesV2.h
@@ -214,8 +214,9 @@ struct JTouch
     JTarget target;
     JRect target_offset { };
     int32_t pressure = 0;
+    bool auto_up = true;
 
-    MEO_TOJSON(contact, target, target_offset, pressure);
+    MEO_TOJSON(contact, target, target_offset, pressure, auto_up);
 };
 
 struct JTouchUp
@@ -243,8 +244,9 @@ struct JLongPressKey
 struct JKey
 {
     int key = 0;
+    bool auto_up = true;
 
-    MEO_TOJSON(key);
+    MEO_TOJSON(key, auto_up);
 };
 
 struct JInputText

--- a/source/MaaFramework/Task/Component/Actuator.cpp
+++ b/source/MaaFramework/Task/Component/Actuator.cpp
@@ -339,7 +339,12 @@ ActionResult Actuator::touch_down(const MAA_RES_NS::Action::TouchParam& param, c
         return { };
     }
     cv::Point point = rand_point(target_rect);
-    MAA_CTRL_NS::TouchParam ctrl_param { .contact = static_cast<int>(param.contact), .point = point, .pressure = param.pressure };
+    MAA_CTRL_NS::TouchParam ctrl_param {
+        .contact = static_cast<int>(param.contact),
+        .point = point,
+        .pressure = param.pressure,
+        .auto_up = param.auto_up,
+    };
     bool ret = controller()->touch_down(ctrl_param);
 
     return ActionResult {
@@ -365,7 +370,12 @@ ActionResult Actuator::touch_move(const MAA_RES_NS::Action::TouchParam& param, c
         return { };
     }
     cv::Point point = rand_point(target_rect);
-    MAA_CTRL_NS::TouchParam ctrl_param { .contact = static_cast<int>(param.contact), .point = point, .pressure = param.pressure };
+    MAA_CTRL_NS::TouchParam ctrl_param {
+        .contact = static_cast<int>(param.contact),
+        .point = point,
+        .pressure = param.pressure,
+        .auto_up = param.auto_up,
+    };
     bool ret = controller()->touch_move(ctrl_param);
 
     return ActionResult {
@@ -445,7 +455,7 @@ ActionResult Actuator::key_down(const MAA_RES_NS::Action::KeyParam& param, const
         return { };
     }
 
-    MAA_CTRL_NS::ClickKeyParam ctrl_param { .keycode = { param.key } };
+    MAA_CTRL_NS::ClickKeyParam ctrl_param { .keycode = { param.key }, .auto_up = param.auto_up };
     bool ret = controller()->key_down(ctrl_param);
 
     return ActionResult {

--- a/source/MaaFramework/Tasker/Tasker.cpp
+++ b/source/MaaFramework/Tasker/Tasker.cpp
@@ -352,6 +352,10 @@ bool Tasker::run_task(RunnerId runner_id, TaskPtr task_ptr)
 
     bool ret = task_ptr->run();
 
+    if (controller_) {
+        controller_->auto_release_pressed();
+    }
+
     LogInfo << "task end:" << VAR(cb_detail) << VAR(ret);
     {
         // value_or 的默认值用于 run 到一半调用方手动 clear cache 了的情况

--- a/source/binding/NodeJS/src/apis/pipeline.d.ts
+++ b/source/binding/NodeJS/src/apis/pipeline.d.ts
@@ -260,6 +260,7 @@ declare global {
                 target?: true | NodeName | Rect
                 target_offset?: Rect
                 pressure?: number
+                auto_up?: boolean
             },
             never,
             Mode
@@ -293,6 +294,7 @@ declare global {
         type ActionSingleKey<Mode> = RequiredIfStrict<
             {
                 key?: number
+                auto_up?: boolean
             },
             'key',
             Mode

--- a/source/binding/Python/maa/pipeline.py
+++ b/source/binding/Python/maa/pipeline.py
@@ -217,6 +217,7 @@ class JTouch:
     target: JTarget = True
     target_offset: JRect = (0, 0, 0, 0)
     pressure: int = 0
+    auto_up: bool = True
 
 
 @dataclass
@@ -238,6 +239,7 @@ class JLongPressKey:
 @dataclass
 class JKey:
     key: int
+    auto_up: bool = True
 
 
 @dataclass

--- a/test/python/pipeline_test.py
+++ b/test/python/pipeline_test.py
@@ -64,6 +64,7 @@ from maa.pipeline import (
     JLongPress,
     JSwipe,
     JMultiSwipe,
+    JTouch,
     JInputText,
     JStartApp,
     JStopApp,
@@ -73,6 +74,7 @@ from maa.pipeline import (
     JScreencap,
     JCustomAction,
     JNodeAttr,
+    JKey,
 )
 
 
@@ -940,6 +942,54 @@ class PipelineTestRecognition(CustomRecognition):
         assert_eq(param.target_offset, [10, 10, 0, 0], "target_offset")
         assert_eq(param.dx, 0, "dx")
         assert_eq(param.dy, -360, "dy")
+
+        # TouchDown
+        new_ctx.override_pipeline(
+            {
+                "ActTouchDown": {
+                    "action": "TouchDown",
+                    "target": [100, 200, 50, 50],
+                    "contact": 1,
+                    "pressure": 2,
+                    "auto_up": False,
+                }
+            }
+        )
+        obj = new_ctx.get_node_object("ActTouchDown")
+        assert_eq(obj.action.type, JActionType.TouchDown, "TouchDown type")
+        param = obj.action.param
+        assert_true(isinstance(param, JTouch), "TouchDown param")
+        assert_eq(param.contact, 1, "contact")
+        assert_eq(param.pressure, 2, "pressure")
+        assert_eq(param.auto_up, False, "auto_up")
+
+        # TouchDown default auto_up
+        new_ctx.override_pipeline({"ActTouchDownDefault": {"action": "TouchDown"}})
+        obj = new_ctx.get_node_object("ActTouchDownDefault")
+        assert_eq(obj.action.type, JActionType.TouchDown, "TouchDown default type")
+        param = obj.action.param
+        assert_true(isinstance(param, JTouch), "TouchDown default param")
+        assert_eq(param.auto_up, True, "default auto_up")
+
+        # KeyDown
+        new_ctx.override_pipeline(
+            {"ActKeyDown": {"action": "KeyDown", "key": 65, "auto_up": False}}
+        )
+        obj = new_ctx.get_node_object("ActKeyDown")
+        assert_eq(obj.action.type, JActionType.KeyDown, "KeyDown type")
+        param = obj.action.param
+        assert_true(isinstance(param, JKey), "KeyDown param")
+        assert_eq(param.key, 65, "key")
+        assert_eq(param.auto_up, False, "auto_up")
+
+        # KeyDown default auto_up
+        new_ctx.override_pipeline({"ActKeyDownDefault": {"action": "KeyDown", "key": 66}})
+        obj = new_ctx.get_node_object("ActKeyDownDefault")
+        assert_eq(obj.action.type, JActionType.KeyDown, "KeyDown default type")
+        param = obj.action.param
+        assert_true(isinstance(param, JKey), "KeyDown default param")
+        assert_eq(param.key, 66, "key")
+        assert_eq(param.auto_up, True, "default auto_up")
 
         print("    PASS: action types parsing")
 

--- a/tools/pipeline.schema.json
+++ b/tools/pipeline.schema.json
@@ -2603,6 +2603,13 @@
                     "$ref": "#/$defs/jsonInt32",
                     "markdownDescription": "*int*\n\n触控压力，范围取决于控制器实现。可选，默认 0 。",
                     "default": 0
+                },
+                "auto_up": {
+                    "title": "Auto Up Property",
+                    "description": "任务停止或结束时是否自动抬起仍按住的触点。可选，默认 true 。仅对 TouchDown 生效。",
+                    "$ref": "#/$defs/jsonBooleanTrue",
+                    "markdownDescription": "*bool*\n\n任务停止或结束时是否自动抬起仍按住的触点。可选，默认 true 。\n\n仅对 `TouchDown` 生效。若用户中途停止任务或任务正常结束时仍未 `TouchUp`，将自动抬起以免设备保持按下。设为 false 可保持按下状态。",
+                    "default": true
                 }
             }
         },
@@ -2783,6 +2790,13 @@
                     "description": "与 `key` 相同，向下兼容字段。",
                     "$ref": "#/$defs/jsonInt32",
                     "markdownDescription": "*int*\n\n与 `key` 相同，向下兼容字段。"
+                },
+                "auto_up": {
+                    "title": "Auto Up Property",
+                    "description": "任务停止或结束时是否自动抬起仍按下的按键。可选，默认 true 。",
+                    "$ref": "#/$defs/jsonBooleanTrue",
+                    "markdownDescription": "*bool*\n\n任务停止或结束时是否自动抬起仍按下的按键。可选，默认 true 。\n\n若用户中途停止任务或任务正常结束时仍未 `KeyUp`，将自动抬起以免设备保持按下。设为 false 可保持按下状态。",
+                    "default": true
                 }
             },
             "anyOf": [
@@ -2847,6 +2861,13 @@
                     "description": "与 `key` 相同，向下兼容字段。",
                     "$ref": "#/$defs/jsonInt32",
                     "markdownDescription": "*int*\n\n与 `key` 相同，向下兼容字段。"
+                },
+                "auto_up": {
+                    "title": "Auto Up Property",
+                    "description": "仅对 KeyDown 生效，KeyUp 忽略该字段。可选，默认 true 。",
+                    "$ref": "#/$defs/jsonBooleanTrue",
+                    "markdownDescription": "*bool*\n\n仅对 `KeyDown` 生效，`KeyUp` 忽略该字段。可选，默认 true 。",
+                    "default": true
                 }
             },
             "anyOf": [
@@ -3749,6 +3770,16 @@
                     "anyOf": [
                         {
                             "$ref": "#/$defs/Swipe/properties/only_hover"
+                        }
+                    ]
+                },
+                "auto_up": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Touch/properties/auto_up"
+                        },
+                        {
+                            "$ref": "#/$defs/KeyDown/properties/auto_up"
                         }
                     ]
                 }


### PR DESCRIPTION
## Summary
- 给 `TouchDown` / `KeyDown` 增加 `auto_up` 字段（默认 `true`）：任务被 `post_stop`、正常结束或控制器销毁时，自动抬起仍按住的触点/按键
- 显式 `TouchUp` / `KeyUp` 会取消对应记录，已配对抬起的不会再自动抬一次
- `Click` / `LongPress` / `Swipe` / `ClickKey` / `LongPressKey` 若在按下过程中被中断，同样会抬起，避免半截动作卡住设备

Closes #1394

## Test plan
- [ ] `TouchDown` 后 `post_stop`，触点被自动抬起
- [ ] `KeyDown` 后任务正常结束且没有 `KeyUp`，按键被自动抬起
- [ ] `TouchDown` → `TouchUp` 完整走完后，任务结束不再额外抬起
- [ ] `auto_up: false` 时停止/结束后保持按下
- [ ] pipeline 解析/override：`auto_up` 默认 true，显式 false 生效

Made with [Cursor](https://cursor.com)

## Sourcery 摘要

确保在输入操作被中断或完成后，触摸接触点和键盘按键能够安全释放，同时允许调用方显式保留输入。

新功能：
- 为 `TouchDown` 和 `KeyDown` 添加可配置的 `auto_up` 支持。默认情况下，当任务停止、完成或控制器被销毁时，自动释放仍处于按下状态的输入。
- 自动释放被中断的点击、长按、滑动和按键输入手势，以防止设备输入卡住。

错误修复：
- 防止任务被中断或完成后，在没有对应释放操作的情况下，触摸接触点和按键仍保持按下状态。
- 确保已显式成对使用的 `TouchUp` 和 `KeyUp` 操作不会被重复释放。

增强功能：
- 在控制器、任务、流水线、Node.js 和 Python API 中传递 `auto_up`，并支持流水线解析、覆盖、序列化和架构验证。

文档：
- 在英文和中文流水线协议文档中，记录 `TouchDown` 和 `KeyDown` 新增的 `auto_up` 行为及选项。

测试：
- 增加对显式和默认 `auto_up` 值的流水线解析与覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保触摸接触点和键盘按键在输入操作被中断或完成后能够安全释放，同时允许调用方显式保留处于按下状态的输入。

新功能：
- 为 `TouchDown` 和 `KeyDown` 添加可配置的 `auto_up` 支持，默认会在任务完成、停止或控制器销毁时自动释放处于按下状态的输入。
- 自动释放被中断的触摸和键盘手势，防止未完成的操作导致设备输入保持按下状态。

错误修复：
- 防止任务被中断或完成后，未释放的触摸接触点和按键保持卡住。
- 当匹配的 `TouchUp` 或 `KeyUp` 操作已经执行时，避免重复释放。

增强功能：
- 在控制器、任务、流水线、Node.js 和 Python API 中传递 `auto_up`，包括解析、覆盖、序列化和架构验证。

文档：
- 在英文和中文流水线协议文档中，记录 `TouchDown` 和 `KeyDown` 的 `auto_up` 行为及配置方式。

测试：
- 增加对默认和显式 `auto_up` 值的流水线解析及覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保触摸接触点和键盘按键在输入操作被中断或完成后能够安全释放，同时允许调用方明确保留处于按下状态的输入。

新功能：
- 为 `TouchDown` 和 `KeyDown` 添加可配置的 `auto_up` 支持。默认情况下，当任务完成、停止或控制器被销毁时，自动释放仍处于按下状态的输入。
- 自动释放被中断的触摸和键盘手势，防止设备一直处于按下状态。

错误修复：
- 当匹配的 `TouchUp` 或 `KeyUp` 操作已完成时，防止重复释放。
- 防止未完成的输入操作在中断或任务完成后导致触摸接触点或按键卡住。

增强功能：
- 在控制器、任务、流水线、Node.js 和 Python API 中传递 `auto_up`，包括解析、覆盖、序列化和架构验证。

文档：
- 在英文和中文流水线协议文档中，记录 `TouchDown` 和 `KeyDown` 的 `auto_up` 行为及配置方式。

测试：
- 添加流水线解析和覆盖测试，涵盖默认及显式设置的 `auto_up` 值。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止中断或未完成的输入操作导致触摸接点或按键保持按下状态，同时允许调用方选择退出自动释放功能。

新功能：
- 为 TouchDown 和 KeyDown 管道操作及公共 API 添加可配置的 `auto_up` 支持。

错误修复：
- 当任务停止、完成或控制器被销毁时，自动释放已跟踪的触摸接点和键盘按键；这也适用于被中断的复合手势，并且不会重复执行显式的 TouchUp 或 KeyUp 释放操作。

增强功能：
- 在控制器、任务、管道解析、覆盖、序列化、架构验证、Node.js 和 Python 接口中传递 `auto_up`。

文档：
- 在中文和英文管道协议中记录 `auto_up` 选项及自动释放输入的行为。

测试：
- 添加管道解析和覆盖测试，涵盖显式及默认的 `auto_up` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent interrupted or incomplete input actions from leaving touch contacts or keys pressed while allowing callers to opt out of automatic release.

New Features:
- Add configurable `auto_up` support to TouchDown and KeyDown pipeline actions and public APIs.

Bug Fixes:
- Automatically release tracked touch contacts and keyboard keys when tasks stop, finish, or controllers are destroyed, including interrupted composite gestures, without duplicating explicit TouchUp or KeyUp releases.

Enhancements:
- Propagate `auto_up` through controller, task, pipeline parsing, overriding, serialization, schema validation, Node.js, and Python interfaces.

Documentation:
- Document the `auto_up` option and automatic input-release behavior in the English and Chinese pipeline protocols.

Tests:
- Add pipeline parsing and override coverage for explicit and default `auto_up` values.

</details>

</details>

</details>

</details>