### PR TITLE
fix: 修复AnchoredTouch潜在的最小化和窗口显形问题

### DIFF
--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -401,6 +401,7 @@ typedef uint64_t MaaWin32ScreencapMethod;
  * - "WithWindowPos" methods briefly move the window so the target aligns with the current cursor
  *   position, send message, then restore the window position. The cursor is not moved.
  * - "AnchoredTouch" injects synthetic touch points, the target window receives WM_POINTER messages.
+ *   Each target point must be on an existing monitor; off-screen points are rejected.
  *   The cursor is never moved and the foreground window is never changed. Since synthetic pointers
  *   are dispatched by desktop Z-order, the target window is briefly raised to topmost while
  *   the target point is occluded, and restored once all contacts are released. If raising does not

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -400,7 +400,11 @@ typedef uint64_t MaaWin32ScreencapMethod;
  *   then restore cursor position. This "briefly" seizes the mouse but won't block user operations.
  * - "WithWindowPos" methods briefly move the window so the target aligns with the current cursor
  *   position, send message, then restore the window position. The cursor is not moved.
- * - "AnchoredTouch" injects synthetic touch points, the target window receives WM_POINTER messages.
+ * - "AnchoredTouch" injects synthetic touch points without moving the cursor or the target window.
+ *   The target receives WM_POINTER messages. Activation is suppressed during a touch sequence, but
+ *   the target application can still bring itself to the foreground. Its existing window styles
+ *   are preserved when the temporary activation styles are removed after the anchor is released.
+ *   A target already in the foreground is not given these temporary activation styles.
  *   Each target point must be on an existing monitor; off-screen points are rejected.
  *   When the target point is occluded, the window is temporarily raised and made nearly invisible.
  *   While raised, it can take mouse clicks inside its rectangle from the windows underneath.

--- a/include/MaaFramework/MaaDef.h
+++ b/include/MaaFramework/MaaDef.h
@@ -402,23 +402,16 @@ typedef uint64_t MaaWin32ScreencapMethod;
  *   position, send message, then restore the window position. The cursor is not moved.
  * - "AnchoredTouch" injects synthetic touch points, the target window receives WM_POINTER messages.
  *   Each target point must be on an existing monitor; off-screen points are rejected.
- *   The cursor is never moved and the foreground window is never changed. Since synthetic pointers
- *   are dispatched by desktop Z-order, the target window is briefly raised to topmost while
- *   the target point is occluded, and restored once all contacts are released. If raising does not
- *   take effect, the operation fails instead of injecting into the window that occludes the target.
- *   Raising requires WS_EX_LAYERED on the target window, which is added on the first raise, verified
- *   before every raise, and removed when the controller goes idle unless another module is relying on
- *   that layered state by then. If the style cannot be kept or the
- *   opacity cannot be lowered, the operation fails rather than raising the target window visibly.
- *   Windows layered via UpdateLayeredWindow are not supported. CS_OWNDC / CS_CLASSDC window classes
- *   are documented as incompatible with WS_EX_LAYERED, but that restriction does not always hold in
- *   practice, so such classes only produce a warning and the actual API results decide.
- *   A minimized target window is not supported and the operation fails, since its client area is
- *   off-screen and raising does not change that. Screencap methods with pseudo-minimize take the
- *   window out of that state before every capture, so this does not occur with them.
- *   WS_EX_TRANSPARENT is temporarily removed while the window is borrowed, since it lets input pass
- *   through to the windows underneath. Because the screencap side writes the same window state,
- *   the borrowed attributes are verified before being restored, and left alone once taken over.
+ *   When the target point is occluded, the window is temporarily raised and made nearly invisible.
+ *   While raised, it can take mouse clicks inside its rectangle from the windows underneath.
+ *   The window is restored after the touch sequence. If it cannot be raised and made hit-testable
+ *   at low opacity, the operation fails.
+ *   Raising requires WS_EX_LAYERED. Windows layered via UpdateLayeredWindow are not supported.
+ *   CS_OWNDC / CS_CLASSDC window classes produce a compatibility warning; the actual API results
+ *   determine whether raising can proceed. Layered style added by this method may remain until
+ *   inactive() or idle shutdown, and is retained if another module is using it.
+ *   A minimized target must be restored before input. Screencap methods with pseudo-minimize do
+ *   this before capture and can be used with AnchoredTouch.
  *   Clicking and swiping only. Keyboard can be routed to another method, but scroll cannot:
  *   it always goes through the mouse method and a synthetic touch device has no wheel.
  */

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
@@ -28,6 +28,10 @@ constexpr BYTE kAnchorAlpha = 1;
 // 借用目标窗口期间同样降到最低 alpha，肉眼几乎看不到画面变化，但命中判定仍然有效
 constexpr BYTE kDimAlpha = 1;
 
+// 保存多个前序窗口，供还原 Z 序时选择。
+// 最近的前序窗口可能在触控期间关闭，因此保留其他候选。
+constexpr size_t kMaxPrevSiblings = 8;
+
 // 注入帧间隔。实测超过约 400ms 不提交新帧，系统会回收接触点
 constexpr int kTickMs = 12;
 
@@ -823,7 +827,15 @@ void AnchoredTouchInput::begin_borrow()
     }
 
     borrowed_ = true;
-    prev_sibling_ = GetWindow(hwnd_, GW_HWNDPREV);
+
+    prev_siblings_.clear();
+    for (HWND sibling = GetWindow(hwnd_, GW_HWNDPREV); sibling && prev_siblings_.size() < kMaxPrevSiblings;
+         sibling = GetWindow(sibling, GW_HWNDPREV)) {
+        prev_siblings_.emplace_back(sibling);
+    }
+
+    // 归还时据此区分「目标窗口本来就在前台」与「借用期间才变成前台」，见 release_window_locked()
+    foreground_at_borrow_ = GetForegroundWindow();
 
     // 置顶状态与分层属性一样按次读取，跨借用沿用会写回过期的值
     original_topmost_ = (GetWindowLongPtrW(hwnd_, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
@@ -1038,15 +1050,26 @@ void AnchoredTouchInput::release_window_locked()
     bool restored = true;
 
     if (raised_) {
-        // 把 topmost 窗口插到非 topmost 窗口之后会剥掉它的 topmost 属性，
-        // 因此只有前序兄弟与目标窗口的 topmost 状态一致时才用它还原
+        // HWND_NOTOPMOST 会使窗口位于非置顶窗口的最前面。
+        // 还原时优先使用保存的前序窗口，避免目标窗口因取消置顶而改变原来的遮挡关系。
         HWND insert_after = original_topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST;
-        if (prev_sibling_ && IsWindow(prev_sibling_) && GetForegroundWindow() != hwnd_) {
-            // 用户在借用期间把窗口调到了前台，插回原来的兄弟之后会把它压到别的窗口下面。
-            // 这种情况下只摘掉 topmost 属性，不再恢复具体位置
-            bool sibling_topmost = (GetWindowLongPtrW(prev_sibling_, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0;
-            if (sibling_topmost == original_topmost_) {
-                insert_after = prev_sibling_;
+
+        // 借用前后目标窗口均处于前台时，不恢复此前保存的 Z 序。
+        // 其他情况下仍尝试恢复，避免触控期间发生的激活使目标窗口留在最前面。
+        bool foreground_owned_by_user = GetForegroundWindow() == hwnd_ && foreground_at_borrow_ == hwnd_;
+
+        if (!foreground_owned_by_user) {
+            // 按记录顺序选择仍存在且置顶状态匹配的前序窗口。
+            // 将置顶窗口插入非置顶窗口之后会取消其置顶状态，因此不能使用状态不匹配的候选。
+            for (HWND sibling : prev_siblings_) {
+                if (!IsWindow(sibling)) {
+                    continue;
+                }
+
+                if (((GetWindowLongPtrW(sibling, GWL_EXSTYLE) & WS_EX_TOPMOST) != 0) == original_topmost_) {
+                    insert_after = sibling;
+                    break;
+                }
             }
         }
 
@@ -1090,7 +1113,8 @@ void AnchoredTouchInput::release_window_locked()
 
     if (restored) {
         borrowed_ = false;
-        prev_sibling_ = nullptr;
+        prev_siblings_.clear();
+        foreground_at_borrow_ = nullptr;
     }
 }
 
@@ -1140,7 +1164,7 @@ void AnchoredTouchInput::unprepare_window()
         // 这份已经挂好的样式，把不透明度压到 0 并加上 WS_EX_TRANSPARENT。此时摘掉样式，
         // 那份不透明度会随之失效，本该隐形的窗口整个显出来，对方也再无从还原。
         // 因此只在这份分层状态没有被别人占用时才清，否则留着，等下一次调用再试。
-        // Win32ControlUnitMgr::inactive() 先停截图侧再停输入侧，任务结束时的那一次重试即可清干净。
+        // 宿主调用 Win32ControlUnitMgr::inactive() 时会先停截图侧再停输入侧，为清理提供一次重试机会。
         // 样式已经不在则不算被占用——截图侧的还原是整份写回扩展样式，会把我们加的这一位一并抹掉，
         // 此时下面的清除退化成空操作，照常销账即可
         COLORREF color_key = 0;

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
@@ -53,6 +53,14 @@ CreateSyntheticPointerDeviceFunc g_create_device = nullptr;
 InjectSyntheticPointerInputFunc g_inject_input = nullptr;
 DestroySyntheticPointerDeviceFunc g_destroy_device = nullptr;
 
+// 注入点必须落在真实存在的显示器上。目标窗口被拖出屏幕后，由客户区换算出的坐标会落在桌面之外，
+// 而合成指针打不到不存在的位置，系统会把越界的点钳到屏幕边缘，落在任务栏之类的地方。
+// 用 MonitorFromPoint 判断目标点是否位于实际显示器范围内。
+bool point_on_desktop(POINT screen)
+{
+    return MonitorFromPoint(screen, MONITOR_DEFAULTTONULL) != nullptr;
+}
+
 POINTER_TYPE_INFO make_touch_info(uint32_t id, POINT point, UINT32 flags)
 {
     POINTER_TYPE_INFO info = { };
@@ -179,6 +187,13 @@ bool AnchoredTouchInput::touch_move(int contact, int x, int y, [[maybe_unused]] 
 
     POINT point = { };
     if (!to_screen(x, y, point)) {
+        return false;
+    }
+
+    // 滑动中途移出桌面同样不能注入。这里不更新坐标，接触点留在上一个有效位置，
+    // 由上层判定这一步失败，而不是把它抬起在屏幕外
+    if (!point_on_desktop(point)) {
+        LogError << "the target point is outside the desktop" << VAR(point.x) << VAR(point.y);
         return false;
     }
 
@@ -949,6 +964,14 @@ bool AnchoredTouchInput::ensure_hittable(POINT screen)
     std::lock_guard lock(window_mutex_);
 
     if (!hwnd_) {
+        return false;
+    }
+
+    // 本函数其余部分只回答「有没有被别的窗口遮挡」，越界的点两种形态都会被放行：
+    // 点仍在目标窗口矩形内时 WindowFromPoint 返回目标窗口自己，判为无需提升；
+    // 落在所有窗口之外时返回空，判为被遮挡，提升之后照样注入
+    if (!point_on_desktop(screen)) {
+        LogError << "the target point is outside the desktop" << VAR(screen.x) << VAR(screen.y);
         return false;
     }
 

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.cpp
@@ -32,6 +32,10 @@ constexpr BYTE kDimAlpha = 1;
 // 最近的前序窗口可能在触控期间关闭，因此保留其他候选。
 constexpr size_t kMaxPrevSiblings = 8;
 
+// WS_EX_NOACTIVATE 用于抑制触控期间的点击激活。
+// 同时设置 WS_EX_APPWINDOW，避免目标窗口的任务栏按钮因样式变化而消失。
+constexpr LONG_PTR kActivationStyles = WS_EX_NOACTIVATE | WS_EX_APPWINDOW;
+
 // 注入帧间隔。实测超过约 400ms 不提交新帧，系统会回收接触点
 constexpr int kTickMs = 12;
 
@@ -157,9 +161,15 @@ bool AnchoredTouchInput::touch_down(int contact, int x, int y, [[maybe_unused]] 
         return false;
     }
 
+    // 必须赶在 ensure_hittable() 之前挂上：提升目标窗口这个动作本身就会引起激活，
+    // 而提升就发生在它里面。未走借用的点击同样会被注入激活，所以每次都挂。
+    // 挂不上也不拦截注入，让点击照常进行
+    suppress_activation();
+
     // 目标点打不中目标窗口就不能注入，否则输入会落到遮挡它的那个窗口上
     if (!ensure_hittable(point)) {
         release_window_if_idle();
+        restore_activation_if_idle();
         return false;
     }
 
@@ -177,6 +187,7 @@ bool AnchoredTouchInput::touch_down(int contact, int x, int y, [[maybe_unused]] 
         contacts_.erase(contact);
         lock.unlock();
         release_window_if_idle();
+        restore_activation_if_idle();
         return false;
     }
 
@@ -232,16 +243,25 @@ bool AnchoredTouchInput::touch_up(int contact)
         LogError << "contact is not down" << VAR(contact);
         lock.unlock();
         release_window_if_idle();
+        restore_activation_if_idle();
         return false;
     }
 
     it->second.pending_up = true;
 
     bool ok = wait_for_contact_released(lock, contact);
+
+    // 只有最后一个操作点释放后，锚点才会释放。
+    // 其他操作点仍存在时，继续保留锚点和激活样式。
+    if (contacts_.empty()) {
+        wait_for_anchor_released(lock);
+    }
+
     lock.unlock();
 
     // 必须等所有接触点都抬起后再归还窗口，否则剩下的接触点会在触控序列中途丢失命中
     release_window_if_idle();
+    restore_activation_if_idle();
 
     return ok;
 }
@@ -654,6 +674,20 @@ bool AnchoredTouchInput::wait_for_contact_released(std::unique_lock<std::mutex>&
     }
 
     return running_;
+}
+
+// 锚点由注入线程按 contacts_ 是否为空自行按下与松开，比最后一个接触点晚一帧。
+// 等待锚点释放后再摘除激活样式，避免操作点抬起后、锚点释放前出现保护空档。
+bool AnchoredTouchInput::wait_for_anchor_released(std::unique_lock<std::mutex>& lock)
+{
+    bool done = cv_.wait_for(lock, kWaitTimeout, [this] { return !running_ || !anchor_down_; });
+
+    if (!done) {
+        LogError << "timed out waiting for the anchor to be released";
+        return false;
+    }
+
+    return !anchor_down_;
 }
 
 bool AnchoredTouchInput::wait_for_frames(std::unique_lock<std::mutex>& lock, int frames)
@@ -1118,6 +1152,84 @@ void AnchoredTouchInput::release_window_locked()
     }
 }
 
+bool AnchoredTouchInput::suppress_activation()
+{
+    // 目标窗口已经在前台时不必压制：所谓被夺前台指的是它从后台跳到最前，已经在最前就没有
+    // 可见变化。这一支同时让开了用户正在使用目标窗口的整段时间，期间不去动它的样式
+    if (GetForegroundWindow() == hwnd_) {
+        return true;
+    }
+
+    std::lock_guard lock(window_mutex_);
+
+    if (activation_styles_applied_ != 0 || !hwnd_) {
+        return true;
+    }
+
+    SetLastError(0);
+    LONG_PTR exstyle = GetWindowLongPtrW(hwnd_, GWL_EXSTYLE);
+    if (exstyle == 0 && GetLastError() != 0) {
+        LogError << "GetWindowLongPtrW failed" << VAR_VOIDP(hwnd_) << VAR(GetLastError());
+        return false;
+    }
+
+    // 目标窗口自带的位不记账也不动，免得归还时把它本来就有的东西摘掉
+    LONG_PTR missing = kActivationStyles & ~exstyle;
+    if (missing == 0) {
+        return true;
+    }
+
+    SetLastError(0);
+    if (SetWindowLongPtrW(hwnd_, GWL_EXSTYLE, exstyle | missing) == 0 && GetLastError() != 0) {
+        LogError << "failed to suppress activation on the target window" << VAR_VOIDP(hwnd_) << VAR(GetLastError());
+        return false;
+    }
+
+    activation_styles_applied_ = missing;
+    return true;
+}
+
+void AnchoredTouchInput::restore_activation_locked()
+{
+    if (activation_styles_applied_ == 0 || !hwnd_) {
+        return;
+    }
+
+    SetLastError(0);
+    LONG_PTR exstyle = GetWindowLongPtrW(hwnd_, GWL_EXSTYLE);
+    if (exstyle == 0 && GetLastError() != 0) {
+        LogError << "GetWindowLongPtrW failed" << VAR_VOIDP(hwnd_) << VAR(GetLastError());
+        return;
+    }
+
+    SetLastError(0);
+    if (SetWindowLongPtrW(hwnd_, GWL_EXSTYLE, exstyle & ~activation_styles_applied_) == 0 && GetLastError() != 0) {
+        LogError << "failed to restore the target window ex-style" << VAR_VOIDP(hwnd_) << VAR(GetLastError());
+        return;
+    }
+
+    activation_styles_applied_ = 0;
+}
+
+void AnchoredTouchInput::restore_activation()
+{
+    std::lock_guard lock(window_mutex_);
+
+    restore_activation_locked();
+}
+
+void AnchoredTouchInput::restore_activation_if_idle()
+{
+    {
+        std::lock_guard lock(mutex_);
+        if (!contacts_.empty()) {
+            return;
+        }
+    }
+
+    restore_activation();
+}
+
 void AnchoredTouchInput::release_window()
 {
     std::lock_guard lock(window_mutex_);
@@ -1140,6 +1252,10 @@ void AnchoredTouchInput::release_window_if_idle()
 void AnchoredTouchInput::unprepare_window()
 {
     std::lock_guard lock(window_mutex_);
+
+    // 压制激活与借用各自记账：没走过借用路径的点击也会挂它，
+    // 所以要放在 window_prepared_ 判断之前，否则会残留在目标窗口上
+    restore_activation_locked();
 
     if (!window_prepared_ || !hwnd_) {
         return;

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
@@ -37,6 +37,11 @@ MAA_CTRL_UNIT_NS_BEGIN
 //
 // 目标操作点必须落在实际显示器范围内，按下与移动均会校验，见 point_on_desktop()。
 //
+// 触控序列期间通过 WS_EX_NOACTIVATE 抑制点击激活，并以 WS_EX_APPWINDOW 保留任务栏按钮。
+// 无需提升窗口的点击同样适用；目标窗口已在前台时跳过添加。
+// 等待锚点释放后再摘除激活样式，且仅移除本方式添加的位，保留目标窗口原有的样式。
+// 目标进程仍可能显式调用激活 API，因此不能保证前台窗口始终不变。
+//
 // 为省掉每次借用都要切换扩展样式引起的闪烁，WS_EX_LAYERED 一旦挂上就保留到 inactive()
 // 或空闲退出，由 unprepare_window() 清除。该样式随时可能被目标程序自己重设掉，
 // 因此每次借用前都要重新确认，缺了就补挂；补不上或压不低不透明度时一律不提升，
@@ -109,6 +114,7 @@ private:
     bool wait_for_frames(std::unique_lock<std::mutex>& lock, int frames);
     bool wait_for_contact_active(std::unique_lock<std::mutex>& lock, int contact);
     bool wait_for_contact_released(std::unique_lock<std::mutex>& lock, int contact);
+    bool wait_for_anchor_released(std::unique_lock<std::mutex>& lock);
 
     bool to_screen(int x, int y, POINT& out) const;
     POINT compute_anchor_origin() const;
@@ -131,6 +137,12 @@ private:
     void release_window_if_idle();
     void unprepare_window();
 
+    // 通过窗口样式抑制点击激活；目标进程显式调用激活 API 不在此控制范围内。
+    bool suppress_activation();
+    void restore_activation_locked(); // 需要在持有 window_mutex_ 的情况下调用
+    void restore_activation();
+    void restore_activation_if_idle();
+
 private:
     HWND hwnd_ = nullptr;
 
@@ -148,9 +160,10 @@ private:
     // 注入线程创建与销毁，调用线程在提升目标窗口时需要一并把它压回最上层
     std::atomic<HWND> anchor_hwnd_ = nullptr;
 
-    // 以下仅注入线程访问
+    // 合成设备与锚点位置由注入线程维护。
     void* device_ = nullptr;
     POINT anchor_pos_ = { };
+    // 注入线程更新；调用线程持有 mutex_ 等待释放，启动前由 ensure_worker() 初始化。
     bool anchor_down_ = false;
     RECT last_target_rect_ = { };
     std::wstring class_name_;
@@ -184,6 +197,10 @@ private:
     // dim_window() 实际写入目标窗口的分层属性，供 check_borrow_mark() 核对
     COLORREF mark_color_key_ = 0;
     DWORD mark_layered_flags_ = LWA_ALPHA;
+
+    // kActivationStyles 中由本方式挂上去的那几位，归还时按此摘除。
+    // 目标窗口自带的位不计入，也就不会被摘掉
+    LONG_PTR activation_styles_applied_ = 0;
 };
 
 MAA_CTRL_UNIT_NS_END

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
@@ -33,6 +33,8 @@ MAA_CTRL_UNIT_NS_BEGIN
 // 见 ensure_hittable / release_window_locked。借用不成功时 touch_down 直接失败，绝不注入，
 // 否则输入会落到遮挡目标的那个窗口上。
 //
+// 目标操作点必须落在实际显示器范围内，按下与移动均会校验，见 point_on_desktop()。
+//
 // 为省掉每次借用都要切换扩展样式引起的闪烁，WS_EX_LAYERED 一旦挂上就保留到 inactive()
 // 或空闲退出，由 unprepare_window() 清除。该样式随时可能被目标程序自己重设掉，
 // 因此每次借用前都要重新确认，缺了就补挂；补不上或压不低不透明度时一律不提升，

--- a/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
+++ b/source/MaaWin32ControlUnit/Input/AnchoredTouchInput.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "MaaControlUnit/ControlUnitAPI.h"
 
@@ -32,6 +33,7 @@ MAA_CTRL_UNIT_NS_BEGIN
 // 所以按下前会把目标窗口提到 topmost 并降到最低分层透明度，所有接触点抬起后还原，
 // 见 ensure_hittable / release_window_locked。借用不成功时 touch_down 直接失败，绝不注入，
 // 否则输入会落到遮挡目标的那个窗口上。
+// 当前实现借用期间会接走矩形内的鼠标点击，因此序列结束后立即归还，见 release_window_locked()。
 //
 // 目标操作点必须落在实际显示器范围内，按下与移动均会校验，见 point_on_desktop()。
 //
@@ -170,7 +172,14 @@ private:
     bool dimmed_ = false;
     bool raised_ = false;
     bool transparent_suppressed_ = false;
-    HWND prev_sibling_ = nullptr;
+
+    // 借用前目标窗口在 Z 序中的前序兄弟，由近及远。归还时插回其中一个即可回到原位；
+    // 只记最近的那一个时，它一旦在借用期间被关掉就只剩 HWND_NOTOPMOST 可用，
+    // 而那个值会把目标窗口推到非置顶层的最前面
+    std::vector<HWND> prev_siblings_;
+
+    // 借用开始时的前台窗口，用于决定归还时是否恢复原 Z 序，见 release_window_locked()。
+    HWND foreground_at_borrow_ = nullptr;
 
     // dim_window() 实际写入目标窗口的分层属性，供 check_borrow_mark() 核对
     COLORREF mark_color_key_ = 0;


### PR DESCRIPTION
## Summary by Sourcery

修复 AnchoredTouch 的窗口激活、最小化处理、桌面边界校验及触控结束后的窗口状态恢复问题。

Bug Fixes:
- 修复 AnchoredTouch 在触控过程中意外激活、改变窗口前台状态或遗留窗口样式的问题。
- 修复目标窗口最小化、触控点位于桌面范围外以及前序窗口关闭时导致输入或窗口 Z 序恢复异常的问题。

Enhancements:
- 改进触控序列期间的窗口借用与恢复逻辑，保留原有窗口样式并更可靠地恢复 Z 序。

Documentation:
- 更新 AnchoredTouch 的行为说明，包括激活抑制、桌面范围校验、最小化窗口处理及窗口借用限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复 AnchoredTouch 的窗口激活、最小化处理、桌面边界校验及触控结束后的窗口状态恢复问题。

Bug Fixes:
- 修复 AnchoredTouch 在触控过程中意外激活、改变窗口前台状态或遗留窗口样式的问题。
- 修复目标窗口最小化、触控点位于桌面范围外以及前序窗口关闭时导致输入或窗口 Z 序恢复异常的问题。

Enhancements:
- 改进触控序列期间的窗口借用与恢复逻辑，保留原有窗口样式并更可靠地恢复 Z 序。

Documentation:
- 更新 AnchoredTouch 的行为说明，包括激活抑制、桌面范围校验、最小化窗口处理及窗口借用限制。

</details>